### PR TITLE
Update hybridauth/Hybrid/Auth.php

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -386,11 +386,12 @@ class Hybrid_Auth
 		$url = $protocol . $_SERVER['HTTP_HOST'];
 
 		// use port if non default
-		$url .= 
-			isset( $_SERVER['SERVER_PORT'] ) 
-			&&( ($protocol === 'http://' && $_SERVER['SERVER_PORT'] != 80 && !isset( $_SERVER['HTTP_X_FORWARDED_PROTO'])) || ($protocol === 'https://' && $_SERVER['SERVER_PORT'] != 443 && !isset( $_SERVER['HTTP_X_FORWARDED_PROTO'])) )
-			? ':' . $_SERVER['SERVER_PORT'] 
-			: '';
+		if( isset( $_SERVER['SERVER_PORT'] ) && strpos( $url, ':'.$_SERVER['SERVER_PORT'] ) === FALSE ) {
+			$url .= ($protocol === 'http://' && $_SERVER['SERVER_PORT'] != 80 && !isset( $_SERVER['HTTP_X_FORWARDED_PROTO']))
+				|| ($protocol === 'https://' && $_SERVER['SERVER_PORT'] != 443 && !isset( $_SERVER['HTTP_X_FORWARDED_PROTO']))
+				? ':' . $_SERVER['SERVER_PORT'] 
+				: '';
+		}
 
 		if( $request_uri ){
 			$url .= $_SERVER['REQUEST_URI'];


### PR DESCRIPTION
fix bug when $_SERVER['HTTP_HOST'] includes port

Bug:
when $_SERVER['HTTP_HOST'] = "10.23.45.67:8080"
the callback_url will be http://10.23.45.67:8080:8080/...
