### PR TITLE
[Facebook] Fixes getUserProfile v2.4 compatibility

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -45,7 +45,7 @@ class Facebook extends OAuth2
     */
     public function getUserProfile($callback = null)
     {
-        $response = $this->apiRequest('me');
+        $response = $this->apiRequest('me?fields=id,name,first_name,last_name,link,website,gender,locale,about,email,hometown,verified,birthday');
 
         $data = new Data\Collection($response);
 


### PR DESCRIPTION
Facebook changed profile data requests to provide the minimal of name and id. Without specifying the fields HybridAuth uses it'll only have those two for their profile data. This fixes it to request the fields used by HybridAuth specifically.