### PR TITLE
Undefined index: oauth_token notice in Linkedin provider

### DIFF
--- a/hybridauth/Hybrid/Providers/LinkedIn.php
+++ b/hybridauth/Hybrid/Providers/LinkedIn.php
@@ -62,10 +62,15 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 	 * {@inheritdoc}
 	 */
 	function loginFinish() {
-		$oauth_token = $_REQUEST['oauth_token'];
-		$oauth_verifier = $_REQUEST['oauth_verifier'];
+        // in case we get oauth_problem=user_refused
+        if (isset($_REQUEST['oauth_problem']) && $_REQUEST['oauth_problem'] == "user_refused") {
+            throw new Exception("Authentication failed! The user denied your request.", 5);
+        }
 
-		if (!$oauth_verifier) {
+		$oauth_token = isset($_REQUEST['oauth_token']) ? $_REQUEST['oauth_token'] : null;
+		$oauth_verifier = isset($_REQUEST['oauth_verifier']) ? $_REQUEST['oauth_verifier'] : null;
+
+		if (!$oauth_token || !$oauth_verifier) {
 			throw new Exception("Authentication failed! {$this->providerId} returned an invalid Token.", 5);
 		}
 


### PR DESCRIPTION
When trying to login with Linkedin, if I refused the permission, I would get the following PHP notice:
<pre>
Undefined index: oauth_token
/home/foobar/shared/common/lib/vendor/hybridauth/hybridauth/hybridauth/Hybrid/Providers/LinkedIn.php(62)
</pre>
return url:
https://www.foo.bar/site/oauth?hauth%2Edone=LinkedIn&oauth_problem=user_refused