### PR TITLE
Uses Exceptions instead of die() to handle critical problems.

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -68,6 +68,7 @@ class Hybrid_Auth
 
 		# load hybridauth required files, a autoload is on the way...
 		require_once $config["path_base"] . "Error.php";
+		require_once $config["path_base"] . "Exception.php";
 		require_once $config["path_base"] . "Logger.php";
 
 		require_once $config["path_base"] . "Storage.php";

--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -119,8 +119,7 @@ class Hybrid_Endpoint {
 		if( ! Hybrid_Auth::storage()->get( "hauth_session.$provider_id.hauth_endpoint" ) ) {
 			Hybrid_Logger::error( "Endpoint: hauth_endpoint parameter is not defined on hauth_start, halt login process!" );
 
-			header( "HTTP/1.0 404 Not Found" );
-			die( "You cannot access this page directly." );
+			throw new Hybrid_Exception( "You cannot access this page directly." );
 		}
 
 		# define:hybrid.endpoint.php step 2.
@@ -130,8 +129,7 @@ class Hybrid_Endpoint {
 		if( ! $hauth ) {
 			Hybrid_Logger::error( "Endpoint: Invalid parameter on hauth_start!" );
 
-			header( "HTTP/1.0 404 Not Found" );
-			die( "Invalid parameter! Please return to the login page and try again." );
+			throw new Hybrid_Exception( "Invalid parameter! Please return to the login page and try again." );
 		}
 
 		try {
@@ -165,8 +163,7 @@ class Hybrid_Endpoint {
 
 			$hauth->adapter->setUserUnconnected();
 
-			header("HTTP/1.0 404 Not Found"); 
-			die( "Invalid parameter! Please return to the login page and try again." );
+			throw new Hybrid_Exception( "Invalid parameter! Please return to the login page and try again." );
 		}
 
 		try {
@@ -200,8 +197,7 @@ class Hybrid_Endpoint {
 
 				// Check if Hybrid_Auth session already exist
 				if ( ! $storage->config( "CONFIG" ) ) { 
-					header( "HTTP/1.0 404 Not Found" );
-					die( "You cannot access this page directly." );
+					throw new Hybrid_Exception( "You cannot access this page directly." );
 				}
 
 				Hybrid_Auth::initialize( $storage->config( "CONFIG" ) ); 
@@ -209,8 +205,7 @@ class Hybrid_Endpoint {
 			catch ( Exception $e ){
 				Hybrid_Logger::error( "Endpoint: Error while trying to init Hybrid_Auth" ); 
 
-				header( "HTTP/1.0 404 Not Found" );
-				die( "Oophs. Error!" );
+				throw new Hybrid_Exception( "Oophs. Error!" );
 			}
 		}
 	}

--- a/hybridauth/Hybrid/Exception.php
+++ b/hybridauth/Hybrid/Exception.php
@@ -1,0 +1,16 @@
+<?php
+/*!
+* HybridAuth
+* http://hybridauth.sourceforge.net | http://github.com/hybridauth/hybridauth
+* (c) 2009-2012, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html
+*/
+
+/**
+ * Exception implementation
+ * 
+ * The base Exception is extended to allow applications to handle exceptions from hybrid auth
+ * separately from general exceptions.
+ */
+class Hybrid_Exception extends Exception
+{
+}


### PR DESCRIPTION
- Add a new Hybrid_Exception class
- Use Hybrid_Exception instead of die() for critical problems.

Using Exceptions is preferable to die, as it allows client code to
handle problems rather than forcing the client application to die.

A local Exception extension is used to allow code which handles the
exception to distinguish the exception type in try/catch blocks.
