### PR TITLE
Disable autoloading when doing class_exists()

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -82,9 +82,9 @@ class Hybrid_Auth
 		require_once $config["path_base"] . "User_Contact.php";
 		require_once $config["path_base"] . "User_Activity.php";
 
-        if(!class_exists("Hybrid_Storage")){
-            require_once $config["path_base"] . "Storage.php";
-        }
+		if ( ! class_exists("Hybrid_Storage", false) ){
+			require_once $config["path_base"] . "Storage.php";
+        	}
 
 		// hash given config
 		Hybrid_Auth::$config = $config;


### PR DESCRIPTION
First I don't know why the above check is needed at all (if `Hybrid_Storage` is already loaded). But the above line is triggering external autoloaders of libraries that include `hybridauth/Auth.php`. Given that `hybridauth` doesn't have it's own autoloader yet, it makes sense to disable autoloading on that check.
