### PR TITLE
[odnoklassniki] Improve error reporting

### DIFF
--- a/additional-providers/hybridauth-odnoklassniki/Providers/Odnoklassniki.php
+++ b/additional-providers/hybridauth-odnoklassniki/Providers/Odnoklassniki.php
@@ -91,8 +91,16 @@ class Hybrid_Providers_Odnoklassniki extends Hybrid_Provider_Model_OAuth2
 		
 		$response = $this->parseRequestResult( $response );
 
-		if( ! $response || ! isset( $response->access_token ) ){
-			throw new Exception( "The Authorization Service has return: " . $response->error );
+		if ( ! $response ) {
+			throw new Exception( "Curl error fetching {$this->api->token_url}" );
+		}
+
+		if( ! isset( $response->access_token ) ){
+			if ( isset( $response->error ) ){
+				throw new Exception( "The Authorization Service has return error: " . $response->error );
+			} else {
+				throw new Exception( "The Authorization Service has return unknown data: " . json_encode( $response ) );
+			}
 		}
 
 		if( isset( $response->access_token  ) ) $this->api->access_token            = $response->access_token;


### PR DESCRIPTION
This PR improves error handling within Odnoklassniki provider. Sometimes $response returned from curl is false and thus doesn't contain 'error' property. This leads to log messages in the software I maintain like this: 

>User profile request failed! Odnoklassniki returned an error: exception 'ErrorException' with message 'Undefined property: stdClass::$error

So, I propose to improve error handling in this provider with this PR.