### PR TITLE
Make Hybrid_Endpoint methods non-static

### DIFF
--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -11,15 +11,15 @@
  * Hybrid_Endpoint class provides a simple way to handle the OpenID and OAuth endpoint.
  */
 class Hybrid_Endpoint {
-	public $request = NULL;
-	public $initDone = FALSE;
+	protected $request = NULL;
+	protected $initDone = FALSE;
 
 	/**
 	 * Process the current request
 	 *
 	 * $request - The current request parameters. Leave as NULL to default to use $_REQUEST.
 	 */
-	function __construct ( $request = NULL )
+	public function __construct( $request = NULL )
 	{
 		if ( is_null($request) ){
 			// Fix a strange behavior when some provider call back ha endpoint
@@ -72,7 +72,7 @@ class Hybrid_Endpoint {
 	/**
 	* Process OpenID policy request
 	*/
-	public function processOpenidPolicy()
+	protected function processOpenidPolicy()
 	{
 		$output = file_get_contents( dirname(__FILE__) . "/resources/openid_policy.html" );
 		print $output;
@@ -82,7 +82,7 @@ class Hybrid_Endpoint {
 	/**
 	* Process OpenID XRDS request
 	*/
-	public function processOpenidXRDS()
+	protected function processOpenidXRDS()
 	{
 		header("Content-Type: application/xrds+xml");
 
@@ -102,7 +102,7 @@ class Hybrid_Endpoint {
 	/**
 	* Process OpenID realm request
 	*/
-	public function processOpenidRealm()
+	protected function processOpenidRealm()
 	{
 		$output = str_replace
 		(
@@ -117,7 +117,7 @@ class Hybrid_Endpoint {
 	/**
 	* define:endpoint step 3.
 	*/
-	public function processAuthStart()
+	protected function processAuthStart()
 	{
 		$this->authInit();
 
@@ -158,7 +158,7 @@ class Hybrid_Endpoint {
 	/**
 	* define:endpoint step 3.1 and 3.2
 	*/
-	public function processAuthDone()
+	protected function processAuthDone()
 	{
 		$this->authInit();
 
@@ -192,7 +192,7 @@ class Hybrid_Endpoint {
 		die();
 	}
 
-	public function authInit()
+	protected function authInit()
 	{
 		if ( ! $this->initDone) {
 			$this->initDone = TRUE;

--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -66,7 +66,9 @@ class Hybrid_Endpoint {
 	 */
 	public static function process( $request = NULL )
 	{
-		new static( $request );
+		// Trick for PHP 5.2, because it doesn't support late static binding
+		$class = function_exists('get_called_class') ? get_called_class() : __CLASS__;
+		new $class( $request );
 	}
 
 	/**

--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -8,7 +8,7 @@
 /**
  * Hybrid_Endpoint class
  *
- * Hybrid_Endpoint class provides a simple way to handle the OpenID and OAuth endpoint.
+ * Provides a simple way to handle the OpenID and OAuth endpoint
  */
 class Hybrid_Endpoint {
 	protected $request = NULL;
@@ -17,7 +17,7 @@ class Hybrid_Endpoint {
 	/**
 	 * Process the current request
 	 *
-	 * $request - The current request parameters. Leave as NULL to default to use $_REQUEST.
+	 * @param array $request The current request parameters. Leave as NULL to default to use $_REQUEST.
 	 */
 	public function __construct( $request = NULL )
 	{
@@ -60,18 +60,18 @@ class Hybrid_Endpoint {
 		}
 	}
 	/**
-	* Process the current request
-	*
-	* $request - The current request parameters. Leave as NULL to default to use $_REQUEST.
-	*/
+	 * Process the current request
+	 *
+	 * @param array $request The current request parameters. Leave as NULL to default to use $_REQUEST.
+	 */
 	public static function process( $request = NULL )
 	{
 		new static( $request );
 	}
 
 	/**
-	* Process OpenID policy request
-	*/
+	 * Process OpenID policy request
+	 */
 	protected function processOpenidPolicy()
 	{
 		$output = file_get_contents( dirname(__FILE__) . "/resources/openid_policy.html" );
@@ -80,8 +80,8 @@ class Hybrid_Endpoint {
 	}
 
 	/**
-	* Process OpenID XRDS request
-	*/
+	 * Process OpenID XRDS request
+	 */
 	protected function processOpenidXRDS()
 	{
 		header("Content-Type: application/xrds+xml");
@@ -100,8 +100,8 @@ class Hybrid_Endpoint {
 	}
 
 	/**
-	* Process OpenID realm request
-	*/
+	 * Process OpenID realm request
+	 */
 	protected function processOpenidRealm()
 	{
 		$output = str_replace
@@ -115,25 +115,25 @@ class Hybrid_Endpoint {
 	}
 
 	/**
-	* define:endpoint step 3.
-	*/
+	 * define:endpoint step 3.
+	 */
 	protected function processAuthStart()
 	{
 		$this->authInit();
 
 		$provider_id = trim( strip_tags( $this->request["hauth_start"] ) );
 
-		# check if page accessed directly
+		// check if page accessed directly
 		if( ! Hybrid_Auth::storage()->get( "hauth_session.$provider_id.hauth_endpoint" ) ) {
 			Hybrid_Logger::error( "Endpoint: hauth_endpoint parameter is not defined on hauth_start, halt login process!" );
 
 			throw new Hybrid_Exception( "You cannot access this page directly." );
 		}
 
-		# define:hybrid.endpoint.php step 2.
+		// define:hybrid.endpoint.php step 2.
 		$hauth = Hybrid_Auth::setup( $provider_id );
 
-		# if REQUESTed hauth_idprovider is wrong, session not created, etc.
+		// if REQUESTed hauth_idprovider is wrong, session not created, etc.
 		if( ! $hauth ) {
 			Hybrid_Logger::error( "Endpoint: Invalid parameter on hauth_start!" );
 
@@ -156,8 +156,8 @@ class Hybrid_Endpoint {
 	}
 
 	/**
-	* define:endpoint step 3.1 and 3.2
-	*/
+	 * define:endpoint step 3.1 and 3.2
+	 */
 	protected function processAuthDone()
 	{
 		$this->authInit();
@@ -197,7 +197,7 @@ class Hybrid_Endpoint {
 		if ( ! $this->initDone) {
 			$this->initDone = TRUE;
 
-			# Init Hybrid_Auth
+			// Init Hybrid_Auth
 			try {
                 if(!class_exists("Hybrid_Storage")){
                     require_once realpath( dirname( __FILE__ ) )  . "/Storage.php";

--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -2,7 +2,7 @@
 /**
 * HybridAuth
 * http://hybridauth.sourceforge.net | http://github.com/hybridauth/hybridauth
-* (c) 2009-2014, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html
+* (c) 2009-2015, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html
 */
 
 /**
@@ -11,20 +11,17 @@
  * Hybrid_Endpoint class provides a simple way to handle the OpenID and OAuth endpoint.
  */
 class Hybrid_Endpoint {
-	public static $request = NULL;
-	public static $initDone = FALSE;
+	public $request = NULL;
+	public $initDone = FALSE;
 
 	/**
-	* Process the current request
-	*
-	* $request - The current request parameters. Leave as NULL to default to use $_REQUEST.
-	*/
-	public static function process( $request = NULL )
+	 * Process the current request
+	 *
+	 * $request - The current request parameters. Leave as NULL to default to use $_REQUEST.
+	 */
+	function __construct ( $request = NULL )
 	{
-		// Setup request variable
-		Hybrid_Endpoint::$request = $request;
-
-		if ( is_null(Hybrid_Endpoint::$request) ){
+		if ( is_null($request) ){
 			// Fix a strange behavior when some provider call back ha endpoint
 			// with /index.php?hauth.done={provider}?{args}...
 			// >here we need to parse $_SERVER[QUERY_STRING]
@@ -34,38 +31,48 @@ class Hybrid_Endpoint {
 
 				parse_str( $_SERVER["QUERY_STRING"], $request );
 			}
-
-			Hybrid_Endpoint::$request = $request;
 		}
 
+		// Setup request variable
+		$this->request = $request;
+
 		// If openid_policy requested, we return our policy document
-		if ( isset( Hybrid_Endpoint::$request["get"] ) && Hybrid_Endpoint::$request["get"] == "openid_policy" ) {
-			Hybrid_Endpoint::processOpenidPolicy();
+		if ( isset( $this->request["get"] ) && $this->request["get"] == "openid_policy" ) {
+			$this->processOpenidPolicy();
 		}
 
 		// If openid_xrds requested, we return our XRDS document
-		if ( isset( Hybrid_Endpoint::$request["get"] ) && Hybrid_Endpoint::$request["get"] == "openid_xrds" ) {
-			Hybrid_Endpoint::processOpenidXRDS();
+		if ( isset( $this->request["get"] ) && $this->request["get"] == "openid_xrds" ) {
+			$this->processOpenidXRDS();
 		}
 
 		// If we get a hauth.start
-		if ( isset( Hybrid_Endpoint::$request["hauth_start"] ) && Hybrid_Endpoint::$request["hauth_start"] ) {
-			Hybrid_Endpoint::processAuthStart();
+		if ( isset( $this->request["hauth_start"] ) && $this->request["hauth_start"] ) {
+			$this->processAuthStart();
 		}
 		// Else if hauth.done
-		elseif ( isset( Hybrid_Endpoint::$request["hauth_done"] ) && Hybrid_Endpoint::$request["hauth_done"] ) {
-			Hybrid_Endpoint::processAuthDone();
+		elseif ( isset( $this->request["hauth_done"] ) && $this->request["hauth_done"] ) {
+			$this->processAuthDone();
 		}
 		// Else we advertise our XRDS document, something supposed to be done from the Realm URL page
 		else {
-			Hybrid_Endpoint::processOpenidRealm();
+			$this->processOpenidRealm();
 		}
+	}
+	/**
+	* Process the current request
+	*
+	* $request - The current request parameters. Leave as NULL to default to use $_REQUEST.
+	*/
+	public static function process( $request = NULL )
+	{
+		new static( $request );
 	}
 
 	/**
 	* Process OpenID policy request
 	*/
-	public static function processOpenidPolicy()
+	public function processOpenidPolicy()
 	{
 		$output = file_get_contents( dirname(__FILE__) . "/resources/openid_policy.html" );
 		print $output;
@@ -75,7 +82,7 @@ class Hybrid_Endpoint {
 	/**
 	* Process OpenID XRDS request
 	*/
-	public static function processOpenidXRDS()
+	public function processOpenidXRDS()
 	{
 		header("Content-Type: application/xrds+xml");
 
@@ -95,7 +102,7 @@ class Hybrid_Endpoint {
 	/**
 	* Process OpenID realm request
 	*/
-	public static function processOpenidRealm()
+	public function processOpenidRealm()
 	{
 		$output = str_replace
 		(
@@ -110,11 +117,11 @@ class Hybrid_Endpoint {
 	/**
 	* define:endpoint step 3.
 	*/
-	public static function processAuthStart()
+	public function processAuthStart()
 	{
-		Hybrid_Endpoint::authInit();
+		$this->authInit();
 
-		$provider_id = trim( strip_tags( Hybrid_Endpoint::$request["hauth_start"] ) );
+		$provider_id = trim( strip_tags( $this->request["hauth_start"] ) );
 
 		# check if page accessed directly
 		if( ! Hybrid_Auth::storage()->get( "hauth_session.$provider_id.hauth_endpoint" ) ) {
@@ -151,11 +158,11 @@ class Hybrid_Endpoint {
 	/**
 	* define:endpoint step 3.1 and 3.2
 	*/
-	public static function processAuthDone()
+	public function processAuthDone()
 	{
-		Hybrid_Endpoint::authInit();
+		$this->authInit();
 
-		$provider_id = trim( strip_tags( Hybrid_Endpoint::$request["hauth_done"] ) );
+		$provider_id = trim( strip_tags( $this->request["hauth_done"] ) );
 
 		$hauth = Hybrid_Auth::setup( $provider_id );
 
@@ -185,10 +192,10 @@ class Hybrid_Endpoint {
 		die();
 	}
 
-	public static function authInit()
+	public function authInit()
 	{
-		if ( ! Hybrid_Endpoint::$initDone) {
-			Hybrid_Endpoint::$initDone = TRUE;
+		if ( ! $this->initDone) {
+			$this->initDone = TRUE;
 
 			# Init Hybrid_Auth
 			try {

--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -7,7 +7,7 @@
 
 /**
  * Hybrid_Endpoint class
- * 
+ *
  * Hybrid_Endpoint class provides a simple way to handle the OpenID and OAuth endpoint.
  */
 class Hybrid_Endpoint {
@@ -26,7 +26,7 @@ class Hybrid_Endpoint {
 
 		if ( is_null(Hybrid_Endpoint::$request) ){
 			// Fix a strange behavior when some provider call back ha endpoint
-			// with /index.php?hauth.done={provider}?{args}... 
+			// with /index.php?hauth.done={provider}?{args}...
 			// >here we need to parse $_SERVER[QUERY_STRING]
 			$request = $_REQUEST;
 			if ( strrpos( $_SERVER["QUERY_STRING"], '?' ) ) {
@@ -67,7 +67,7 @@ class Hybrid_Endpoint {
 	*/
 	public static function processOpenidPolicy()
 	{
-		$output = file_get_contents( dirname(__FILE__) . "/resources/openid_policy.html" ); 
+		$output = file_get_contents( dirname(__FILE__) . "/resources/openid_policy.html" );
 		print $output;
 		die();
 	}
@@ -83,7 +83,7 @@ class Hybrid_Endpoint {
 		(
 			"{RETURN_TO_URL}",
 			str_replace(
-				array("<", ">", "\"", "'", "&"), array("&lt;", "&gt;", "&quot;", "&apos;", "&amp;"), 
+				array("<", ">", "\"", "'", "&"), array("&lt;", "&gt;", "&quot;", "&apos;", "&amp;"),
 				Hybrid_Auth::getCurrentUrl( false )
 			),
 			file_get_contents( dirname(__FILE__) . "/resources/openid_xrds.xml" )
@@ -102,7 +102,7 @@ class Hybrid_Endpoint {
 			"{X_XRDS_LOCATION}",
 			htmlentities( Hybrid_Auth::getCurrentUrl( false ), ENT_QUOTES, 'UTF-8' ) . "?get=openid_xrds&v=" . Hybrid_Auth::$version,
 			file_get_contents( dirname(__FILE__) . "/resources/openid_realm.html" )
-		); 
+		);
 		print $output;
 		die();
 	}
@@ -126,7 +126,7 @@ class Hybrid_Endpoint {
 		# define:hybrid.endpoint.php step 2.
 		$hauth = Hybrid_Auth::setup( $provider_id );
 
-		# if REQUESTed hauth_idprovider is wrong, session not created, etc. 
+		# if REQUESTed hauth_idprovider is wrong, session not created, etc.
 		if( ! $hauth ) {
 			Hybrid_Logger::error( "Endpoint: Invalid parameter on hauth_start!" );
 
@@ -160,7 +160,7 @@ class Hybrid_Endpoint {
 		$hauth = Hybrid_Auth::setup( $provider_id );
 
 		if( ! $hauth ) {
-			Hybrid_Logger::error( "Endpoint: Invalid parameter on hauth_done!" ); 
+			Hybrid_Logger::error( "Endpoint: Invalid parameter on hauth_done!" );
 
 			$hauth->adapter->setUserUnconnected();
 
@@ -170,13 +170,13 @@ class Hybrid_Endpoint {
 		try {
 			Hybrid_Logger::info( "Endpoint: call adapter [{$provider_id}] loginFinish() " );
 
-			$hauth->adapter->loginFinish(); 
+			$hauth->adapter->loginFinish();
 		}
 		catch( Exception $e ){
 			Hybrid_Logger::error( "Exception:" . $e->getMessage(), $e );
 			Hybrid_Error::setError( $e->getMessage(), $e->getCode(), $e->getTraceAsString(), $e->getPrevious());
 
-			$hauth->adapter->setUserUnconnected(); 
+			$hauth->adapter->setUserUnconnected();
 		}
 
 		Hybrid_Logger::info( "Endpoint: job done. retrun to callback url." );
@@ -195,8 +195,8 @@ class Hybrid_Endpoint {
                 if(!class_exists("Hybrid_Storage")){
                     require_once realpath( dirname( __FILE__ ) )  . "/Storage.php";
                 }
-				
-				$storage = new Hybrid_Storage(); 
+
+				$storage = new Hybrid_Storage();
 
 				// Check if Hybrid_Auth session already exist
 				if ( ! $storage->config( "CONFIG" ) ) {
@@ -204,10 +204,10 @@ class Hybrid_Endpoint {
 					throw new Hybrid_Exception( "You cannot access this page directly." );
 				}
 
-				Hybrid_Auth::initialize( $storage->config( "CONFIG" ) ); 
+				Hybrid_Auth::initialize( $storage->config( "CONFIG" ) );
 			}
 			catch ( Exception $e ){
-				Hybrid_Logger::error( "Endpoint: Error while trying to init Hybrid_Auth: " . $e->getMessage()); 
+				Hybrid_Logger::error( "Endpoint: Error while trying to init Hybrid_Auth: " . $e->getMessage());
 
 				throw new Hybrid_Exception( "Oophs. Error!" );
 			}


### PR DESCRIPTION
Changed static methods to dynamic, also constructor added.
`::process` method left for backward-compatibility and calls constructor.

Should not break any existing code using this according to documentation.
Also big question whether we need all that methods and properties to be public?