### PR TITLE
Resolving `Undefined property: stdClass::$email` error on GitHub auth

### DIFF
--- a/additional-providers/hybridauth-github/Providers/GitHub.php
+++ b/additional-providers/hybridauth-github/Providers/GitHub.php
@@ -47,12 +47,12 @@ class Hybrid_Providers_GitHub extends Hybrid_Provider_Model_OAuth2
 		$this->user->profile->webSiteURL  = @ $data->blog;
 		$this->user->profile->region      = @ $data->location;
 
-		if( ! $this->user->profile->displayName ){
+		if( empty($this->user->profile->displayName) ){
 			$this->user->profile->displayName = @ $data->login;
 		}
 
 		// request user emails from github api
-		if( ! $data->email ){
+		if( empty($data->email) ){
 			try{
 				$emails = $this->api->api("user/emails");
 


### PR DESCRIPTION
`if( ! $data->email )` throws a `Undefined property: stdClass::$email` error when the email property is not set for some reason; changing it to use PHP's `empty` method remedies this.

Resolves #310 
