### PR TITLE
Removed duplicate empty displayName logic block

### DIFF
--- a/hybridauth/Hybrid/Provider_Model_OpenID.php
+++ b/hybridauth/Hybrid/Provider_Model_OpenID.php
@@ -117,10 +117,6 @@ class Hybrid_Provider_Model_OpenID extends Hybrid_Provider_Model
 		$this->user->profile->birthMonth  = (array_key_exists("birthDate/birthMonth",$response))?$response["birthDate/birthMonth"]:""; 
 		$this->user->profile->birthYear   = (array_key_exists("birthDate/birthDate",$response))?$response["birthDate/birthDate"]:"";  
 
-		if( ! $this->user->profile->displayName ) {
-			$this->user->profile->displayName = trim( $this->user->profile->lastName . " " . $this->user->profile->firstName ); 
-		}
-
 		if( isset( $response['namePerson/friendly'] ) && ! empty( $response['namePerson/friendly'] ) && ! $this->user->profile->displayName ) { 
 			$this->user->profile->displayName = (array_key_exists("namePerson/friendly",$response))?$response["namePerson/friendly"]:"" ; 
 		}


### PR DESCRIPTION
The code was checking for an emptyDisplay name before trying to set the displayName based on the friendly name. It was also swapping the firstName and lastName.

This changes removes that code block and fixes the logic in the code.
