### PR TITLE
Check if $params is_array

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -261,11 +261,11 @@ class Hybrid_Auth
 			Hybrid_Logger::info( "Hybrid_Auth::setup( $providerId ), no stored params found for this provider. Initialize a new one for new session" );
 		}
 
-		if( ! isset( $params["hauth_return_to"] ) ){
+		if( is_array($params) && ! isset( $params["hauth_return_to"] ) ){
 			$params["hauth_return_to"] = Hybrid_Auth::getCurrentUrl(); 
-		}
 
-		Hybrid_Logger::debug( "Hybrid_Auth::setup( $providerId ). HybridAuth Callback URL set to: ", $params["hauth_return_to"] );
+			Hybrid_Logger::debug( "Hybrid_Auth::setup( $providerId ). HybridAuth Callback URL set to: ", $params["hauth_return_to"] );
+		}
 
 		# instantiate a new IDProvider Adapter
 		$provider   = new Hybrid_Provider_Adapter();


### PR DESCRIPTION
<strong>Errors:</strong>
Warning: Illegal string offset 'hauth_return_to' in /vagrant/erp/source/deploy/vendor/hybridauth/hybridauth/hybridauth/Hybrid/Auth.php on line 265

Warning: Illegal string offset 'hauth_return_to' in /vagrant/erp/source/deploy/vendor/hybridauth/hybridauth/hybridauth/Hybrid/Auth.php on line 268

Warning: Cannot modify header information - headers already sent by (output started at /vagrant/erp/source/deploy/vendor/hybridauth/hybridauth/hybridauth/Hybrid/Auth.php:265) in /vagrant/erp/source/deploy/vendor/hybridauth/hybridauth/hybridauth/Hybrid/Auth.php on line 354
