### PR TITLE
Support for a configurable logging threshold.

### DIFF
--- a/hybridauth/Hybrid/resources/config.php.tpl
+++ b/hybridauth/Hybrid/resources/config.php.tpl
@@ -68,5 +68,8 @@ return
 		// if you want to enable logging, set 'debug_mode' to true  then provide a writable file by the web server on "debug_file"
 		"debug_mode" => false,
 
-		"debug_file" => ""
+		"debug_file" => "",
+
+        // Debug levels are error (1), info (2) and debug (3)
+        "debug_level" => 1,
 	);

--- a/hybridauth/config.php
+++ b/hybridauth/config.php
@@ -69,4 +69,7 @@ return
 		"debug_mode" => false,
 
 		"debug_file" => "",
+
+        // Debug levels are error (1), info (2) and debug (3)
+        "debug_level" => 1,
 	);


### PR DESCRIPTION
Adds support for filtering log messages by a configurable threshold, so
that only logs above the threshold are reported.  This is mainly useful
for restricting logs to only show errors, without the performance
penalty and noise required when logging everything.

A small amount of refactoring is done so simplify the logging and more
levels can easily be added by simply adding a class constant with the
level.
