### PR TITLE
Exception object is missing getPrevious method

### DIFF
--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -141,7 +141,7 @@ class Hybrid_Endpoint {
 		}
 		catch ( Exception $e ) {
 			Hybrid_Logger::error( "Exception:" . $e->getMessage(), $e );
-			Hybrid_Error::setError( $e->getMessage(), $e->getCode(), $e->getTraceAsString(), $e );
+			Hybrid_Error::setError( $e->getMessage(), $e->getCode(), $e->getTraceAsString(), $e->getPrevious() );
 
 			$hauth->returnToCallbackUrl();
 		}


### PR DESCRIPTION
Exception object is missing getPrevious method which leads to whole $e object serialization. If stack trace has closures the following error occurs "Serialization of 'Closure' is not allowed" in hybridauth/Hybrid/Storage.php(54).
