### PR TITLE
Fix null exception error

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -144,7 +144,7 @@ class Hybrid_Auth
 
 			// try to provide the previous if any
 			// Exception::getPrevious (PHP 5 >= 5.3.0) http://php.net/manual/en/exception.getprevious.php
-			if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {  
+			if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) && ($p instanceof Exception) ) {  
 				throw new Exception( $m, $c, $p );
 			}
 			else{


### PR DESCRIPTION
When authenticating, sometimes the previousException was null; this checks for that.
