### PR TITLE
If logfile does not exist - try to create it instead of throw exception....

### DIFF
--- a/hybridauth/Hybrid/Logger.php
+++ b/hybridauth/Hybrid/Logger.php
@@ -12,12 +12,14 @@ class Hybrid_Logger
 {
 	function __construct()
 	{
-		// if debug mode is set to true, then check for the writable log file
-		if ( Hybrid_Auth::$config["debug_mode"] ){
-			if ( ! file_exists( Hybrid_Auth::$config["debug_file"] ) ){
-				throw new Exception( "'debug_mode' is set to 'true', but the file " . Hybrid_Auth::$config['debug_file'] . " in 'debug_file' does not exist.", 1 );
+ 		// if debug mode is set to true, then check for the writable log file
+ 		if ( Hybrid_Auth::$config["debug_mode"] ){
+ 			if ( ! file_exists( Hybrid_Auth::$config["debug_file"] ) ){
+                                if ( ! touch( Hybrid_Auth::$config["debug_file"] ) ){
+                                        throw new Exception( "'debug_mode' is set to 'true', but the file " . Hybrid_Auth::$config['debug_file'] . " in 'debug_file' can not be created.", 1 );
+                                }
 			}
-
+ 
 			if ( ! is_writable( Hybrid_Auth::$config["debug_file"] ) ){
 				throw new Exception( "'debug_mode' is set to 'true', but the given log file path 'debug_file' is not a writable file.", 1 );
 			}


### PR DESCRIPTION
If logfile does not exist, more reasonable try to create it instead of trow exception. If file create fails, then we have to throw exception.
