### PR TITLE
change uid vkontakte to screen_name

### DIFF
--- a/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
+++ b/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
@@ -86,10 +86,10 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 		}
 
 		$response = $response->response[0];
-		$this->user->profile->identifier    = (property_exists($response,'uid'))?$response->screen_name:"";
+		$this->user->profile->identifier    = (property_exists($response,'uid'))?$response->uid:"";
 		$this->user->profile->firstName     = (property_exists($response,'first_name'))?$response->first_name:"";
 		$this->user->profile->lastName      = (property_exists($response,'last_name'))?$response->last_name:"";
-		$this->user->profile->displayName   = (property_exists($response,'nickname'))?$response->nickname:"";
+		$this->user->profile->displayName   = (property_exists($response,'screen_name'))?$response->screen_name:"";
 		$this->user->profile->photoURL      = (property_exists($response,'photo_big'))?$response->photo_big:"";
 		$this->user->profile->profileURL    = (property_exists($response,'screen_name'))?"http://vk.com/" . $response->screen_name:"";
 


### PR DESCRIPTION
change "identifier" from "uid" to "screen_name". This field return unique page name (like field nickname, but now field nickname canceled). If screen_name not filled, api return "uid".
So if user fill screen_name api return "my_nickname" or is empty api return uid but have prefix "id" - "id1235213412".
