### PR TITLE
Simplification of `HybridAuth\HttpClient\Util::getCurrentUrl()`

### DIFF
--- a/src/HttpClient/Util.php
+++ b/src/HttpClient/Util.php
@@ -12,10 +12,10 @@ use Hybridauth\Data;
 class Util
 {
     /**
-    * Redirect to a given URL
-    *
-    * @param string $url
-    */
+     * Redirect to a given URL
+     *
+     * @param string $url
+     */
     public static function redirect($url)
     {
         header("Location: $url");
@@ -23,35 +23,31 @@ class Util
         exit(1);
     }
 
-    // --------------------------------------------------------------------
-
     /**
-    * Returns the Current URL
-    *
-    * @param boolean $requestUri TRUE to get $_SERVER['REQUEST_URI'], FALSE for $_SERVER['PHP_SELF']
-    *
-    * @return string
-    */
+     * Returns the Current URL
+     *
+     * @param boolean $requestUri TRUE to use $_SERVER['REQUEST_URI'], FALSE for $_SERVER['PHP_SELF']
+     *
+     * @return string
+     */
     public static function getCurrentUrl($requestUri = false)
     {
         $collection = new Data\Collection($_SERVER);
-        
+
         $protocol = 'http://';
 
-        if ($collection->exists('HTTPS')
-            &&  ($collection->get('HTTPS') == 'on' || $collection->get('HTTPS') == 1)
-            ||  $collection->exists('HTTP_X_FORWARDED_PROTO')
-            &&  $collection->get('HTTP_X_FORWARDED_PROTO') == 'https'
+        if (
+            (
+                $collection->exists('HTTPS') && $collection->get('HTTPS') !== 'off'
+            ) || (
+                $collection->exists('HTTP_X_FORWARDED_PROTO') && $collection->get('HTTP_X_FORWARDED_PROTO') === 'https'
+            )
         ) {
             $protocol = 'https://';
         }
 
-        $basUrl = $protocol . $collection->get('HTTP_HOST');
-
-        if ($requestUri) {
-            return $basUrl . $collection->get('REQUEST_URI');
-        }
-
-        return $basUrl . $collection->get('PHP_SELF');
+        return $protocol.
+               $collection->get('HTTP_HOST').
+               $collection->get($requestUri ? 'REQUEST_URI' : 'PHP_SELF');
     }
 }


### PR DESCRIPTION
According to [PHP documentation](https://php.net/manual/en/reserved.variables.server.php):

> 'HTTPS'
> Set to a non-empty value if the script was queried through the HTTPS protocol.
> Note: Note that when using ISAPI with IIS, the value will be off if the request was not made through the HTTPS protocol.

That is why we just need to check whether `$_SERVER['HTTPS'] ` exists and is not `off`.
Also equality changed to strict one.