### PR TITLE
Missing OpenID use statement

### DIFF
--- a/src/Adapter/OpenID.php
+++ b/src/Adapter/OpenID.php
@@ -11,6 +11,7 @@ use Hybridauth\Exception;
 use Hybridauth\Exception\InvalidOpenidIdentifierException;
 use Hybridauth\Exception\AuthorizationDeniedException;
 use Hybridauth\Exception\InvalidOpenidResponseException;
+use Hybridauth\Exception\UnexpectedValueException;
 use Hybridauth\Data;
 use Hybridauth\HttpClient;
 use Hybridauth\User;


### PR DESCRIPTION
Fixes missing use statement for an exception called in the OpenID adapter.