### PR TITLE
Revert serializing and string casting in Storage::set().

### DIFF
--- a/hybridauth/Hybrid/Storage.php
+++ b/hybridauth/Hybrid/Storage.php
@@ -69,13 +69,8 @@ class Hybrid_Storage implements Hybrid_Storage_Interface
 	public function set( $key, $value )
 	{
 		$key = strtolower( $key );
-                
-                if(is_array($value))
-                {
-                    $value = implode($value);
-                }
 
-		$_SESSION["HA::STORE"][$key] = serialize( (string)$value );
+		$_SESSION["HA::STORE"][$key] = serialize( $value );
 	}
 	
 	/**


### PR DESCRIPTION
This should fix the problem stated [here](https://github.com/hybridauth/hybridauth/issues/200#issuecomment-50018813). The imploding of value breaking the OpenID provider and most likely others too as there's not corresponding exploding of values when they are read back from session. I am pretty sure all the other error reports for "Illegal string offset" are also as a result of this.

We'll need to come up with a better fix for the original "Serialization of 'Closure' is not allowed" error that these changes intended to solved.
