### PR TITLE
Adapts deletion of Session-Keys to ArrayObject

### DIFF
--- a/hybridauth/Hybrid/Storage.php
+++ b/hybridauth/Hybrid/Storage.php
@@ -64,7 +64,9 @@ class Hybrid_Storage
 		$key = strtolower( $key );  
 
 		if( isset( $_SESSION["HA::STORE"], $_SESSION["HA::STORE"][$key] ) ){
-			unset( $_SESSION["HA::STORE"][$key] );
+		    $f = $_SESSION['HA::STORE'];
+		    unset($f[$key]);
+		    $_SESSION["HA::STORE"] = $f;
 		} 
 	}
 
@@ -73,11 +75,14 @@ class Hybrid_Storage
 		$key = strtolower( $key ); 
 
 		if( isset( $_SESSION["HA::STORE"] ) && count( $_SESSION["HA::STORE"] ) ) {
-			foreach( $_SESSION["HA::STORE"] as $k => $v ){ 
+		    $f = $_SESSION['HA::STORE'];
+		    foreach( $f as $k => $v ){ 
 				if( strstr( $k, $key ) ){
-					unset( $_SESSION["HA::STORE"][ $k ] ); 
+					unset( $f[ $k ] ); 
 				}
 			}
+			$_SESSION["HA::STORE"] = $f;
+			
 		}
 	}
 


### PR DESCRIPTION
If `$_SESSION` is an ArrayObject, the usual `unset` does not work.
Therefore the change adapts the code to enable deletion off session-keys
even if `$_SESSION` is an ArrayObject.
