### PR TITLE
PSR3 logger

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -1,4 +1,5 @@
 <?php
+
 /*!
 * Hybridauth
 * https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
@@ -27,62 +28,62 @@ abstract class AbstractAdapter implements AdapterInterface
     use DeprecatedAdapterTrait;
 
     /**
-    * Provider ID (unique name)
-    *
-    * @var string
-    */
+     * Provider ID (unique name).
+     *
+     * @var string
+     */
     protected $providerId = '';
 
     /**
-    * Specific Provider config
-    *
-    * @var mixed
-    */
+     * Specific Provider config.
+     *
+     * @var mixed
+     */
     protected $config = [];
 
     /**
-    * Extra Provider parameters
-    *
-    * @var mixed
-    */
-    protected $params = [];
+     * Extra Provider parameters.
+     *
+     * @var array
+     */
+    protected $params;
 
     /**
-    * Redirection Endpoint (i.e., redirect_uri, callback_url)
-    *
-    * @var string
-    */
+     * Redirection Endpoint (i.e., redirect_uri, callback_url).
+     *
+     * @var string
+     */
     protected $endpoint = '';
 
     /**
-    * Storage
-    *
-    * @var object
-    */
-    public $storage = null;
+     * Storage.
+     *
+     * @var StorageInterface
+     */
+    public $storage;
 
     /**
-    * HttpClient
-    *
-    * @var object
-    */
-    public $httpClient = null;
+     * HttpClient.
+     *
+     * @var HttpClientInterface
+     */
+    public $httpClient;
 
     /**
-    * Logger
-    *
-    * @var object
-    */
-    public $logger = null;
+     * Logger.
+     *
+     * @var LoggerInterface
+     */
+    public $logger;
 
     /**
-    * Common adapters constructor
-    *
-    * @param array               $config
-    * @param HttpClientInterface $httpClient
-    * @param StorageInterface    $storage
-    * @param LoggerInterface     $logger
-    */
+     * Common adapters constructor.
+     *
+     * @param array               $config
+     * @param HttpClientInterface $httpClient
+     * @param StorageInterface    $storage
+     * @param LoggerInterface     $logger
+     */
     public function __construct(
         $config = [],
         HttpClientInterface $httpClient = null,
@@ -91,14 +92,14 @@ abstract class AbstractAdapter implements AdapterInterface
     ) {
         $this->providerId = str_replace('Hybridauth\\Provider\\', '', get_class($this));
 
-        $this->storage = $storage ? $storage : new Session();
+        $this->storage = $storage ?: new Session();
 
-        $this->logger = $logger ? $logger : new Logger(
-            (isset($config['debug_mode']) ? $config['debug_mode'] : false),
-            (isset($config['debug_file']) ? $config['debug_file'] : '')
+        $this->logger = $logger ?: new Logger(
+            isset($config['debug_mode']) ? $config['debug_mode'] : Logger::NONE,
+            isset($config['debug_file']) ? $config['debug_file'] : ''
         );
 
-        $this->httpClient = $httpClient ? $httpClient : new HttpClient();
+        $this->httpClient = $httpClient ?: new HttpClient();
 
         if (isset($config['curl_options']) && method_exists($this->httpClient, 'setCurlOptions')) {
             $this->httpClient->setCurlOptions($this->config['curl_options']);
@@ -108,7 +109,7 @@ abstract class AbstractAdapter implements AdapterInterface
             $this->httpClient->setLogger($this->logger);
         }
 
-        $this->logger->debug('Initialize ' . get_class($this) . '. Provider config: ', $config);
+        $this->logger->debug('Initialize '.get_class($this).'. Provider config: ', $config);
 
         $this->config = new Data\Collection($config);
 
@@ -127,56 +128,56 @@ abstract class AbstractAdapter implements AdapterInterface
     abstract protected function initialize();
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         throw new NotImplementedException('Provider does not support this feature.', 8);
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserContacts()
     {
         throw new NotImplementedException('Provider does not support this feature.', 8);
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function setUserStatus($status)
     {
         throw new NotImplementedException('Provider does not support this feature.', 8);
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserActivity($stream)
     {
         throw new NotImplementedException('Provider does not support this feature.', 8);
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [])
     {
         throw new NotImplementedException('Provider does not support this feature.', 8);
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function isAuthorized()
     {
         return (bool) $this->token('access_token');
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function disconnect()
     {
         $this->clearTokens();
@@ -185,12 +186,12 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Return oauth access tokens
-    *
-    * @param array $tokenNames
-    *
-    * @return array
-    */
+     * Return oauth access tokens.
+     *
+     * @param array $tokenNames
+     *
+     * @return array
+     */
     public function getAccessToken($tokenNames = [])
     {
         if (empty($tokenNames)) {
@@ -200,7 +201,7 @@ abstract class AbstractAdapter implements AdapterInterface
                 'token_type',
                 'refresh_token',
                 'expires_in',
-                'expires_at'
+                'expires_at',
             ];
         }
 
@@ -216,10 +217,10 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Reset adapter access tokens
-    *
-    * @param array $tokens
-    */
+     * Reset adapter access tokens.
+     *
+     * @param array $tokens
+     */
     public function setAccessToken($tokens = [])
     {
         $this->clearTokens();
@@ -230,99 +231,97 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Get or Set a token
-    *
-    * This method provide a common way for providers adapter to store data internally.
-    * These tokens can be either OAuth tokens or any useful data (i.e., user_id, auth_nonce, etc.)
-    *
-    * @param string $token
-    * @param mixed  $value
-    *
-    * @return mixed
-    */
+     * Get or Set a token.
+     *
+     * This method provide a common way for providers adapter to store data internally.
+     * These tokens can be either OAuth tokens or any useful data (i.e., user_id, auth_nonce, etc.)
+     *
+     * @param string $token
+     * @param mixed  $value
+     *
+     * @return mixed
+     */
     public function token($token, $value = null)
     {
         if ($value === null) {
-            return $this->storage->get($this->providerId . '.token.' . $token);
+            return $this->storage->get($this->providerId.'.token.'.$token);
         }
 
         // we only store necessary data
         if (empty($value)) {
             $this->deleteToken($token);
         } else {
-            $this->storage->set($this->providerId . '.token.' . $token, $value);
+            $this->storage->set($this->providerId.'.token.'.$token, $value);
         }
-
-        return null;
     }
 
     /**
-    * Delete all tokens of the instantiated adapter
-    */
+     * Delete all tokens of the instantiated adapter.
+     */
     public function clearTokens()
     {
-        $this->storage->deleteMatch($this->providerId . '.');
+        $this->storage->deleteMatch($this->providerId.'.');
     }
 
     /**
-    * Delete a stored token
-    *
-    * @param string $token
-    */
+     * Delete a stored token.
+     *
+     * @param string $token
+     */
     protected function deleteToken($token)
     {
-        $this->storage->delete($this->providerId . '.token.' . $token);
+        $this->storage->delete($this->providerId.'.token.'.$token);
     }
 
     /**
-    * Return http client instance
-    *
-    * @return HttpClient
-    */
+     * Return http client instance.
+     *
+     * @return HttpClientInterface
+     */
     public function getHttpClient()
     {
         return $this->httpClient;
     }
 
     /**
-    * Validate Signed API Requests responses
-    *
-    * Since the specifics of error responses is beyond the scope of RFC6749 and OAuth Core specifications,
-    * Hybridauth will consider any HTTP status code that is different than '200 OK' as an ERROR.
-    *
-    * @throws HttpClientFailureException
-    * @throws HttpRequestFailedException
-    */
+     * Validate Signed API Requests responses.
+     *
+     * Since the specifics of error responses is beyond the scope of RFC6749 and OAuth Core specifications,
+     * Hybridauth will consider any HTTP status code that is different than '200 OK' as an ERROR.
+     *
+     * @throws HttpClientFailureException
+     * @throws HttpRequestFailedException
+     */
     protected function validateApiResponse()
     {
         if ($this->httpClient->getResponseClientError()) {
             throw new HttpClientFailureException(
-                'HTTP client error: ' .
-                $this->httpClient->getResponseClientError() .
+                'HTTP client error: '.
+                $this->httpClient->getResponseClientError().
                 '.'
             );
         }
 
         if (200 != $this->httpClient->getResponseHttpCode()) {
             throw new HttpRequestFailedException(
-                'HTTP error ' .
-                $this->httpClient->getResponseHttpCode() .
-                '. Raw Provider API response: ' .
-                $this->httpClient->getResponseBody() .
+                'HTTP error '.
+                $this->httpClient->getResponseHttpCode().
+                '. Raw Provider API response: '.
+                $this->httpClient->getResponseBody().
                 '.'
             );
         }
     }
 
     /**
-    * Override defaults endpoints
-    */
+     * Override defaults endpoints.
+     */
     protected function overrideEndpoints()
     {
         $endpoints = $this->config->filter('endpoints');
 
-        $this->apiBaseUrl     = $endpoints->get('api_base_url')     ?: $this->apiBaseUrl;
-        $this->authorizeUrl   = $endpoints->get('authorize_url')    ?: $this->authorizeUrl;
+        $this->apiBaseUrl = $endpoints->get('api_base_url')     ?: $this->apiBaseUrl;
+        $this->authorizeUrl = $endpoints->get('authorize_url')    ?: $this->authorizeUrl;
         $this->accessTokenUrl = $endpoints->get('access_token_url') ?: $this->accessTokenUrl;
     }
 }

--- a/src/HttpClient/Curl.php
+++ b/src/HttpClient/Curl.php
@@ -141,7 +141,7 @@ class Curl implements HttpClientInterface
             $this->logger->debug("HttpClient\Curl::request( $uri, $method ), response:", $this->getResponse());
 
             if (false === $response) {
-                $this->logger->error("HttpClient\Curl::request( $uri, $method ), curl_exec error: ", $this->responseClientError);
+                $this->logger->error("HttpClient\Curl::request( $uri, $method ), curl_exec error: ", [$this->responseClientError]);
             }
         }
 

--- a/src/HttpClient/Guzzle.php
+++ b/src/HttpClient/Guzzle.php
@@ -144,7 +144,7 @@ class Guzzle implements HttpClientInterface
             $this->logger->debug("HttpClient\Guzzle::request( $uri, $method ), response:", $this->getResponse());
 
             if ($this->responseClientError) {
-                $this->logger->error("HttpClient\Guzzle::request( $uri, $method ), GuzzleHttp error: ", $this->responseClientError);
+                $this->logger->error("HttpClient\Guzzle::request( $uri, $method ), GuzzleHttp error: ", [$this->responseClientError]);
             }
         }
 

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -85,7 +85,7 @@ class Hybridauth
         $this->storage = $storage ?: new Session();
 
         $this->logger = $logger ?: new Logger(
-            isset($config['debug_mode']) ? $config['debug_mode'] : false,
+            isset($config['debug_mode']) ? $config['debug_mode'] : Logger::NONE,
             isset($config['debug_file']) ? $config['debug_file'] : ''
         );
 

--- a/src/Logger/LoggerInterface.php
+++ b/src/Logger/LoggerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /*!
 * Hybridauth
 * https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
@@ -8,36 +9,43 @@
 namespace Hybridauth\Logger;
 
 /**
- * Logger interface
+ * Logger interface, forward-compatible with PSR-3.
  */
 interface LoggerInterface
 {
     /**
-    * Info
-    *
-    * @param string $message
-    *
-    * @return boolean
-    */
-    public function info($message);
+     * Interesting events.
+     *
+     * Example: User logs in, SQL logs.
+     *
+     * @param string $message
+     * @param array  $context
+     */
+    public function info($message, array $context = array());
 
     /**
-    * Debug
-    *
-    * @param string $message
-    * @param mixed  $object
-    *
-    * @return boolean
-    */
-    public function debug($message, $object = null);
+     * Detailed debug information.
+     *
+     * @param string $message
+     * @param array  $context
+     */
+    public function debug($message, array $context = array());
 
     /**
-    * Error
-    *
-    * @param string $message
-    * @param mixed  $object
-    *
-    * @return boolean
-    */
-    public function error($message, $object = null);
+     * Runtime errors that do not require immediate action but should typically
+     * be logged and monitored.
+     *
+     * @param string $message
+     * @param array  $context
+     */
+    public function error($message, array $context = array());
+
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed  $level
+     * @param string $message
+     * @param array  $context
+     */
+    public function log($level, $message, array $context = array());
 }

--- a/src/Logger/Psr3LoggerWrapper.php
+++ b/src/Logger/Psr3LoggerWrapper.php
@@ -1,0 +1,51 @@
+<?php
+
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2015 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Logger;
+
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * Wrapper for PSR3 logger.
+ */
+class Psr3LoggerWrapper implements LoggerInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public function info($message, array $context = [])
+    {
+        $this->logger->info($message, $context);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->logger->debug($message, $context);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function error($message, array $context = [])
+    {
+        $this->logger->error($message, $context);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->logger->log($level, $message, $context);
+    }
+}


### PR DESCRIPTION
#### Problem
Since we are trying to keep Hybridauth standalone, PSR3 logger interface was not includes into source code. This would cause problems when Composer's version will be used with Hybridauth and will make bundled autoloader much more complex.

That is why bundled logger interface is only forward-compatible with PSR3 logger interface.

What does this mean? Well, it contains some of methods from PSR3's Logger interface with exactly the same names and set/type of arguments.

While this is great, PHP doesn't allow you to inject some object that doesn't directly (or by some of its parents) implement required method, which makes it impossible to inject PSR3 loggers directly.

#### Solution
For Composer we'll use dummy logger interface that will extend `\Psr\Log\LoggerInterface` and thus will be also compatible with any PSR3 autoloader!
That is why we depend on `psr/log` in `composer.json` now and have 2 autoload elements there.

#### Summary
Implementation is a bit tricky, but we achieved what we need:
* completely standalone implementation that is forward-compatible with PSR3
* with Composer we use native PSR3 logger interface instead of built-in to allow using any PSR3-compatible logger

P.S. Sorry about long explanation, but I wanted to make clear what is going in this PR.