### PR TITLE
Added missing php extension in require statement

### DIFF
--- a/hybridauth/Hybrid/Storage.php
+++ b/hybridauth/Hybrid/Storage.php
@@ -5,7 +5,7 @@
 * (c) 2009-2012, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html 
 */
 
-require_once realpath( dirname( __FILE__ ) )  . "/StorageInterface";
+require_once realpath( dirname( __FILE__ ) )  . "/StorageInterface.php";
 
 /**
  * HybridAuth storage manager


### PR DESCRIPTION
I got this error:
`( ! ) Warning: require_once(D:\webdocuments\cm\vendor\hybridauth\hybridauth\hybridauth\Hybrid/StorageInterface): failed to open stream: No such file or directory in D:\webdocuments\cm\vendor\hybridauth\hybridauth\hybridauth\Hybrid\Storage.php on line 8`
