### PR TITLE
Less restrictive phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-curl": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "~4.1",
         "mockery/mockery": "0.9.2",
         "fabpot/php-cs-fixer": "~1.6"
     },


### PR DESCRIPTION
Just a composer requirements improve to allow getting latest PHPUnit 4 versions.

Note: `4.6` is the latest version.