### PR TITLE
Update hybridauth/Hybrid/Storage.php

### DIFF
--- a/hybridauth/Hybrid/Storage.php
+++ b/hybridauth/Hybrid/Storage.php
@@ -40,7 +40,7 @@ class Hybrid_Storage
 	{
 		$key = strtolower( $key );  
 
-		if( isset( $_SESSION["HA::STORE"]) && isset( $_SESSION["HA::STORE"][$key] ) ){ 
+		if( isset( $_SESSION["HA::STORE"], $_SESSION["HA::STORE"][$key] ) ){ 
 			return unserialize( $_SESSION["HA::STORE"][$key] );  
 		}
 


### PR DESCRIPTION
If $_SESSION["HA::STORE"] is not set, it's throw a notice "Notice:
Undefined index: HA::STORE"
