### PR TITLE
Bumping API call "version" to a useable number

### DIFF
--- a/hybridauth/Hybrid/Providers/Foursquare.php
+++ b/hybridauth/Hybrid/Providers/Foursquare.php
@@ -32,7 +32,7 @@ class Hybrid_Providers_Foursquare extends Hybrid_Provider_Model_OAuth2
 	*/
 	function getUserProfile()
 	{
-		$data = $this->api->api( "users/self", "GET", array( "v" => "20120401" ) ); 
+		$data = $this->api->api( "users/self", "GET", array( "v" => "20120610" ) ); 
 
 		if ( ! isset( $data->response->user->id ) ){
 			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );


### PR DESCRIPTION
FourSquare no longer supports requests to API calls with version <= 20120609. Setting the version call to 20120610 so that this goes through.
