### PR TITLE
Global 'force' configuration option to always request login credentials.

### DIFF
--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -78,6 +78,13 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model
 			}
 		}
 
+        if( isset( $this->config[ 'force' ] ) && $this->config[ 'force' ] === true ){
+            $parameters[ 'auth_type' ]  = 'reauthenticate';
+            $parameters[ 'auth_nonce' ] = md5( uniqid( mt_rand(), true ) );
+
+            Hybrid_Auth::storage()->set( 'fb_auth_nonce', $parameters[ 'auth_nonce' ] );
+        }
+
 		// get the login url 
 		$url = $this->api->getLoginUrl( $parameters );
 

--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -54,6 +54,10 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 			}
 		}
 
+        if( isset( $this->config[ 'force' ] ) && $this->config[ 'force' ] === true ){
+            $parameters[ 'approval_prompt' ] = 'force';
+        }
+
 		Hybrid_Auth::redirect( $this->api->authorizeUrl( $parameters ) ); 
 	}
 

--- a/hybridauth/Hybrid/Providers/Twitter.php
+++ b/hybridauth/Hybrid/Providers/Twitter.php
@@ -69,7 +69,7 @@ class Hybrid_Providers_Twitter extends Hybrid_Provider_Model_OAuth1
  		$this->token( "request_token_secret", $tokens["oauth_token_secret"] );
  	
 		// redirect the user to the provider authentication url with force_login
- 		if ( isset( $this->config['force_login'] ) && $this->config['force_login'] ){
+ 		if ( ( isset( $this->config['force_login'] ) && $this->config['force_login'] ) || ( isset( $this->config[ 'force' ] ) && $this->config[ 'force' ] === true ) ){
  			Hybrid_Auth::redirect( $this->api->authorizeUrl( $tokens, array( 'force_login' => true ) ) );
  		}
 


### PR DESCRIPTION
This implements a common `force` configuration variable that is recognized by major providers in a simple and effective way, so that issue https://github.com/hybridauth/hybridauth/issues/287 can be easier and cleaner.

``` php
 'Facebook' => array (
     'enabled' => true,
     'keys'    => array ( 'id' => '65...', 'secret' => 'ae...' ),
     'scope'   => 'email, ...',
     'display' => 'popup',
     'force'   => true
 ),
 'Twitter' => array (
     'enabled' => true,
     'keys'    => array ( 'key' => 'IA...', 'secret' => 'V6...' ),
     'force'   => true
 ),
```

best,
FA
