### PR TITLE
LinkedIn Proxy Aware

### DIFF
--- a/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
+++ b/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
@@ -670,6 +670,10 @@ class LinkedIn {
       curl_setopt($handle, CURLOPT_SSL_VERIFYPEER, FALSE);
       curl_setopt($handle, CURLOPT_URL, $url);
       curl_setopt($handle, CURLOPT_VERBOSE, FALSE);
+
+      if ( isset ( Hybrid_Auth::$config["proxy"] ) ) {
+      	curl_setopt($handle, CURLOPT_PROXY, Hybrid_Auth::$config["proxy"]);
+      }
       
       // configure the header we are sending to LinkedIn - http://developer.linkedin.com/docs/DOC-1203
       $header = array($oauth_req->to_header(self::_API_OAUTH_REALM));


### PR DESCRIPTION
Linkedin was not honouring the proxy settings in the config array. This minor fix ensures Curl requests are sent via the proxy if they are present.

Cheers
Ben
