### PR TITLE
Update permission scope in LinkedIn 3rd party lib

### DIFF
--- a/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
+++ b/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
@@ -123,7 +123,7 @@ class LinkedIn {
 	const _URL_API                     = 'https://api.linkedin.com';
 	const _URL_AUTH                    = 'https://www.linkedin.com/uas/oauth/authenticate?oauth_token=';
 	// const _URL_REQUEST                 = 'https://api.linkedin.com/uas/oauth/requestToken';
-	const _URL_REQUEST                 = 'https://api.linkedin.com/uas/oauth/requestToken?scope=r_basicprofile+r_emailaddress'; 
+	const _URL_REQUEST                 = 'https://api.linkedin.com/uas/oauth/requestToken?scope=r_basicprofile+r_emailaddress+rw_nus'; 
 	const _URL_REVOKE                  = 'https://api.linkedin.com/uas/oauth/invalidateToken';
 	
 	// Library version


### PR DESCRIPTION
Without this scope LinkedIn does not allow share status on profile.
