### PR TITLE
Composer Require CURL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "issues": "https://github.com/hybridauth/hybridauth/issues"
     },
     "require": {
-        "php": ">=5.2.0" 
+        "php": ">=5.2.0",
+        "ext-curl": "*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This will warn a user that they don't have the curl extension installed when using composer install.
