### PR TITLE
Revert a hack that blocks scope flexibility

### DIFF
--- a/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
+++ b/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
@@ -2,6 +2,8 @@
 // http://code.google.com/p/simple-linkedinphp/
 // 3.2.0 - November 29, 2011
 // hacked into the code to handel new scope (r_basicprofile+r_emailaddress) - until Paul update linkedinphp library!
+// Facyla note 20131219 : this in fact should not be hacked, as Linkedin lets developpers define the wanted scope 
+//   in Linkedin application settings, when creating the (required) application and API access
 
 /**
  * This file defines the 'LinkedIn' class. This class is designed to be a 
@@ -122,8 +124,8 @@ class LinkedIn {
 	const _URL_ACCESS                  = 'https://api.linkedin.com/uas/oauth/accessToken';
 	const _URL_API                     = 'https://api.linkedin.com';
 	const _URL_AUTH                    = 'https://www.linkedin.com/uas/oauth/authenticate?oauth_token=';
-	// const _URL_REQUEST                 = 'https://api.linkedin.com/uas/oauth/requestToken';
-	const _URL_REQUEST                 = 'https://api.linkedin.com/uas/oauth/requestToken?scope=r_basicprofile+r_emailaddress+rw_nus+r_network'; 
+	const _URL_REQUEST                 = 'https://api.linkedin.com/uas/oauth/requestToken';
+	// const _URL_REQUEST                 = 'https://api.linkedin.com/uas/oauth/requestToken?scope=r_basicprofile+r_emailaddress+rw_nus+r_network'; 
 	const _URL_REVOKE                  = 'https://api.linkedin.com/uas/oauth/invalidateToken';
 	
 	// Library version


### PR DESCRIPTION
Hardcoding the scope disables the settings that are defined in the application itself, and blocks per-implementation scope configuration.
The scope can be defined when creating/updating a LinkedIn app, so it's useless to hack it.
The scope should be hardcoded only if it can be set elsewhere, out of the library, so that implementation can define their own scope directly, so not as a constant.
Application scope setting seems the most flexible solution for the moment.
