### PR TITLE
VKontakte birthdate handling fix

### DIFF
--- a/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
+++ b/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
@@ -102,13 +102,15 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 			}
 		}
 
-		if( property_exists($response,'bdate') ){
-			list($birthday_year, $birthday_month, $birthday_day) = explode( '.', $response->bdate );
+        if (property_exists($response, 'bdate')) {
+            $bdateData = explode('.', $response->bdate);
 
-			$this->user->profile->birthDay   = (int) $birthday_day;
-			$this->user->profile->birthMonth = (int) $birthday_month;
-			$this->user->profile->birthYear  = (int) $birthday_year;
-		}
+            $this->user->profile->birthDay   = (int)$bdateData[0];
+            $this->user->profile->birthMonth = (int)$bdateData[1];
+            if (count($bdateData) > 2) {
+                $this->user->profile->birthYear = (int)$bdateData[2];
+            }
+        }
 
 		return $this->user->profile;
 	}


### PR DESCRIPTION
According to the documentation for developers at vk.com/developers.php
http://vk.com/developers.php?oid=-1&p=%D0%9E%D0%BF%D0%B8%D1%81%D0%B0%D0%BD%D0%B8%D0%B5_%D0%BF%D0%BE%D0%BB%D0%B5%D0%B9_%D0%BF%D0%B0%D1%80%D0%B0%D0%BC%D0%B5%D1%82%D1%80%D0%B0_fields

bdate
Date is shown in the following format: "23.11.1981" or "21.9" (if the year is hidden). If the full birthdate is hidden, then when receiving data in XML format, the tag "bdate" will be missing from the node <user>. 
