### PR TITLE
Fixed an issue with email property for vkontakte

### DIFF
--- a/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
+++ b/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
@@ -61,7 +61,7 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 
 		// store user id. it is required for api access to Vkontakte
 		Hybrid_Auth::storage()->set( "hauth_session.{$this->providerId}.user_id", $response->user_id );
-		Hybrid_Auth::storage()->set( "hauth_session.{$this->providerId}.user_email", $response->user_email );
+		Hybrid_Auth::storage()->set( "hauth_session.{$this->providerId}.user_email", $response->email );
 
 		// set user connected locally
 		$this->setUserConnected();


### PR DESCRIPTION
Here's the request object:

```
"PHP message: stdClass Object
(
    [access_token] => 80...
    [expires_in] => 86400
    [user_id] => 1
    [email] => me@example.com
)"
```

So there's no ```user_email```...