### PR TITLE
Improve logging and error handling in main providers

### DIFF
--- a/hybridauth/Hybrid/Logger.php
+++ b/hybridauth/Hybrid/Logger.php
@@ -88,4 +88,15 @@ class Hybrid_Logger {
 		}
 	}
 
+    /**
+     * Dumps the data in the way suitable to be output in log files for debug purposes
+     *
+     * @param mixed $data
+     *
+     * @return string
+     */
+    public static function dumpData($data) {
+		return var_export($data, true);
+	}
+
 }

--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -170,12 +170,12 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 
 			$data = $this->api->api('/me?fields=' . implode(',', $fields));
 		} catch (FacebookApiException $e) {
-			throw new Exception("User profile request failed! {$this->providerId} returned an error: $e", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an error: {$e->getMessage()}", 6, $e);
 		}
 
 		// if the provider identifier is not received, we assume the auth has failed
 		if (!isset($data["id"])) {
-			throw new Exception("User profile request failed! {$this->providerId} api returned an invalid response.", 6);
+			throw new Exception("User profile request failed! {$this->providerId} api returned an invalid response: " . Hybrid_Logger::dumpData( $data ), 6);
 		}
 
 		# store the user profile.
@@ -248,7 +248,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 			try {
 				$response = $this->api->api('/me/friends' . $apiCall);
 			} catch (FacebookApiException $e) {
-				throw new Exception('User contacts request failed! {$this->providerId} returned an error: $e');
+				throw new Exception("User contacts request failed! {$this->providerId} returned an error {$e->getMessage()}", 0, $e);
 			}
 
 			// Prepare the next call if paging links have been returned
@@ -316,7 +316,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 		try {
 			$response = $this->api->api('/' . $pageid . '/feed', 'post', $status);
 		} catch (FacebookApiException $e) {
-			throw new Exception("Update user status failed! {$this->providerId} returned an error: $e");
+			throw new Exception("Update user status failed! {$this->providerId} returned an error {$e->getMessage()}", 0, $e);
 		}
 
 		return $response;
@@ -329,7 +329,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 		try {
 			$postinfo = $this->api->api("/" . $postid);
 		} catch (FacebookApiException $e) {
-			throw new Exception("Cannot retrieve user status! {$this->providerId} returned an error: $e");
+			throw new Exception("Cannot retrieve user status! {$this->providerId} returned an error: {$e->getMessage()}", 0, $e);
 		}
 
 		return $postinfo;
@@ -345,7 +345,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 		try {
 			$pages = $this->api->api("/me/accounts", 'get');
 		} catch (FacebookApiException $e) {
-			throw new Exception("Cannot retrieve user pages! {$this->providerId} returned an error: $e");
+			throw new Exception("Cannot retrieve user pages! {$this->providerId} returned an error: {$e->getMessage()}", 0, $e);
 		}
 
 		if (!isset($pages['data'])) {
@@ -380,7 +380,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 				$response = $this->api->api('/me/home');
 			}
 		} catch (FacebookApiException $e) {
-			throw new Exception("User activity stream request failed! {$this->providerId} returned an error: $e");
+			throw new Exception("User activity stream request failed! {$this->providerId} returned an error: {$e->getMessage()}", 0, $e);
 		}
 
 		if (!$response || !count($response['data'])) {

--- a/hybridauth/Hybrid/Providers/Foursquare.php
+++ b/hybridauth/Hybrid/Providers/Foursquare.php
@@ -51,7 +51,7 @@ class Hybrid_Providers_Foursquare extends Hybrid_Provider_Model_OAuth2 {
 		$data = $this->api->api("users/self", "GET", Hybrid_Providers_Foursquare::$apiVersion);
 
 		if (!isset($data->response->user->id)) {
-			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response.", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response:" . Hybrid_Logger::dumpData( $data ), 6);
 		}
 
 		$data = $data->response->user;
@@ -83,7 +83,7 @@ class Hybrid_Providers_Foursquare extends Hybrid_Provider_Model_OAuth2 {
 		try {
 			$response = $this->api->api("users/self/friends", "GET", Hybrid_Providers_Foursquare::$apiVersion);
 		} catch (LinkedInException $e) {
-			throw new Exception("User contacts request failed! {$this->providerId} returned an error: $e");
+			throw new Exception("User contacts request failed! {$this->providerId} returned an error: {$e->getMessage()}", 0, $e);
 		}
 
 		if (isset($response) && $response->meta->code == 200) {

--- a/hybridauth/Hybrid/Providers/Google.php
+++ b/hybridauth/Hybrid/Providers/Google.php
@@ -87,7 +87,7 @@ class Hybrid_Providers_Google extends Hybrid_Provider_Model_OAuth2 {
 
 		$response = $this->api->api("https://www.googleapis.com/plus/v1/people/me");
 		if (!isset($response->id) || isset($response->error)) {
-			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response.", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response:" . Hybrid_Logger::dumpData( $response ), 6);
 		}
 
 		$this->user->profile->identifier = (property_exists($verified, 'id')) ? $verified->id : ((property_exists($response, 'id')) ? $response->id : "");

--- a/hybridauth/Hybrid/Providers/LinkedIn.php
+++ b/hybridauth/Hybrid/Providers/LinkedIn.php
@@ -54,7 +54,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 			# redirect user to LinkedIn authorisation web page
 			Hybrid_Auth::redirect(LINKEDIN::_URL_AUTH . $response['linkedin']['oauth_token']);
 		} else {
-			throw new Exception("Authentication failed! {$this->providerId} returned an invalid Token.", 5);
+			throw new Exception("Authentication failed! {$this->providerId} returned an invalid Token in response: " . Hybrid_Logger::dumpData( $response ), 5);
 		}
 	}
 
@@ -87,7 +87,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 			// set user as logged in
 			$this->setUserConnected();
 		} else {
-			throw new Exception("Authentication failed! {$this->providerId} returned an invalid Token.", 5);
+			throw new Exception("Authentication failed! {$this->providerId} returned an invalid Token in response: " . Hybrid_Logger::dumpData( $response ), 5);
 		}
 	}
 
@@ -99,14 +99,14 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 			// http://developer.linkedin.com/docs/DOC-1061
 			$response = $this->api->profile('~:(id,first-name,last-name,public-profile-url,picture-url,email-address,date-of-birth,phone-numbers,summary)');
 		} catch (LinkedInException $e) {
-			throw new Exception("User profile request failed! {$this->providerId} returned an error: $e", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an error: {$e->getMessage()}", 6, $e);
 		}
 
 		if (isset($response['success']) && $response['success'] === true) {
 			$data = @ new SimpleXMLElement($response['linkedin']);
 
 			if (!is_object($data)) {
-				throw new Exception("User profile request failed! {$this->providerId} returned an invalid xml data.", 6);
+				throw new Exception("User profile request failed! {$this->providerId} returned an invalid xml data: " . Hybrid_Logger::dumpData( $data ), 6);
 			}
 
 			$this->user->profile->identifier = (string) $data->{'id'};
@@ -135,7 +135,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 
 			return $this->user->profile;
 		} else {
-			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response.", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response: " . Hybrid_Logger::dumpData( $response ), 6);
 		}
 	}
 
@@ -146,7 +146,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 		try {
 			$response = $this->api->profile('~/connections:(id,first-name,last-name,picture-url,public-profile-url,summary)');
 		} catch (LinkedInException $e) {
-			throw new Exception("User contacts request failed! {$this->providerId} returned an error: $e");
+			throw new Exception("User contacts request failed! {$this->providerId} returned an error: {$e->getMessage()}", 0, $e);
 		}
 
 		if (!$response || !$response['success']) {
@@ -198,11 +198,11 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 		try {
 			$response = $this->api->share('new', $parameters, $private);
 		} catch (LinkedInException $e) {
-			throw new Exception("Update user status update failed!  {$this->providerId} returned an error: $e");
+			throw new Exception("Update user status update failed!  {$this->providerId} returned an error: {$e->getMessage()}", 0, $e);
 		}
 
 		if (!$response || !$response['success']) {
-			throw new Exception("Update user status update failed! {$this->providerId} returned an error.");
+			throw new Exception("Update user status update failed! {$this->providerId} returned an error in response: " . Hybrid_Logger::dumpData( $response ));
 		}
 
 		return $response;
@@ -222,7 +222,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 				$response = $this->api->updates('?type=SHAR&count=25');
 			}
 		} catch (LinkedInException $e) {
-			throw new Exception("User activity stream request failed! {$this->providerId} returned an error: $e");
+			throw new Exception("User activity stream request failed! {$this->providerId} returned an error: {$e->getMessage()}", 0, $e);
 		}
 
 		if (!$response || !$response['success']) {

--- a/hybridauth/Hybrid/Providers/Live.php
+++ b/hybridauth/Hybrid/Providers/Live.php
@@ -46,7 +46,7 @@ class Hybrid_Providers_Live extends Hybrid_Provider_Model_OAuth2 {
 		$data = $this->api->get("me");
 
 		if (!isset($data->id)) {
-			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response.", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response: " . Hybrid_Logger::dumpData( $data ), 6);
 		}
 
 		$this->user->profile->identifier = (property_exists($data, 'id')) ? $data->id : "";

--- a/hybridauth/Hybrid/Providers/Twitter.php
+++ b/hybridauth/Hybrid/Providers/Twitter.php
@@ -118,7 +118,7 @@ class Hybrid_Providers_Twitter extends Hybrid_Provider_Model_OAuth1 {
 		}
 
 		if (!is_object($response) || !isset($response->id)) {
-			throw new Exception("User profile request failed! {$this->providerId} api returned an invalid response.", 6);
+			throw new Exception("User profile request failed! {$this->providerId} api returned an invalid response: " . Hybrid_Logger::dumpData( $response ), 6);
 		}
 
 		# store the user profile.  

--- a/hybridauth/Hybrid/Providers/Yahoo.php
+++ b/hybridauth/Hybrid/Providers/Yahoo.php
@@ -45,7 +45,7 @@ class Hybrid_Providers_Yahoo extends Hybrid_Provider_Model_OAuth1 {
 		$response = $this->api->get('user/' . $userId . '/profile', $parameters);
 
 		if (!isset($response->profile)) {
-			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response.", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an invalid response: " . Hybrid_Logger::dumpData( $response ), 6);
 		}
 
 		$data = $response->profile;
@@ -267,7 +267,7 @@ class Hybrid_Providers_Yahoo extends Hybrid_Provider_Model_OAuth1 {
 		$response = $this->api->get('me/guid', $parameters);
 
 		if (!isset($response->guid->value)) {
-			throw new Exception("User id request failed! {$this->providerId} returned an invalid response.");
+			throw new Exception("User id request failed! {$this->providerId} returned an invalid response: " . Hybrid_Logger::dumpData( $response ));
 		}
 
 		return $response->guid->value;


### PR DESCRIPTION
With this PR I propose to improve HybridAuth logging and error reporting by the following:

 - Where appropriate, propagate nested exception
 - Where appropriate, output actual server response in "invalid response"-like messages to make debugging easier.