### PR TITLE
Enable extra parameters from config to be passed into OAuth1 authorizeUr...

### DIFF
--- a/hybridauth/Hybrid/Provider_Model_OAuth1.php
+++ b/hybridauth/Hybrid/Provider_Model_OAuth1.php
@@ -114,7 +114,7 @@ class Hybrid_Provider_Model_OAuth1 extends Hybrid_Provider_Model
 		$this->token( "request_token_secret", $tokens["oauth_token_secret"] ); 
 
 		# redirect the user to the provider authentication url
-		Hybrid_Auth::redirect( $this->api->authorizeUrl( $tokens ) );
+		Hybrid_Auth::redirect( $this->api->authorizeUrl( $tokens, $this->config['extras'] ) );
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
It is often necessary to request the permissions of a given service during authorization, and the OAuth1Client allows for an "extras" parameter, so I am passing the provider's config["extras"] array to the api's authorizeUrl method. This may also benefit the OAuth2 provider, but I haven't gone there yet.
