### PR TITLE
providers setUserStatus() return status info

### DIFF
--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -272,6 +272,8 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model
 		catch( FacebookApiException $e ){
 			throw new Exception( "Update user status failed! {$this->providerId} returned an error: $e" );
 		}
+
+        return $response;
  	}
 
 	/**

--- a/hybridauth/Hybrid/Providers/LinkedIn.php
+++ b/hybridauth/Hybrid/Providers/LinkedIn.php
@@ -201,6 +201,8 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model
 		{
 			throw new Exception( "Update user status update failed! {$this->providerId} returned an error." );
 		}
+
+        return $response;
 	}
 
 	/**

--- a/hybridauth/Hybrid/Providers/Twitter.php
+++ b/hybridauth/Hybrid/Providers/Twitter.php
@@ -202,6 +202,8 @@ class Hybrid_Providers_Twitter extends Hybrid_Provider_Model_OAuth1
         if ( $this->api->http_code != 200 ){
             throw new Exception( "Update user status failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ) );
         }
+
+        return $response;
     }
 
 	/**


### PR DESCRIPTION
A status info is always returned from social engine when we update a status.
This is very relevant if we want to track this status. 
