### PR TITLE
Fix expires_in not always set

### DIFF
--- a/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+++ b/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
@@ -87,7 +87,9 @@ class OAuth2Client
 		if( isset( $response->expires_in    ) ) $this->access_token_expires_in = $response->expires_in; 
 		
 		// calculate when the access token expire
-		$this->access_token_expires_at = time() + $response->expires_in; 
+		if( isset($response->expires_in)) {
+			$this->access_token_expires_at = time() + $response->expires_in;
+		}
 
 		return $response;  
 	}


### PR DESCRIPTION
$response->expires_in is checked to exist in the code directly above setting access_token_expires, however this check is missed when access_token_expires_at is set, causing a notice error.
This branch fixes that.
