### PR TITLE
Fix misspellings of "authentication" and "valid"

### DIFF
--- a/additional-providers/hybridauth-disqus/Providers/Disqus.php
+++ b/additional-providers/hybridauth-disqus/Providers/Disqus.php
@@ -36,7 +36,7 @@ class Hybrid_Providers_Disqus extends Hybrid_Provider_Model_OAuth2
 		$data = $this->api->get( "users/details" ); 
 		print_r($data);
 		if ( ! isset( $data->code ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		} else if ( $data->code != 0 ){
 			throw new Exception( "User profile request failed! {$this->providerId} returned error code".$data->code.".", 6 );
 		}

--- a/additional-providers/hybridauth-github/Providers/GitHub.php
+++ b/additional-providers/hybridauth-github/Providers/GitHub.php
@@ -35,7 +35,7 @@ class Hybrid_Providers_GitHub extends Hybrid_Provider_Model_OAuth2
 		$data = $this->api->api( "user" ); 
 
 		if ( ! isset( $data->id ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$this->user->profile->identifier  = @ $data->id; 

--- a/additional-providers/hybridauth-goodreads/Providers/Goodreads.php
+++ b/additional-providers/hybridauth-goodreads/Providers/Goodreads.php
@@ -34,13 +34,13 @@ class Hybrid_Providers_Goodreads extends Hybrid_Provider_Model_OAuth1
 	{
 		// in case we get authorize=0
 		if ( ! isset($_REQUEST['oauth_token']) || ( isset( $_REQUEST['authorize'] ) && $_REQUEST['authorize'] == "0" ) ){ 
-			throw new Exception( "Authentification failed! The user denied your request.", 5 );
+			throw new Exception( "Authentication failed! The user denied your request.", 5 );
 		}
 
 		$oauth_verifier = @ $_REQUEST['oauth_token'];
 
 		if ( !$oauth_verifier ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid oauth verifier.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid oauth verifier.", 5 );
 		}
 
 		// request an access token
@@ -51,12 +51,12 @@ class Hybrid_Providers_Goodreads extends Hybrid_Provider_Model_OAuth1
 
 		// check the last HTTP status code returned
 		if ( $this->api->http_code != 200 ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 5 );
 		}
 
 		// we should have an access_token, or else, something has gone wrong
 		if ( ! isset( $tokens["oauth_token"] ) ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid access token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid access token.", 5 );
 		}
 
 		// we no more need to store requet tokens

--- a/additional-providers/hybridauth-instagram/Providers/Instagram.php
+++ b/additional-providers/hybridauth-instagram/Providers/Instagram.php
@@ -33,7 +33,7 @@ class Hybrid_Providers_Instagram extends Hybrid_Provider_Model_OAuth2
 		$data = $this->api->api("users/self/" ); 
 
 		if ( $data->meta->code != 200 ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$this->user->profile->identifier  = $data->data->id; 

--- a/additional-providers/hybridauth-lastfm/Providers/LastFM.php
+++ b/additional-providers/hybridauth-lastfm/Providers/LastFM.php
@@ -48,14 +48,14 @@ class Hybrid_Providers_LastFM extends Hybrid_Provider_Model
 
 		if ( ! $token )
 		{
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid Token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid Token.", 5 );
 		}
 
 		try{
 			$response = $this->api->fetchSession( $token );
 		}
 		catch( LastFMException $e ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error while requesting and access token. $e.", 6 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error while requesting and access token. $e.", 6 );
 		}
 
 		if( isset( $response['sk'] ) && isset( $response['name'] ) ){
@@ -68,7 +68,7 @@ class Hybrid_Providers_LastFM extends Hybrid_Provider_Model
 			$this->setUserConnected();
 		}
 		else{
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid access Token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid access Token.", 5 );
 		}
 	}
 

--- a/additional-providers/hybridauth-mailru/Providers/Mailru.php
+++ b/additional-providers/hybridauth-mailru/Providers/Mailru.php
@@ -35,7 +35,7 @@ class Hybrid_Providers_Mailru extends Hybrid_Provider_Model_OAuth2
     $sig = md5( "client_id=" . $this->api->client_id . "format=jsonmethod=users.getInfosecure=1session_key=". $this->api->access_token . $this->api->client_secret );
 		$response = $this->api->api( "?format=json&client_id=" . $this->api->client_id . "&method=users.getInfo&secure=1&sig=" .$sig); 
     if ( ! isset( $response[0]->uid ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
     
     $response = $response[0];

--- a/additional-providers/hybridauth-murmur/Providers/Murmur.php
+++ b/additional-providers/hybridauth-murmur/Providers/Murmur.php
@@ -41,7 +41,7 @@ class Hybrid_Providers_Murmur extends Hybrid_Provider_Model_OAuth1
 		$tokens = $this->api->requestToken( $this->endpoint ); 
 
 		if ( ! isset( $tokens ) ){
-			throw new Exception( 'Authentification failed! '.$this->providerId.' returned an invalid Request Token.', 5 );
+			throw new Exception( 'Authentication failed! '.$this->providerId.' returned an invalid Request Token.', 5 );
 		}
 
 		$this->token( 'request_token'       ,  $tokens['oauth_token'] ); 

--- a/additional-providers/hybridauth-odnoklassniki/Providers/Odnoklassniki.php
+++ b/additional-providers/hybridauth-odnoklassniki/Providers/Odnoklassniki.php
@@ -111,7 +111,7 @@ class Hybrid_Providers_Odnoklassniki extends Hybrid_Provider_Model_OAuth2
 
 		// check for errors
 		if ( $error ){ 
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error: $error", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error: $error", 5 );
 		}
 
 		// try to authenicate user
@@ -126,7 +126,7 @@ class Hybrid_Providers_Odnoklassniki extends Hybrid_Provider_Model_OAuth2
 
 		// check if authenticated
 		if ( ! $this->api->access_token ){ 
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid access token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid access token.", 5 );
 		}
 
 		// store tokens
@@ -147,7 +147,7 @@ class Hybrid_Providers_Odnoklassniki extends Hybrid_Provider_Model_OAuth2
     $sig = md5('application_key=' . $this->config['keys']['key'] . 'method=users.getCurrentUser' . md5($this->api->access_token . $this->api->client_secret));
   	$response = $this->api->api( '?application_key=' . $this->config['keys']['key'] . '&method=users.getCurrentUser&sig=' .$sig); 
     if ( ! isset( $response->uid ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
     
     $this->user->profile->identifier    = (property_exists($response,'uid'))?$response->uid:"";

--- a/additional-providers/hybridauth-sina/Providers/Sina.php
+++ b/additional-providers/hybridauth-sina/Providers/Sina.php
@@ -64,7 +64,7 @@ class Hybrid_Providers_Sina extends Hybrid_Provider_Model
 	{ 
 		if ( ! $_REQUEST['code'] )
 		{
-			throw new Exception( 'Authentification failed! ' . $this->providerId . ' returned an invalid OAuth Token and Verifier.', 5 );
+			throw new Exception( 'Authentication failed! ' . $this->providerId . ' returned an invalid OAuth Token and Verifier.', 5 );
 		}
 		
 
@@ -75,7 +75,7 @@ class Hybrid_Providers_Sina extends Hybrid_Provider_Model
 		try {
 			$tokz = $this->api->getAccessToken( 'code', $params ) ;
 		} catch (OAuthException $e) {
-			throw new Exception( 'Authentification failed! ' . $this->providerId . ' returned an invalid Access Token.', 5 );
+			throw new Exception( 'Authentication failed! ' . $this->providerId . ' returned an invalid Access Token.', 5 );
 		}
 
 		// Store tokens 

--- a/additional-providers/hybridauth-viadeo/Providers/Viadeo.php
+++ b/additional-providers/hybridauth-viadeo/Providers/Viadeo.php
@@ -48,7 +48,7 @@ class Hybrid_Providers_Viadeo extends Hybrid_Provider_Model
 			Hybrid_Auth::redirect( $url );
 		}
 		catch ( ViadeoException $e ){
-			throw new Exception( "Authentification failed! An error occured during {$this->providerId} authentication.", 5 );
+			throw new Exception( "Authentication failed! An error occured during {$this->providerId} authentication.", 5 );
 		}
 	}
  
@@ -63,12 +63,12 @@ class Hybrid_Providers_Viadeo extends Hybrid_Provider_Model
 			$this->api->setAccessTokenFromCode();
 		}
 		catch ( ViadeoException $e ){
-			throw new Exception( "Authentification failed! An error occured during {$this->providerId} authentication", 5 );
+			throw new Exception( "Authentication failed! An error occured during {$this->providerId} authentication", 5 );
 		}
 
 		if ( ! $this->api->isAuthenticated() )
 		{
-			throw new Exception( "Authentification failed! An error occured during {$this->providerId} authentication", 5 );
+			throw new Exception( "Authentication failed! An error occured during {$this->providerId} authentication", 5 );
 		} 
 
 		// Store tokens 

--- a/additional-providers/hybridauth-vimeo/Providers/Vimeo.php
+++ b/additional-providers/hybridauth-vimeo/Providers/Vimeo.php
@@ -44,7 +44,7 @@ class Hybrid_Providers_Vimeo extends Hybrid_Provider_Model
 
 		if ( ! isset( $tokz["oauth_token"] ) )
 		{
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid Request Token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid Request Token.", 5 );
 		}
 
 		$this->token( "request_token"        , $tokz['oauth_token'] ); 
@@ -64,7 +64,7 @@ class Hybrid_Providers_Vimeo extends Hybrid_Provider_Model
 
 		if ( ! $oauth_token || ! $oauth_verifier )
 		{
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid OAuth Token and Verifier.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid OAuth Token and Verifier.", 5 );
 		}
 
 		try{ 
@@ -76,12 +76,12 @@ class Hybrid_Providers_Vimeo extends Hybrid_Provider_Model
 			$tokz = $this->api->getAccessToken( $oauth_verifier );
 		}
 		catch( VimeoAPIException $e ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error while requesting a request token. $e.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error while requesting a request token. $e.", 5 );
 		}
 
 		if ( ! isset( $tokz["oauth_token"] ) )
 		{
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid Access Token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid Access Token.", 5 );
 		}
 
 		// Store tokens 

--- a/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
+++ b/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
@@ -35,7 +35,7 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 
 		// check for errors
 		if ( $error ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error: $error", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error: $error", 5 );
 		}
 
 		// try to authenicate user
@@ -50,7 +50,7 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 
 		// check if authenticated
 		if ( !property_exists($response,'user_id') || ! $this->api->access_token ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid access token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid access token.", 5 );
 		}
 
 		// store tokens
@@ -82,7 +82,7 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 
 
 		if (!isset( $response->response[0] ) || !isset( $response->response[0]->uid ) || isset( $response->error ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$response = $response->response[0];

--- a/additional-providers/hybridauth-yandex/Providers/Yandex.php
+++ b/additional-providers/hybridauth-yandex/Providers/Yandex.php
@@ -35,7 +35,7 @@ class Hybrid_Providers_Yandex extends Hybrid_Provider_Model_OAuth2
 	{
 		$response = $this->api->api( "?format=json" ); 
 		if ( ! isset( $response->id ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
     
     $this->user->profile->identifier    = (property_exists($response,'id'))?$response->id:"";

--- a/examples/hello_world/index.php
+++ b/examples/hello_world/index.php
@@ -56,7 +56,7 @@
 			case 2 : echo "Provider not properly configured."; break;
 			case 3 : echo "Unknown or disabled provider."; break;
 			case 4 : echo "Missing provider application credentials."; break;
-			case 5 : echo "Authentification failed. " 
+			case 5 : echo "Authentication failed. " 
 					  . "The user has canceled the authentication or the provider refused the connection."; 
 				   break;
 			case 6 : echo "User profile request failed. Most likely the user is not connected "

--- a/examples/signin_signup/application/controllers/authentications.php
+++ b/examples/signin_signup/application/controllers/authentications.php
@@ -34,7 +34,7 @@ class authentications extends controller {
 		# 3 - else, here lets check if the user email we got from the provider already exists in our database ( for this example the email is UNIQUE for each user )
 			// if authentication does not exist, but the email address returned  by the provider does exist in database, 
 			// then we tell the user that the email  is already in use 
-			// but, its up to you if you want to associate the authentification with the user having the adresse email in the database
+			// but, its up to you if you want to associate the authentication with the user having the adresse email in the database
 			if( $user_profile->email ){
 				$user_info = $user->find_by_email( $user_profile->email );
 
@@ -73,7 +73,7 @@ class authentications extends controller {
 				case 2 : $error = "Provider not properly configured."; break;
 				case 3 : $error = "Unknown or disabled provider."; break;
 				case 4 : $error = "Missing provider application credentials."; break;
-				case 5 : $error = "Authentification failed. The user has canceled the authentication or the provider refused the connection."; break;
+				case 5 : $error = "Authentication failed. The user has canceled the authentication or the provider refused the connection."; break;
 				case 6 : $error = "User profile request failed. Most likely the user is not connected to the provider and he should to authenticate again."; 
 					     $adapter->logout(); 
 					     break;

--- a/examples/social_hub/login.php
+++ b/examples/social_hub/login.php
@@ -42,7 +42,7 @@
 				case 2 : $error = "Provider not properly configured."; break;
 				case 3 : $error = "Unknown or disabled provider."; break;
 				case 4 : $error = "Missing provider application credentials."; break;
-				case 5 : $error = "Authentification failed. The user has canceled the authentication or the provider refused the connection."; break;
+				case 5 : $error = "Authentication failed. The user has canceled the authentication or the provider refused the connection."; break;
 				case 6 : $error = "User profile request failed. Most likely the user is not connected to the provider and he should to authenticate again."; 
 					     $adapter->logout(); 
 					     break;

--- a/examples/social_hub/profile.php
+++ b/examples/social_hub/profile.php
@@ -36,7 +36,7 @@
 			case 2 : echo "Provider not properly configured."; break;
 			case 3 : echo "Unknown or disabled provider."; break;
 			case 4 : echo "Missing provider application credentials."; break;
-			case 5 : echo "Authentification failed. " 
+			case 5 : echo "Authentication failed. " 
 					  . "The user has canceled the authentication or the provider refused the connection."; 
 			case 6 : echo "User profile request failed. Most likely the user is not connected "
 					  . "to the provider and he should to authenticate again."; 

--- a/examples/widget_authentication/widget/index.php
+++ b/examples/widget_authentication/widget/index.php
@@ -19,7 +19,7 @@
 			case 2 : $message = "Provider not properly configured."; break;
 			case 3 : $message = "Unknown or disabled provider."; break;
 			case 4 : $message = "Missing provider application credentials."; break;
-			case 5 : $message = "Authentification failed. The user has canceled the authentication or the provider refused the connection."; break;
+			case 5 : $message = "Authentication failed. The user has canceled the authentication or the provider refused the connection."; break;
 
 			default: $message = "Unspecified error!";
 		}

--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -128,10 +128,10 @@ class Hybrid_Endpoint {
 
 		# if REQUESTed hauth_idprovider is wrong, session not created, etc. 
 		if( ! $hauth ) {
-			Hybrid_Logger::error( "Endpoint: Invalide parameter on hauth_start!" );
+			Hybrid_Logger::error( "Endpoint: Invalid parameter on hauth_start!" );
 
 			header( "HTTP/1.0 404 Not Found" );
-			die( "Invalide parameter! Please return to the login page and try again." );
+			die( "Invalid parameter! Please return to the login page and try again." );
 		}
 
 		try {
@@ -161,12 +161,12 @@ class Hybrid_Endpoint {
 		$hauth = Hybrid_Auth::setup( $provider_id );
 
 		if( ! $hauth ) {
-			Hybrid_Logger::error( "Endpoint: Invalide parameter on hauth_done!" ); 
+			Hybrid_Logger::error( "Endpoint: Invalid parameter on hauth_done!" ); 
 
 			$hauth->adapter->setUserUnconnected();
 
 			header("HTTP/1.0 404 Not Found"); 
-			die( "Invalide parameter! Please return to the login page and try again." );
+			die( "Invalid parameter! Please return to the login page and try again." );
 		}
 
 		try {

--- a/hybridauth/Hybrid/Provider_Adapter.php
+++ b/hybridauth/Hybrid/Provider_Adapter.php
@@ -90,7 +90,7 @@ class Hybrid_Provider_Adapter
 	// --------------------------------------------------------------------
 
 	/**
-	* Hybrid_Provider_Adapter::login(), prepare the user session and the authentification request
+	* Hybrid_Provider_Adapter::login(), prepare the user session and the authentication request
 	* for index.php
 	*/
 	function login()

--- a/hybridauth/Hybrid/Provider_Model_OAuth1.php
+++ b/hybridauth/Hybrid/Provider_Model_OAuth1.php
@@ -103,11 +103,11 @@ class Hybrid_Provider_Model_OAuth1 extends Hybrid_Provider_Model
 		
 		// check the last HTTP status code returned
 		if ( $this->api->http_code != 200 ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 5 );
 		}
 
 		if ( ! isset( $tokens["oauth_token"] ) ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid oauth token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid oauth token.", 5 );
 		}
 
 		$this->token( "request_token"       , $tokens["oauth_token"] ); 
@@ -128,7 +128,7 @@ class Hybrid_Provider_Model_OAuth1 extends Hybrid_Provider_Model
 		$oauth_verifier = (array_key_exists('oauth_verifier',$_REQUEST))?$_REQUEST['oauth_verifier']:"";
 
 		if ( ! $oauth_token || ! $oauth_verifier ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid oauth verifier.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid oauth verifier.", 5 );
 		}
 
 		// request an access token
@@ -139,12 +139,12 @@ class Hybrid_Provider_Model_OAuth1 extends Hybrid_Provider_Model
 
 		// check the last HTTP status code returned
 		if ( $this->api->http_code != 200 ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 5 );
 		}
 
 		// we should have an access_token, or else, something has gone wrong
 		if ( ! isset( $tokens["oauth_token"] ) ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid access token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid access token.", 5 );
 		}
 
 		// we no more need to store requet tokens

--- a/hybridauth/Hybrid/Provider_Model_OAuth2.php
+++ b/hybridauth/Hybrid/Provider_Model_OAuth2.php
@@ -104,7 +104,7 @@ class Hybrid_Provider_Model_OAuth2 extends Hybrid_Provider_Model
 
 		// check for errors
 		if ( $error ){ 
-			throw new Exception( "Authentification failed! {$this->providerId} returned an error: $error", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an error: $error", 5 );
 		}
 
 		// try to authenicate user
@@ -119,7 +119,7 @@ class Hybrid_Provider_Model_OAuth2 extends Hybrid_Provider_Model
 
 		// check if authenticated
 		if ( ! $this->api->access_token ){ 
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid access token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid access token.", 5 );
 		}
 
 		// store tokens

--- a/hybridauth/Hybrid/Provider_Model_OpenID.php
+++ b/hybridauth/Hybrid/Provider_Model_OpenID.php
@@ -89,12 +89,12 @@ class Hybrid_Provider_Model_OpenID extends Hybrid_Provider_Model
 	{
 		# if user don't garant acess of their data to your site, halt with an Exception
 		if( $this->api->mode == 'cancel'){
-			throw new Exception( "Authentification failed! User has canceled authentication!", 5 );
+			throw new Exception( "Authentication failed! User has canceled authentication!", 5 );
 		}
 
 		# if something goes wrong
 		if( ! $this->api->validate() ){
-			throw new Exception( "Authentification failed. Invalid request recived!", 5 );
+			throw new Exception( "Authentication failed. Invalid request recived!", 5 );
 		}
 
 		# fetch recived user data

--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -79,12 +79,12 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model
 	{ 
 		// in case we get error_reason=user_denied&error=access_denied
 		if ( isset( $_REQUEST['error'] ) && $_REQUEST['error'] == "access_denied" ){ 
-			throw new Exception( "Authentification failed! The user denied your request.", 5 );
+			throw new Exception( "Authentication failed! The user denied your request.", 5 );
 		}
 
 		// try to get the UID of the connected user from fb, should be > 0 
 		if ( ! $this->api->getUser() ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalide user id.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid user id.", 5 );
 		}
 
 		// set user as logged in

--- a/hybridauth/Hybrid/Providers/Foursquare.php
+++ b/hybridauth/Hybrid/Providers/Foursquare.php
@@ -35,7 +35,7 @@ class Hybrid_Providers_Foursquare extends Hybrid_Provider_Model_OAuth2
 		$data = $this->api->api( "users/self" ); 
 
 		if ( ! isset( $data->response->user->id ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$data = $data->response->user;

--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -57,7 +57,7 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 		$response = $this->api->api( "https://www.googleapis.com/oauth2/v1/userinfo" ); 
 
 		if ( ! isset( $response->id ) || isset( $response->error ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$this->user->profile->identifier    = (property_exists($response,'id'))?$response->id:"";

--- a/hybridauth/Hybrid/Providers/LinkedIn.php
+++ b/hybridauth/Hybrid/Providers/LinkedIn.php
@@ -49,7 +49,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model
 			Hybrid_Auth::redirect( LINKEDIN::_URL_AUTH . $response['linkedin']['oauth_token'] );
 		}
 		else{
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid Token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid Token.", 5 );
 		}
 	}
 
@@ -62,7 +62,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model
 		$oauth_verifier = $_REQUEST['oauth_verifier'];
 
 		if ( ! $oauth_verifier ){
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid Token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid Token.", 5 );
 		}
 
 		$response = $this->api->retrieveTokenAccess( $oauth_token, $this->token( "oauth_token_secret" ), $oauth_verifier );
@@ -79,7 +79,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model
 			$this->setUserConnected();
 		}
 		else{
-			throw new Exception( "Authentification failed! {$this->providerId} returned an invalid Token.", 5 );
+			throw new Exception( "Authentication failed! {$this->providerId} returned an invalid Token.", 5 );
 		}
 	}
 
@@ -100,7 +100,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model
 			$data = @ new SimpleXMLElement( $response['linkedin'] );
 
 			if ( ! is_object( $data ) ){
-				throw new Exception( "User profile request failed! {$this->providerId} returned an invalide xml data.", 6 );
+				throw new Exception( "User profile request failed! {$this->providerId} returned an invalid xml data.", 6 );
 			}
 
 			$this->user->profile->identifier  = (string) $data->{'id'};

--- a/hybridauth/Hybrid/Providers/Live.php
+++ b/hybridauth/Hybrid/Providers/Live.php
@@ -46,7 +46,7 @@ class Hybrid_Providers_Live extends Hybrid_Provider_Model_OAuth2
 		$data = $this->api->get( "me" ); 
 
 		if ( ! isset( $data->id ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$this->user->profile->identifier    = (property_exists($data,'id'))?$data->id:"";

--- a/hybridauth/Hybrid/Providers/MySpace.php
+++ b/hybridauth/Hybrid/Providers/MySpace.php
@@ -34,7 +34,7 @@ class Hybrid_Providers_MySpace extends Hybrid_Provider_Model_OAuth1
 		$response = $this->api->get( 'http://api.myspace.com/v1/user.json' );
 
 		if ( ! isset( $response->userId ) ){
-			throw new Exception( "User id request failed! {$this->providerId} returned an invalide response." );
+			throw new Exception( "User id request failed! {$this->providerId} returned an invalid response." );
 		}
 
 		return $response->userId;
@@ -50,7 +50,7 @@ class Hybrid_Providers_MySpace extends Hybrid_Provider_Model_OAuth1
 		$data = $this->api->get( 'http://api.myspace.com/v1/users/' . $userId . '/profile.json' );
 
 		if ( ! is_object( $data ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$this->user->profile->identifier  = $userId;
@@ -78,7 +78,7 @@ class Hybrid_Providers_MySpace extends Hybrid_Provider_Model_OAuth1
 		$response = $this->api->get( "http://api.myspace.com/v1/users/" . $userId . "/friends.json" );
 
 		if ( ! is_object( $response ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$contacts = ARRAY();
@@ -134,7 +134,7 @@ class Hybrid_Providers_MySpace extends Hybrid_Provider_Model_OAuth1
 		}
 
 		if ( ! is_object( $response ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$activities = ARRAY();

--- a/hybridauth/Hybrid/Providers/Yahoo.php
+++ b/hybridauth/Hybrid/Providers/Yahoo.php
@@ -40,7 +40,7 @@ class Hybrid_Providers_Yahoo extends Hybrid_Provider_Model_OAuth1
 		$response = $this->api->get( 'user/' . $userId . '/profile', $parameters ); 
 
 		if ( ! isset( $response->profile ) ){
-			throw new Exception( "User profile request failed! {$this->providerId} returned an invalide response.", 6 );
+			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
 		$data = $response->profile;
@@ -229,7 +229,7 @@ class Hybrid_Providers_Yahoo extends Hybrid_Provider_Model_OAuth1
 		$response = $this->api->get( 'me/guid', $parameters );
 
 		if ( ! isset( $response->guid->value ) ){
-			throw new Exception( "User id request failed! {$this->providerId} returned an invalide response." );
+			throw new Exception( "User id request failed! {$this->providerId} returned an invalid response." );
 		}
 
 		return $response->guid->value;


### PR DESCRIPTION
"[Authentification](http://www.merriam-webster.com/dictionary/authentification)" is not a word.  Nor is "[valide](http://www.merriam-webster.com/dictionary/valide)".  I personally find it embarrassing for those things to show up in my code, so I always fix hybridauth first.  Makes sense to push that back.
