### PR TITLE
Gmail fix

### DIFF
--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -191,20 +191,20 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 				$uc->displayName 	= isset($entry->title->{'$t'}) ? (string) $entry->title->{'$t'} : '';  
 				$uc->identifier		= ($uc->email!='')?$uc->email:'';
 				$uc->description 	= '';
-                if( property_exists($entry,'link') ){
-                    /**
-                     * sign links with access_token
-                     */
-                    if(is_array($entry->link)){
-                        foreach($entry->link as $l){
-                            if( property_exists($l,'gd$etag') && $l->type=="image/*"){
-                                $uc->photoURL = $this->addUrlParam($l->href, array('access_token' => $this->api->access_token));
-                            } else if($l->type=="self"){
-                                $uc->profileURL = $this->addUrlParam($l->href, array('access_token' => $this->api->access_token));
-                            }
-                        }
-                    }
-                } else {
+				if( property_exists($entry,'link') ){
+					/**
+					 * sign links with access_token
+					 */
+					if(is_array($entry->link)){
+						foreach($entry->link as $l){
+							if( property_exists($l,'gd$etag') && $l->type=="image/*"){
+								$uc->photoURL = $this->addUrlParam($l->href, array('access_token' => $this->api->access_token));
+							} else if($l->type=="self"){
+								$uc->profileURL = $this->addUrlParam($l->href, array('access_token' => $this->api->access_token));
+							}
+						}
+					}
+				} else {
 					$uc->profileURL = '';
 				}
 				if( property_exists($response,'website') ){
@@ -252,22 +252,22 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 		return $contacts;
  	}
 
-  /**
-   * Add to the $url new parameters
-   * @param string $url
-   * @param array $params
-   * @return string
-   */
-  function addUrlParam($url, array $params)
-  {
-    $query = parse_url($url, PHP_URL_QUERY);
+	/**
+	 * Add to the $url new parameters
+	 * @param string $url
+	 * @param array $params
+	 * @return string
+	 */
+	function addUrlParam($url, array $params)
+	{
+		$query = parse_url($url, PHP_URL_QUERY);
 
-    // Returns the URL string with new parameters
-    if( $query ) {
-      $url .= '&' . http_build_query( $params );
-    } else {
-      $url .= '?' . http_build_query( $params );
-    }
-    return $url;
-  }
+		// Returns the URL string with new parameters
+		if( $query ) {
+			$url .= '&' . http_build_query( $params );
+		} else {
+			$url .= '?' . http_build_query( $params );
+		}
+		return $url;
+	}
 }


### PR DESCRIPTION
Hi! I fixed 2 things in gmail getting contacts procedure:
1. There was an error in building photoURL and profileURL when 'auth' parameter adds to url without separator, so link will be 'v=3.0auth=1'.
2. Another thing - urls sign with access_token, so links can be used as expected urls, but not the image bytes in photoURL.

Check it please.
