### PR TITLE
HHVM HTTP fix

### DIFF
--- a/src/HttpClient/Util.php
+++ b/src/HttpClient/Util.php
@@ -59,10 +59,9 @@ class Util
 
         if (
             (
-                $collection->exists('HTTPS') && $collection->get('HTTPS') !== 'off'
-            ) || (
-                $collection->exists('HTTP_X_FORWARDED_PROTO') && $collection->get('HTTP_X_FORWARDED_PROTO') === 'https'
-            )
+                $collection->get('HTTPS') && $collection->get('HTTPS') !== 'off'
+            ) ||
+                $collection->get('HTTP_X_FORWARDED_PROTO') === 'https'
         ) {
             $protocol = 'https://';
         }


### PR DESCRIPTION
* HHVM under HTTP sets `$_SERVER['HTTPS']` to empty string
* Existing check is redundant since it is a part of `Collection::get()` method already