### PR TITLE
Fixed Github provider so it works with no scope, failing gracefully at the request for user email.

### DIFF
--- a/additional-providers/hybridauth-github/Providers/GitHub.php
+++ b/additional-providers/hybridauth-github/Providers/GitHub.php
@@ -56,7 +56,11 @@ class Hybrid_Providers_GitHub extends Hybrid_Provider_Model_OAuth2
 			try{
 				$emails = $this->api->api("user/emails");
 
-				$this->user->profile->email = $emails[0]->email;
+				// fail gracefully, and let apps collect the email if not present
+				if (is_array($emails) && !empty($emails[0]->email))
+				{
+				    $this->user->profile->email = $emails[0]->email;
+				}
 			}
 			catch( GithubApiException $e ){
 				throw new Exception( "User email request failed! {$this->providerId} returned an error: $e", 6 );


### PR DESCRIPTION
Fixes hybridauth/hybridauth#232, relates to hybridauth/hybridauth#227
