### PR TITLE
facebook::setUserStatus on a user's Page

### DIFF
--- a/hybridauth/Hybrid/Provider_Adapter.php
+++ b/hybridauth/Hybrid/Provider_Adapter.php
@@ -217,12 +217,16 @@ class Hybrid_Provider_Adapter
 			throw new Exception( "Call to undefined function Hybrid_Providers_{$this->id}::$name()." );
 		}
 
-		if( count( $arguments ) ){
-			return $this->adapter->$name( $arguments[0] ); 
-		} 
-		else{
-			return $this->adapter->$name(); 
-		}
+        $counter = count( $arguments );
+        if( $counter == 1 ){
+            return $this->adapter->$name( $arguments[0] ); 
+        }
+        elseif( $counter == 2 ){
+            return $this->adapter->$name( $arguments[0], $arguments[1] ); 
+        }
+        else{
+            return $this->adapter->$name(); 
+        }
 	}
 
 	// --------------------------------------------------------------------


### PR DESCRIPTION
Now we can update a user **page** (instead of user wall).
To retrieve all pages that belong to user just call:

``` php
$pages = $hybridauth->authenticate( "Facebook" )->getUserPages();
```

Each page object has an `id` that can be used by `setUserStatus()` to update content:

``` php
$hybridauth->authenticate( "Facebook" )->setUserStatus( 'message', $pages[ 0 ][ 'id' ] );
```

Note: user facebook scope must include `manage_pages` permission.

best,
FA
