### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload": {
         "psr-0": {
-            "hybridauth": "hybridauth/"
+            "Hybrid": "hybridauth/"
         } 
     }
 }


### PR DESCRIPTION
"Namespace" should be used as prefix for classes using PEAR naming conventions.
