### PR TITLE
Fix: Return primary email address, not the first

### DIFF
--- a/additional-providers/hybridauth-github/Providers/GitHub.php
+++ b/additional-providers/hybridauth-github/Providers/GitHub.php
@@ -57,9 +57,17 @@ class Hybrid_Providers_GitHub extends Hybrid_Provider_Model_OAuth2
 				$emails = $this->api->api("user/emails");
 
 				// fail gracefully, and let apps collect the email if not present
-				if (is_array($emails) && !empty($emails[0]->email))
-				{
-				    $this->user->profile->email = $emails[0]->email;
+				if (is_array($emails)) {
+					foreach ($emails as $email) {
+						if ($email instanceof stdClass
+							&& property_exists('primary', $email)
+							&& true === $email->primary
+							&& property_exists('email', $email)
+						) {
+							$this->user->profile->email = $email->email;
+							break;
+						}
+					}
 				}
 			}
 			catch( GithubApiException $e ){


### PR DESCRIPTION
When a user has multiple email addresses, the first doesn't necessarily have to be the primary email address.

``` json
[
    {
        "email": "john@example.org",
        "verified": true,
        "primary": false
    },
    {
        "email": "john.doe@example.com",
        "verified": true,
        "primary": true
    }
]
```

This PR fixes `Hybrid_Providers_GitHub::getUserProfile()` by iterating over the array of email addresses to find the one that is the primary email address.
