### PR TITLE
Make logging level based

### DIFF
--- a/hybridauth/Hybrid/Logger.php
+++ b/hybridauth/Hybrid/Logger.php
@@ -40,7 +40,7 @@ class Hybrid_Logger
 
 	public static function info( $message )
 	{ 
-		if( Hybrid_Auth::$config["debug_mode"] ){
+		if( in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info'), true) ){
 			$datetime = new DateTime();
 			$datetime =  $datetime->format(DATE_ATOM);
 
@@ -54,7 +54,7 @@ class Hybrid_Logger
 
 	public static function error($message, $object = NULL)
 	{ 
-		if( Hybrid_Auth::$config["debug_mode"] ){
+		if( in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info', 'error'), true) ){
 			$datetime = new DateTime();
 			$datetime =  $datetime->format(DATE_ATOM);
 

--- a/hybridauth/config.php
+++ b/hybridauth/config.php
@@ -65,8 +65,12 @@ return
 			),
 		),
 
-		// if you want to enable logging, set 'debug_mode' to true  then provide a writable file by the web server on "debug_file"
+		// If you want to enable logging, set 'debug_mode' to true.
+		// You can also set it to
+		// - "error" To log only error messages. Useful in production
+		// - "info" To log info and error messages (ignore debug messages) 
 		"debug_mode" => false,
 
+		// Path to file writable by the web server. Required if 'debug_mode' is not false
 		"debug_file" => "",
 	);


### PR DESCRIPTION
In production mode you generally want to errors to be logged but ignore info/debug messages. This simple patch achieves that by allowing to set `debug_mode` to string "error" (or "info") while maintaining backwards compatibility with existing behavior of all or nothing approach.
