### PR TITLE
Add check for OAuthException class exists

### DIFF
--- a/additional-providers/hybridauth-sina/thirdparty/Sina/saetv2.ex.class.php
+++ b/additional-providers/hybridauth-sina/thirdparty/Sina/saetv2.ex.class.php
@@ -8,8 +8,10 @@
 /**
  * @ignore
  */
-class OAuthException extends Exception {
-	// pass
+if (!class_exists('OAuthException')) {
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 

--- a/hybridauth/Hybrid/thirdparty/OAuth/OAuth.php
+++ b/hybridauth/Hybrid/thirdparty/OAuth/OAuth.php
@@ -6,8 +6,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if (!class_exists('OAuthException')) {
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
Fatal Conflicts with PHPs OAuth extension

This module has a namespace conflict with the official (according to Rasmus anyway) PHP OAuth implementation:

http://us.php.net/oauth

They both declare the same exception class.
