### PR TITLE
Check for callers URL protocol incorrect

### DIFF
--- a/hybridauth/Hybrid/Provider_Adapter.php
+++ b/hybridauth/Hybrid/Provider_Adapter.php
@@ -130,7 +130,7 @@ class Hybrid_Provider_Adapter
 		if (empty(Hybrid_Auth::$config["base_url"])) {
 	        // the base url wasn't provide, so we must use the current
 	        // url (which makes sense actually)
-			$url  = empty($_SERVER['HTTPS']) ? 'http' : 'https';
+			$url  = empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] == 'off' ? 'http' : 'https';
 			$url .= '://' . $_SERVER['HTTP_HOST'];
 			$url .= $_SERVER['REQUEST_URI'];
 			$HYBRID_AUTH_URL_BASE = $url;


### PR DESCRIPTION
Check for callers URL protocol incorrectly misses that on some systems HTTP systems may return $_SERVER['HTTPS'] == 'off'
- IIS ISAPI
- NginX 'fastcgi_param HTTPS off;'
