### PR TITLE
fix the yahoo configuration

### DIFF
--- a/hybridauth/config.php
+++ b/hybridauth/config.php
@@ -21,7 +21,7 @@ return
 
 			"Yahoo" => array ( 
 				"enabled" => true,
-				"keys"    => array ( "id" => "", "secret" => "" ),
+				"keys"    => array ( "key" => "", "secret" => "" ),
 			),
 
 			"AOL"  => array ( 


### PR DESCRIPTION
yahoo provider extends ouath1 provider and ouath1 provider uses the index key not the index id.
see the following links for more info.
https://github.com/hybridauth/hybridauth/blob/master/hybridauth/Hybrid/Providers/Yahoo.php#L20
https://github.com/hybridauth/hybridauth/blob/master/hybridauth/Hybrid/Provider_Model_OAuth1.php#L67
