### PR TITLE
GitHub identifier changed to account login

### DIFF
--- a/additional-providers/hybridauth-github/Providers/GitHub.php
+++ b/additional-providers/hybridauth-github/Providers/GitHub.php
@@ -38,7 +38,7 @@ class Hybrid_Providers_GitHub extends Hybrid_Provider_Model_OAuth2
 			throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
 		}
 
-		$this->user->profile->identifier  = @ $data->id; 
+		$this->user->profile->identifier  = @ $data->login; 
 		$this->user->profile->displayName = @ $data->name;
 		$this->user->profile->description = @ $data->bio;
 		$this->user->profile->photoURL    = @ $data->avatar_url;


### PR DESCRIPTION
The user identifier `id` field cannot be used for anything,
except asking the GitHub support team to convert them into logins for you.

See: http://stackoverflow.com/a/11984400/508831

This is a breaking change (well, rather a fixing change),
the identifier is now a string instead of an integer.
