### PR TITLE
Steam provider tuning

### DIFF
--- a/additional-providers/hybridauth-steam/Providers/Steam.php
+++ b/additional-providers/hybridauth-steam/Providers/Steam.php
@@ -39,7 +39,7 @@ class Hybrid_Providers_Steam extends Hybrid_Provider_Model_OpenID
 			$realname = (string) $data->{'realname'}; 
 
 			if( $realname ){
-				$this->user->profile->displayName = $realname;
+				$this->user->profile->firstName = $realname;
 			}
 			
 			$customURL = (string) $data->{'customURL'};


### PR DESCRIPTION
I've received some complaints about Steam provider lib: it overwrites previously saved nickname in the favor of displayName, which should be saved to firstName actually.

This is important because people are used to nicknames instead of displayNames, it's what they see in their Friends list.
