### PR TITLE
DateTime error

### DIFF
--- a/hybridauth/Hybrid/Logger.php
+++ b/hybridauth/Hybrid/Logger.php
@@ -38,7 +38,7 @@ class Hybrid_Logger {
 	 */
 	public static function debug($message, $object = null) {
 		if (Hybrid_Auth::$config["debug_mode"] === true) {
-                        $dt = new DateTime;
+                        $dt = new DateTime('now',  new DateTimeZone( 'UTC' ));
 			file_put_contents(Hybrid_Auth::$config["debug_file"], implode(' -- ', array(
 				"DEBUG",
 				$_SERVER['REMOTE_ADDR'],
@@ -58,7 +58,7 @@ class Hybrid_Logger {
 	 */
 	public static function info($message) {
 		if (in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info'), true)) {
-                        $dt = new DateTime;
+                        $dt = new DateTime('now',  new DateTimeZone( 'UTC' ));
 			file_put_contents(Hybrid_Auth::$config["debug_file"], implode(' -- ', array(
 				"INFO",
 				$_SERVER['REMOTE_ADDR'],
@@ -77,7 +77,7 @@ class Hybrid_Logger {
 	 */
 	public static function error($message, $object = null) {
 		if (isset(Hybrid_Auth::$config["debug_mode"]) && in_array(Hybrid_Auth::$config["debug_mode"], array(true, 'info', 'error'), true)) {
-                        $dt = new DateTime;
+                        $dt = new DateTime('now',  new DateTimeZone( 'UTC' ));$dt = new DateTime;
 			file_put_contents(Hybrid_Auth::$config["debug_file"], implode(' -- ', array(
 				'ERROR',
 				$_SERVER['REMOTE_ADDR'],


### PR DESCRIPTION
this error is caused by DateTime settings. please add this to your code

Fatal error: Uncaught exception 'Exception' with message 'DateTime::__construct(): It is not safe to rely on the system's timezone settings. You are required to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.' in /home2/markewl7/public_html/guildgear/system/library/Hybrid/Logger.php:80 Stack trace: #0 /home2/markewl7/public_html/guildgear/system/library/Hybrid/Logger.php(80): DateTime->__construct() #1 /home2/markewl7/public_html/guildgear/system/library/Hybrid/Endpoint.php(210): Hybrid_Logger::error('Endpoint: Error...') #2 /home2/markewl7/public_html/guildgear/system/library/Hybrid/Endpoint.php(117): Hybrid_Endpoint->authInit() #3 /home2/markewl7/public_html/guildgear/system/library/Hybrid/Endpoint.php(51): Hybrid_Endpoint->processAuthStart() #4 /home2/markewl7/public_htm in /home2/markewl7/public_html/guildgear/system/library/Hybrid/Logger.php on line 80