### PR TITLE
send authentication header

### DIFF
--- a/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+++ b/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
@@ -208,7 +208,9 @@ class OAuth2Client
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT , $this->curl_connect_time_out );
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER , $this->curl_ssl_verifypeer );
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST , $this->curl_ssl_verifyhost );
-		curl_setopt($ch, CURLOPT_HTTPHEADER     , $this->curl_header );
+
+		$header = array_merge($this->curl_header, ['Authorization: OAuth ' . $this->access_token]);		
+		curl_setopt($ch, CURLOPT_HTTPHEADER     , $header);
 
 		if($this->curl_proxy){
 			curl_setopt( $ch, CURLOPT_PROXY        , $this->curl_proxy);


### PR DESCRIPTION
as mentioned in https://github.com/hybridauth/hybridauth/issues/389 I'm having problems calling any Google API method using the POST method.

It's still not working, but I believe I'm past the authentication by adding a authentication header.