### PR TITLE
Fix for supporting older PHP < 5.4

### DIFF
--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -248,8 +248,8 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model
 			// Prepare the next call if paging links have been returned
 			if (array_key_exists('paging', $response) && array_key_exists('next', $response['paging'])) {
 				$pagedList = true;
-        $next_page = explode('friends', $response['paging']['next']);
-        $apiCall = $next_page[1];
+			        $next_page = explode('friends', $response['paging']['next']);
+			        $apiCall = $next_page[1];
 			}
 			else{
 				$pagedList = false;


### PR DESCRIPTION
Because only PHP >5.4 support calling an array index directly after function it cause a fatal error.
- Please review if you can the next pull requests for such problems because it's can cause fatal errors in production for other users.
