### PR TITLE
Adding emailVerified for Google email type 'account'

### DIFF
--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -109,6 +109,16 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2
 					}
 				}
 			}
+            if (count($verified->emails) == 1) {
+                $this->user->profile->emailVerified = $verified->emails[0]->value;
+            } else {
+                foreach ($verified->emails as $email) {
+                    if ($email->type == 'account') {
+                        $this->user->profile->emailVerified = $email->value;
+                        break;
+                    }
+                }
+            }
 		}
 		$this->user->profile->phone 		= (property_exists($response,'phone'))?$response->phone:"";
 		$this->user->profile->country 		= (property_exists($response,'country'))?$response->country:"";


### PR DESCRIPTION
This seemed to be a missing logic. I needed it for https://www.drupal.org/project/hybridauth project to have several identities and merge Google account with existing account on Drupal by verified email