### PR TITLE
adding missing file extension (.php) to require_once statement

### DIFF
--- a/hybridauth/Hybrid/Storage.php
+++ b/hybridauth/Hybrid/Storage.php
@@ -5,7 +5,7 @@
 * (c) 2009-2012, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html 
 */
 
-require_once realpath( dirname( __FILE__ ) )  . "/StorageInterface";
+require_once realpath( dirname( __FILE__ ) )  . "/StorageInterface.php";
 
 /**
  * HybridAuth storage manager


### PR DESCRIPTION
The require_once is currently trying to access a non existing resource (StorageInterface).
I assume a use statement was not used for backward pre php 5.3 reasons so I've simply added the correct extension to the require statement. Otherwise PHP is throwing Fatal Errors.
