### PR TITLE
Facebook login read_stream deprecated for 2.5

### DIFF
--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -19,7 +19,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 	 * default permissions, and a lot of them. You can change them from the configuration by setting the scope to what you want/need
 	 * {@inheritdoc}
 	 */
-	public $scope = "email, user_about_me, user_birthday, user_hometown, user_location, user_website, read_stream, publish_actions, read_custom_friendlists";
+	public $scope = "email, user_about_me, user_birthday, user_hometown, user_location, user_website, publish_actions, read_custom_friendlists";
 
 	/**
 	 * Provider API client


### PR DESCRIPTION
For current facebook api (v2.5) read_stream permission is deprecated and not available for new apps. This means that facebook login cannot be used for new sites. (More info here: https://developers.facebook.com/docs/apps/versions)