### PR TITLE
Updating Windows Live endpoint URLs

### DIFF
--- a/hybridauth/Hybrid/Providers/Live.php
+++ b/hybridauth/Hybrid/Providers/Live.php
@@ -31,9 +31,9 @@ class Hybrid_Providers_Live extends Hybrid_Provider_Model_OAuth2
 		parent::initialize();
 
 		// Provider api end-points
-		$this->api->api_base_url  = "https://apis.live.net/v5.0/";
-		$this->api->authorize_url = "https://oauth.live.com/authorize";
-		$this->api->token_url     = 'https://oauth.live.com/token';
+		$this->api->api_base_url  = 'https://apis.live.net/v5.0/';
+		$this->api->authorize_url = 'https://login.live.com/oauth20_authorize.srf';
+		$this->api->token_url     = 'https://login.live.com/oauth20_token.srf';
 
 		$this->api->curl_authenticate_method  = "GET";
 	}


### PR DESCRIPTION
- http://social.msdn.microsoft.com/Forums/en-US/messengerconnect/thread/577aa2de-9409-405a-835f-327e06965f52
- https://github.com/hybridauth/hybridauth/blob/master/hybridauth/Hybrid/Providers/Live.php

> The new endpoints are:
> 
> •authorization: https://login.live.com/oauth20_authorize.srf
> •token: https://login.live.com/oauth20_token.srf
> •desktop: https://login.live.com/oauth20_desktop.srf
> 
> The old end points are:
> 
> •authorization: https://oauth.live.com/authorize  
> •token: https://oauth.live.com/token 
> •desktop: https://oauth.live.com/desktop
