### PR TITLE
Apply CS fixer for PSR-2

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -17,7 +17,6 @@ use Hybridauth\Logger\Logger;
 use Hybridauth\HttpClient\HttpClientInterface;
 use Hybridauth\HttpClient\Curl as HttpClient;
 use Hybridauth\Data;
-
 use Hybridauth\Deprecated\DeprecatedAdapterTrait;
 
 /**

--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -14,7 +14,6 @@ use Hybridauth\Exception\InvalidOauthTokenException;
 use Hybridauth\Exception\InvalidAccessTokenException;
 use Hybridauth\Data;
 use Hybridauth\HttpClient;
-
 use Hybridauth\Thirdparty\OAuth\OAuthConsumer;
 use Hybridauth\Thirdparty\OAuth\OAuthRequest;
 use Hybridauth\Thirdparty\OAuth\OAuthSignatureMethodHMACSHA1;

--- a/src/Adapter/OpenID.php
+++ b/src/Adapter/OpenID.php
@@ -15,7 +15,6 @@ use Hybridauth\Exception\UnexpectedValueException;
 use Hybridauth\Data;
 use Hybridauth\HttpClient;
 use Hybridauth\User;
-
 use Hybridauth\Thirdparty\OpenID\LightOpenID;
 
 /**

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -17,7 +17,6 @@ use Hybridauth\Logger\Logger;
 use Hybridauth\HttpClient\HttpClientInterface;
 use Hybridauth\HttpClient\Curl as HttpClient;
 use Hybridauth\Provider\ProviderAdapter;
-
 use Hybridauth\Deprecated\DeprecatedHybridauthTrait;
 
 /**

--- a/src/Thirdparty/OAuth/OAuthRequest.php
+++ b/src/Thirdparty/OAuth/OAuthRequest.php
@@ -13,7 +13,7 @@ class OAuthRequest
     public $http_method;
     public $http_url;
     // for debug purposes
-    public        $base_string;
+    public $base_string;
     public static $version    = '1.0';
     public static $POST_INPUT = 'php://input';
 

--- a/src/Thirdparty/OpenID/LightOpenID.php
+++ b/src/Thirdparty/OpenID/LightOpenID.php
@@ -31,8 +31,8 @@ class LightOpenID
     , $cainfo = null
     , $data
     ,                $oauth                                                      = [];
-    private          $identity, $claimed_id;
-    protected        $server, $version, $trustRoot, $aliases, $identifier_select = false
+    private $identity, $claimed_id;
+    protected $server, $version, $trustRoot, $aliases, $identifier_select = false
     ,                $ax                                                         = false, $sreg = false, $setup_url = null, $headers = [], $proxy = null
     ,                $xrds_override_pattern                                      = null, $xrds_override_replacement = null;
     protected static $ax_to_sreg                                                 = [


### PR DESCRIPTION
Related to https://github.com/hybridauth/hybridauth/pull/464#issuecomment-98987814.

This is what php-cs-fixer did:

```bash
~/projects/fork/hybridauth(3.0.0-Remake)$ php vendor/bin/php-cs-fixer fix --verbose --level=psr2 .
F.F..................................................F.................FF.F............
Legend: ?-unknown, I-invalid file syntax, file ignored, .-no changes, F-fixed, E-error
   1) src/Thirdparty/OpenID/LightOpenID.php (visibility)
   2) src/Thirdparty/OAuth/OAuthRequest.php (visibility)
   3) src/Hybridauth.php (single_line_after_imports)
   4) src/Adapter/AbstractAdapter.php (single_line_after_imports)
   5) src/Adapter/OAuth1.php (single_line_after_imports)
   6) src/Adapter/OpenID.php (single_line_after_imports)
Fixed all files in 18.646 seconds, 12.000 MB memory used
```