### PR TITLE
add access token to header in google provider

### DIFF
--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -29,6 +29,9 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 		$this->api->authorize_url  = "https://accounts.google.com/o/oauth2/auth";
 		$this->api->token_url      = "https://accounts.google.com/o/oauth2/token";
 		$this->api->token_info_url = "https://www.googleapis.com/oauth2/v2/tokeninfo";
+		
+		// Google POST methods require an access_token in the header
+		$this->api->curl_header = array("Authentication: OAuth " . $this->access_token);
         
 		// Override the redirect uri when it's set in the config parameters. This way we prevent
 		// redirect uri mismatches when authenticating with Google.


### PR DESCRIPTION
* Replaces #390 
* This should make it possible to call google POST methods
* We still have to undo this change https://github.com/hybridauth/hybridauth/issues/296 as explained here https://github.com/hybridauth/hybridauth/issues/389#issuecomment-72837755