### PR TITLE
Google: Handle missing $primary property for placesLived

### DIFF
--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -88,12 +88,19 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 		$this->user->profile->region 		= (property_exists($response,'region'))?$response->region:"";
 		$this->user->profile->zip	 		= (property_exists($response,'zip'))?$response->zip:"";
 		if( property_exists($response,'placesLived') ){
-			$this->user->profile->city 		= ""; 
+			$this->user->profile->city 	= ""; 
 			$this->user->profile->address	= ""; 
 			foreach($response->placesLived as $c){
-				if($c->primary == true){ 
-					$this->user->profile->address 	= $c->value;
-					$this->user->profile->city 		= $c->value;
+				if(property_exists($c,'primary')){
+					if($c->primary == true){ 
+						$this->user->profile->address 	= $c->value;
+						$this->user->profile->city 	= $c->value;
+					}
+				}else{
+					if(property_exists($c,'value')){
+						$this->user->profile->address 	= $c->value;
+						$this->user->profile->city 	= $c->value;
+					}	
 				}
 			}
 		}


### PR DESCRIPTION
Google returned the following for my profile:

```
[placesLived] => Array
    (
        [0] => stdClass Object
            (
                [value] => Mödling
            )

    )
```

So there is no primary property of `$c`.

The code now checks if there is a `$primary` property and otherwise directly uses the `$value` if it exists.
