### PR TITLE
fixed E_NOTICE: Undefined index: debug_mode in Logger class

### DIFF
--- a/hybridauth/Hybrid/Logger.php
+++ b/hybridauth/Hybrid/Logger.php
@@ -75,7 +75,7 @@ class Hybrid_Logger
 	 */
 	public static function error($message, $object = NULL)
 	{ 
-		if( in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info', 'error'), true) ){
+		if(isset(Hybrid_Auth::$config["debug_mode"]) && in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info', 'error'), true) ){
 			$datetime = new DateTime();
 			$datetime =  $datetime->format(DATE_ATOM);
 


### PR DESCRIPTION
Hello,
here is the fix for `E_NOTICE: Undefined index: debug_mode` issue. When somehow Storage config is empty this produces a lot of `Undefined index: debug_mode` errors in server logs which is annoying when you for example run some debug tool for catching errors in your software.

It should check first if `debug_mode` is set in `Hybrid_Auth::$config` array. If it doesn't exist it should ignore displaying this notice message as `Hybrid_Logger::error()` method is being invoked with proper message already saying: `Config storage not found when trying to init Hyrid_Auth`. Which means it should not read `Hybrid_Auth::$config["debug_mode"]` at all in this case.
