### PR TITLE
rewrite syntax into an equivalent way that is compatible with older PHP

### DIFF
--- a/hybridauth/Hybrid/Logger.php
+++ b/hybridauth/Hybrid/Logger.php
@@ -38,10 +38,11 @@ class Hybrid_Logger {
 	 */
 	public static function debug($message, $object = null) {
 		if (Hybrid_Auth::$config["debug_mode"] === true) {
+                        $dt = new DateTime;
 			file_put_contents(Hybrid_Auth::$config["debug_file"], implode(' -- ', array(
 				"DEBUG",
 				$_SERVER['REMOTE_ADDR'],
-				(new DateTime)->format(DATE_ATOM),
+				$dt->format(DATE_ATOM),
 				$message,
 				print_r($object, true) . PHP_EOL,
 					)), FILE_APPEND
@@ -57,10 +58,11 @@ class Hybrid_Logger {
 	 */
 	public static function info($message) {
 		if (in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info'), true)) {
+                        $dt = new DateTime;
 			file_put_contents(Hybrid_Auth::$config["debug_file"], implode(' -- ', array(
 				"INFO",
 				$_SERVER['REMOTE_ADDR'],
-				(new DateTime)->format(DATE_ATOM),
+				$dt->format(DATE_ATOM),
 				$message . PHP_EOL,
 					)), FILE_APPEND);
 		}
@@ -75,10 +77,11 @@ class Hybrid_Logger {
 	 */
 	public static function error($message, $object = null) {
 		if (isset(Hybrid_Auth::$config["debug_mode"]) && in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info', 'error'), true)) {
+                        $dt = new DateTime;
 			file_put_contents(Hybrid_Auth::$config["debug_file"], implode(' -- ', array(
 				'ERROR',
 				$_SERVER['REMOTE_ADDR'],
-				(new DateTime)->format(DATE_ATOM),
+				$dt->format(DATE_ATOM),
 				$message,
 				print_r($object, true) . PHP_EOL
 					)), FILE_APPEND);


### PR DESCRIPTION
The previous version of Logger.php was not compatible with older versions of PHP (my server runs 5.3.3, for reasons beyond my control). It gave this error:

    PHP Parse error:  syntax error, unexpected T_OBJECT_OPERATOR, expecting ')' in     
    .../hybridauth/hybridauth/Hybrid/Logger.php on line 44

(and again on lines 63 and 81)

This fix simply changes that "(new DateTime)->format(DATE_ATOM)" to two separate lines in order to work, but it has exactly the same functionality. I have tested it and it works.

Hybridauth is awesome! Thanks for such a great tool.