### PR TITLE
Fix warnings for getUserByResponse() in Vkontakt provider.

### DIFF
--- a/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
+++ b/additional-providers/hybridauth-vkontakte/Providers/Vkontakte.php
@@ -201,7 +201,9 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 			$cities     = $this->api->api( 'database.getCitiesById' , 'GET', $params);
 			$city       = reset($cities);
 			if (is_array($city)) $city = reset($city);
-			$user->city = property_exists($city, 'name') ? $city->name : null;
+			if (is_object($city) || is_string($city)) {
+				$user->city = property_exists($city, 'name') ? $city->name : null;
+			}
 		}
 
 		if (property_exists($user, 'country') && $withAdditionalRequests) {
@@ -211,7 +213,9 @@ class Hybrid_Providers_Vkontakte extends Hybrid_Provider_Model_OAuth2
 			$countries     = $this->api->api( 'database.getCountriesById' , 'GET', $params);
 			$country       = reset($countries);
 			if (is_array($country)) $country = reset($country);
-			$user->country = property_exists($country, 'name') ? $country->name : null;
+			if (is_object($country) || is_string($country)) {
+				$user->country = property_exists($country, 'name') ? $country->name : null;
+			}
 		}
 
 		return $user;


### PR DESCRIPTION
This method doesn't consider that user can have empty fields as 'country' and 'city'. So there are will be two warnings.