### PR TITLE
Fix for serious OAuth2 bug in 2.4.0 release!

### DIFF
--- a/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+++ b/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
@@ -144,7 +144,7 @@ class OAuth2Client
 			$this->response = json_decode( $response );
 		}
 
-		return $this->response = $response;
+		return $this->response;
 	}
 
 	/**


### PR DESCRIPTION
Fix for serious bug introduced in https://github.com/hybridauth/hybridauth/commit/bf9fb5efb9ac770ded293f799ca4063fb8369df4#diff-9b114ab1ce86b49dbe086cbf8ace8391R147.

Decoded JSON data before return were replaced back by encoded, in particular, Vkontakte failed to work because of this (Facebook worked anyway though).