### PR TITLE
- Added optional state parameter and redirect uri override in Google Provider

### DIFF
--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -30,8 +30,8 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 		$this->api->token_url      = "https://accounts.google.com/o/oauth2/token";
 		$this->api->token_info_url = "https://www.googleapis.com/oauth2/v2/tokeninfo";
         
-        // Override the redirect uri when it's set in the config parameters. This way we prevent
-        // redirect uri mismatches when authenticating with Google.
+		// Override the redirect uri when it's set in the config parameters. This way we prevent
+		// redirect uri mismatches when authenticating with Google.
 		if( isset( $this->config['redirect_uri'] ) && ! empty( $this->config['redirect_uri'] ) ){
 			$this->api->redirect_uri = $this->config['redirect_uri'];
 		}


### PR DESCRIPTION
With these changes it's possible with some url rewriting to create a single entrypoint for a multi domain environment. The optional state parameter is documented by Google and will be send back by Google unmodified after authentication.

After adding the state param i noticed the redirect_uri config parameter wasn't used by the provider when Hybridauth tries to validate the response from Google in the auth.done process. I added an extra line to inject the redirect_uri directly into the api so the correct redirect uri is used on all requests.
