### PR TITLE
Removed code for non-default port

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -388,14 +388,6 @@ class Hybrid_Auth
 
 		$url = $protocol . $_SERVER['HTTP_HOST'];
 
-		// use port if non default
-		if( isset( $_SERVER['SERVER_PORT'] ) && strpos( $url, ':'.$_SERVER['SERVER_PORT'] ) === FALSE ) {
-			$url .= ($protocol === 'http://' && $_SERVER['SERVER_PORT'] != 80 && !isset( $_SERVER['HTTP_X_FORWARDED_PROTO']))
-				|| ($protocol === 'https://' && $_SERVER['SERVER_PORT'] != 443 && !isset( $_SERVER['HTTP_X_FORWARDED_PROTO']))
-				? ':' . $_SERVER['SERVER_PORT'] 
-				: '';
-		}
-
 		if( $request_uri ){
 			$url .= $_SERVER['REQUEST_URI'];
 		}


### PR DESCRIPTION
The preceding lines use $_SERVER['HTTP_HOST'] which will already include
the port if a non-default port is used.  See
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23
