### PR TITLE
Fix FB for projects that use spl_autoload_register

### DIFF
--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -26,7 +26,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model
 			throw new Exception( "Your application id and secret are required in order to connect to {$this->providerId}.", 4 );
 		}
 
-		if ( ! class_exists('FacebookApiException') ) {
+		if ( ! class_exists('FacebookApiException', false) ) {
 			require_once Hybrid_Auth::$config["path_libraries"] . "Facebook/base_facebook.php";
 			require_once Hybrid_Auth::$config["path_libraries"] . "Facebook/facebook.php";
 		}


### PR DESCRIPTION
Autoload tries and fails to automatically load FacebookApiException without this change, causing an error.
