### PR TITLE
Updated Foursquare provider - canonicalUrl removed from user object

### DIFF
--- a/hybridauth/Hybrid/Providers/Foursquare.php
+++ b/hybridauth/Hybrid/Providers/Foursquare.php
@@ -45,7 +45,7 @@ class Hybrid_Providers_Foursquare extends Hybrid_Provider_Model_OAuth2
 		$this->user->profile->lastName      = $data->lastName;
 		$this->user->profile->displayName   = trim( $this->user->profile->firstName . " " . $this->user->profile->lastName );
 		$this->user->profile->photoURL      = $data->photo;
-		$this->user->profile->profileURL    = $data->canonicalUrl;
+		$this->user->profile->profileURL    = "https://www.foursquare.com/user/" . $data->id;
 		$this->user->profile->gender        = $data->gender;
 		$this->user->profile->city          = $data->homeCity;
 		$this->user->profile->email         = $data->contact->email;


### PR DESCRIPTION
This provider no longer works because this property does not exist in the user object that is returned.

http://stackoverflow.com/questions/10745881/canonicalurl-gone-from-foursquare-user-object
