### PR TITLE
Hybrid Auth for DUMMIES => consistent example.

### DIFF
--- a/hybridauth/index.php
+++ b/hybridauth/index.php
@@ -9,7 +9,20 @@
 //	HybridAuth End Point
 // ------------------------------------------------------------------------
 
+$config = require 'config.php';
 require_once( "Hybrid/Auth.php" );
 require_once( "Hybrid/Endpoint.php" );
 
-Hybrid_Endpoint::process();
+if (isset($_REQUEST['hauth_start']) || isset($_REQUEST['hauth_done'])) {
+  Hybrid_Endpoint::process();
+} else {
+  try {
+    $hybridauth = new Hybrid_Auth( $config );
+		$google = $hybridauth->authenticate( "Google");
+		$user_profile = $google->getUserProfile();
+
+		echo "Hi there! " . $user_profile->email; 
+	} catch( Exception $e ){
+		echo "Ooophs, we got an error: " . $e->getMessage();
+	}
+}


### PR DESCRIPTION
I've been trying to implement hybridauth on a vanilla app and it took me long.
Actually docs are not consistent and the example given in this repo is not out of the box.
So after I got my stuff running I wanted to share it to the main repo so as people coming after me can save their time and implement this out of the box.

Changes made:
1) need to check if 'hauth_start' or 'hauth_done' have been requested in order to get Hybrid_Endpoint::process() running properly.
2) if none is requested then we can proceed and get our data out of the user.
3) $config needs to be setted up as a variable otherwise we can't get hold of it on methods further down.