### PR TITLE
[Facebook] Directly check the returned Facebook code for getting an access token

### DIFF
--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -47,8 +47,15 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 		$trustForwarded = isset($this->config['trustForwarded']) ? (bool) $this->config['trustForwarded'] : false;
 		$this->api = new Facebook(array('appId' => $this->config["keys"]["id"], 'secret' => $this->config["keys"]["secret"], 'trustForwarded' => $trustForwarded));
 
-		if ($this->token("access_token")) {
-			$this->api->setAccessToken($this->token("access_token"));
+		if ($this->token("access_token") || isset($_REQUEST["code"])) {
+			if ($this->token("access_token")) {
+				$this->api->setAccessToken($this->token("access_token"));
+		        } else if(isset($_REQUEST["code"])
+			&& $access_token_from_code = $this->api->getAccessTokenFromCode($_REQUEST["code"], $this->config["hauth_return_to"]."?hauth.done=Facebook")
+			) {
+				$this->api->setAccessToken($access_token_from_code);
+			}
+
 			$this->api->setExtendedAccessToken();
 			$access_token = $this->api->getAccessToken();
 

--- a/hybridauth/Hybrid/thirdparty/Facebook/base_facebook.php
+++ b/hybridauth/Hybrid/thirdparty/Facebook/base_facebook.php
@@ -808,7 +808,7 @@ abstract class BaseFacebook
    * @return mixed An access token exchanged for the authorization code, or
    *               false if an access token could not be generated.
    */
-  protected function getAccessTokenFromCode($code, $redirect_uri = null) {
+  public function getAccessTokenFromCode($code, $redirect_uri = null) {
     if (empty($code)) {
       return false;
     }


### PR DESCRIPTION
When using Facebook as login provider there is a problem on multilingual sites that do additional redirects with for example "/en/" or /de/" URL prefixes. See https://www.drupal.org/node/2684015 for background.

This is the proposed solution from that issue, not sure it is correct or the way to go.
