### PR TITLE
Require OAuth.php only if not exist

### DIFF
--- a/hybridauth/Hybrid/Provider_Model_OAuth1.php
+++ b/hybridauth/Hybrid/Provider_Model_OAuth1.php
@@ -77,8 +77,10 @@ class Hybrid_Provider_Model_OAuth1 extends Hybrid_Provider_Model {
 		}
 
 		// 2 - include OAuth lib and client
-		require_once Hybrid_Auth::$config["path_libraries"] . "OAuth/OAuth.php";
-		require_once Hybrid_Auth::$config["path_libraries"] . "OAuth/OAuth1Client.php";
+		if (! class_exists('OAuthConsumer') ) {
+          		require_once Hybrid_Auth::$config["path_libraries"] . "OAuth/OAuth.php";
+		}	
+        	require_once Hybrid_Auth::$config["path_libraries"] . "OAuth/OAuth1Client.php";
 
 		// 3.1 - setup access_token if any stored
 		if ($this->token("access_token")) {


### PR DESCRIPTION
I had problems with the following combination :

Drupal + Drupal HybridAuth + Drupal OAuth + HybridAuth because OAuthConsumer class is already provided within Drupal OAuth.

=> Callback from linkedin and twitter lead to this error message : 

```
PHP Fatal error:  Cannot redeclare class OAuthConsumer in /var/www/sites/domain/sites/all/modules/oauth/lib/OAuth.php on line 20
```

@see : https://www.drupal.org/node/2147429