### PR TITLE
Set LinkedIn API request timeout to 5 seconds because the API can be slow.

### DIFF
--- a/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
+++ b/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
@@ -673,6 +673,10 @@ class LinkedIn {
       curl_setopt($handle, CURLOPT_URL, $url);
       curl_setopt($handle, CURLOPT_VERBOSE, FALSE);
 
+      // Restrict the request timeout to 5 seconds. Linkedin is sometimes very
+      // slow and we don't want to trigger a PHP timeout on our end.
+      curl_setopt($handle, CURLOPT_TIMEOUT, 5);
+
       if ( isset ( Hybrid_Auth::$config["proxy"] ) ) {
       	curl_setopt($handle, CURLOPT_PROXY, Hybrid_Auth::$config["proxy"]);
       }


### PR DESCRIPTION
Problem: sometimes LinkedIn API requests take forever, so the PHP process is blocked waiting for a response. But we don't want to run into timeouts on our end, so we can simply restrict the timeout and HybridAuth will deal with potential errors appropriately :-)