### PR TITLE
Invalid Credentials error when logging in with Google after the initial token expires.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "noisyscanner/hybridauth",
+    "name": "hybridauth/hybridauth",
     "description": "Open source social sign on PHP library.",
     "keywords": ["hybridauth", "login", "oauth", "social", "openid", "facebook", "google", "twitter", "yahoo"],
     "homepage": "http://hybridauth.sourceforge.net",


### PR DESCRIPTION
This patch fixes a bug where logging in with Google after the first token has expired would result in an "Invalid Credentials" error in Hybridauth 3.0.0dev.
