### PR TITLE
Enable user to provide they're own storage mechanism

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -70,8 +70,6 @@ class Hybrid_Auth
 		require_once $config["path_base"] . "Error.php";
 		require_once $config["path_base"] . "Logger.php";
 
-		require_once $config["path_base"] . "Storage.php";
-
 		require_once $config["path_base"] . "Provider_Adapter.php";
 
 		require_once $config["path_base"] . "Provider_Model.php";
@@ -83,6 +81,10 @@ class Hybrid_Auth
 		require_once $config["path_base"] . "User_Profile.php";
 		require_once $config["path_base"] . "User_Contact.php";
 		require_once $config["path_base"] . "User_Activity.php";
+
+        if(!class_exists("Hybrid_Storage")){
+            require_once $config["path_base"] . "Storage.php";
+        }
 
 		// hash given config
 		Hybrid_Auth::$config = $config;

--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -194,7 +194,9 @@ class Hybrid_Endpoint {
 
 			# Init Hybrid_Auth
 			try {
-				require_once realpath( dirname( __FILE__ ) )  . "/Storage.php";
+                if(!class_exists("Hybrid_Storage")){
+                    require_once realpath( dirname( __FILE__ ) )  . "/Storage.php";
+                }
 				
 				$storage = new Hybrid_Storage(); 
 

--- a/hybridauth/Hybrid/Storage.php
+++ b/hybridauth/Hybrid/Storage.php
@@ -5,10 +5,12 @@
 * (c) 2009-2012, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html 
 */
 
+require_once realpath( dirname( __FILE__ ) )  . "/StorageInterface";
+
 /**
  * HybridAuth storage manager
  */
-class Hybrid_Storage 
+class Hybrid_Storage implements Hybrid_Storage_Interface
 {
 	function __construct()
 	{ 

--- a/hybridauth/Hybrid/StorageInterface.php
+++ b/hybridauth/Hybrid/StorageInterface.php
@@ -1,0 +1,28 @@
+<?php
+/*!
+* HybridAuth
+* http://hybridauth.sourceforge.net | http://github.com/hybridauth/hybridauth
+* (c) 2009-2012, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html
+*/
+
+/**
+ * HybridAuth storage manager interface
+ */
+interface Hybrid_Storage_Interface
+{
+    public function config($key, $value);
+
+    public function get($key);
+
+    public function set( $key, $value );
+
+    function clear();
+
+    function delete($key);
+
+    function deleteMatch($key);
+
+    function getSessionData();
+
+    function restoreSessionData( $sessiondata);
+}


### PR DESCRIPTION
This change allows a user to provide their own storage mechanism. This is useful, for example, on a WordPress site where the $_SESSION variable can't be used reliably, or in the case where authentication needs to happen across multiple nodes and the storage would need to use a database or another shared memory.
