### PR TITLE
twitter setUserStatus() message and picture support

### DIFF
--- a/hybridauth/Hybrid/Providers/Twitter.php
+++ b/hybridauth/Hybrid/Providers/Twitter.php
@@ -186,19 +186,23 @@ class Hybrid_Providers_Twitter extends Hybrid_Provider_Model_OAuth1
 		return $contacts;
  	}
 
-	/**
-	* update user status
-	*/ 
-	function setUserStatus( $status )
-	{
-		$parameters = array( 'status' => $status ); 
-		$response  = $this->api->post( 'statuses/update.json', $parameters ); 
+    /**
+    * update user status
+    */ 
+    function setUserStatus( $status )
+    {
 
-		// check the last HTTP status code returned
-		if ( $this->api->http_code != 200 ){
-			throw new Exception( "Update user status failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ) );
-		}
- 	}
+        if( is_array( $status ) && isset( $status[ 'message' ] ) && isset( $status[ 'picture' ] ) ){
+            $response = $this->api->post( 'statuses/update_with_media.json', array( 'status' => $status[ 'message' ], 'media[]' => file_get_contents( $status[ 'picture' ] ) ), null, null, true );
+        }else{
+            $response = $this->api->post( 'statuses/update.json', array( 'status' => $status ) ); 
+        }
+
+        // check the last HTTP status code returned
+        if ( $this->api->http_code != 200 ){
+            throw new Exception( "Update user status failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ) );
+        }
+    }
 
 	/**
 	* load the user latest activity  


### PR DESCRIPTION
Twitter api supports tweets with status and **picture** since [v1.1](https://dev.twitter.com/docs/api/1.1/post/statuses/update_with_media).
Like `Facebook::setUserStatus()` and thanks to latest [multipart feature](https://github.com/hybridauth/hybridauth/commit/cd74d9e749b356bf21df05418cbd8aa13c9f8d17) too, we can set a message and picture that will be upload to Twitter with this modified `Twitter::setUserStatus()`.

As simple as:

``` php
$twitter = $this->hybridauth->authenticate( "Twitter" );
$twitter->setUserStatus( array( 'message' => 'some message', 'picture' => 'http://..image.jpg' ) );
```

Feel free to merge and use.

best
FA
