### PR TITLE
Create tag alias 2.1.1 for dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,10 @@
         "psr-0": {
             "Hybrid": "hybridauth/"
         } 
-    }
+    },
+	"extra": {
+		"branch-alias": {
+			"dev-master": "2.1.0"
+		}
+	}
 }


### PR DESCRIPTION
For current use in composer as

`"hybridauth/hybridauth": "2.1.*"`
