### PR TITLE
Ensure session is saved before sending response

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -350,6 +350,11 @@ class Hybrid_Auth
 	{
 		Hybrid_Logger::info( "Enter Hybrid_Auth::redirect( $url, $mode )" );
 
+		// Ensure session is saved before sending response, see https://github.com/symfony/symfony/pull/12341
+		if ((PHP_VERSION_ID >= 50400 && PHP_SESSION_ACTIVE === session_status()) || (PHP_VERSION_ID < 50400 && isset($_SESSION) && session_id())) {
+			session_write_close();
+		}
+
 		if( $mode == "PHP" ){
 			header( "Location: $url" ) ;
 		}


### PR DESCRIPTION
Sometimes session was not saved before doing a fast redirect (we use nginx/php5-fpm), should fix this issue #340 also.