### PR TITLE
new: provider::getUserStatus($id) retrieves status info

### DIFF
--- a/hybridauth/Hybrid/Provider_Model.php
+++ b/hybridauth/Hybrid/Provider_Model.php
@@ -172,11 +172,22 @@ abstract class Hybrid_Provider_Model
 	// --------------------------------------------------------------------
 
 	/**
-	* return the user activity stream  
+	* set user status
 	*/ 
 	function setUserStatus( $status )
 	{
 		Hybrid_Logger::error( "HybridAuth do not provide user's activity stream for {$this->providerId} yet." ); 
+		
+		throw new Exception( "Provider does not support this feature.", 8 ); 
+	}
+
+
+	/**
+	* return the user status
+	*/ 
+	function getUserStatus( $statusid )
+	{
+		Hybrid_Logger::error( "HybridAuth do not provide user's status for {$this->providerId} yet." ); 
 		
 		throw new Exception( "Provider does not support this feature.", 8 ); 
 	}

--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -277,6 +277,22 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model
  	}
 
 	/**
+	* get user status
+	*/
+    function getUserStatus( $postid )
+    {
+		try{
+            $postinfo = $this->api->api( "/" . $postid );
+        }
+		catch( FacebookApiException $e ){
+			throw new Exception( "Cannot retrieve user status! {$this->providerId} returned an error: $e" );
+		}
+
+        return $postinfo;
+    }
+
+
+	/**
 	* load the user latest activity  
 	*    - timeline : all the stream
 	*    - me       : the user activity only  

--- a/hybridauth/Hybrid/Providers/Twitter.php
+++ b/hybridauth/Hybrid/Providers/Twitter.php
@@ -206,6 +206,23 @@ class Hybrid_Providers_Twitter extends Hybrid_Provider_Model_OAuth1
         return $response;
     }
 
+
+	/**
+	* get user status
+	*/
+    function getUserStatus( $tweetid )
+    {
+        $info = $this->api->get( 'statuses/show.json?id=' . $tweetid . '&include_entities=true' );
+
+        // check the last HTTP status code returned
+        if ( $this->api->http_code != 200 || !isset( $info->id ) ){
+			throw new Exception( "Cannot retrieve user status! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ) );
+        }
+
+        return $info;
+    }
+
+
 	/**
 	* load the user latest activity  
 	*    - timeline : all the stream


### PR DESCRIPTION
Now, we can get information of a previous created facebook post or twitter tweet.
We only need to update status and store id:

``` php
$tweet = $hybridauth->authenticate( "Twitter" )->setUserStatus( ... );
```

then, just use this new feature:

``` php
$status = $hybridauth->authenticate( "Twitter" )->getUserStatus( $tweet[ 'id' ] );
```

best,
FA
