### PR TITLE
[Hybrid_Endpoint] Improve error reporting

### DIFF
--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -208,7 +208,7 @@ class Hybrid_Endpoint {
 				Hybrid_Auth::initialize($storage->config("CONFIG"));
 			} catch (Exception $e) {
 				Hybrid_Logger::error("Endpoint: Error while trying to init Hybrid_Auth: " . $e->getMessage());
-				throw new Hybrid_Exception("Oophs. Error!");
+				throw new Hybrid_Exception( "Endpoint: Error while trying to init Hybrid_Auth: " . $e->getMessage(), $e->getCode(), $e );
 			}
 		}
 	}


### PR DESCRIPTION
This PR enhances error reporting done by Hybrid_Endpoint. It replaces the default "Oophs. Error!" exception message with a more meaningful one and enables nested exception to be logged.