### PR TITLE
Added actual coding standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+install: travis_retry composer install --no-interaction --prefer-source
+
+script:
+  - vendor/bin/phpcs --standard=phpcs.xml hybridauth
+  - vendor/bin/phpcs --standard=phpcs.xml additional-providers
+
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "php": ">=5.2.0",
         "ext-curl": "*"
     },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "2.*"
+    },
     "autoload": {
         "psr-0": {
             "Hybrid": "hybridauth/"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0"?>
+<!--suppress XmlUnboundNsPrefix -->
+<ruleset name="PHP-SDK">
+ <description>Coding standard ruleset based on the PSR-2 coding standard.</description>
+ <rule ref="PSR2"/>
+ <!-- These following sniffs needs manual work to be fixed -->
+
+ <rule ref="Generic.Files.LineLength.TooLong">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Scope.MethodScope.Missing">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PEAR.Functions.ValidDefaultValue.NotAtEnd">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.PropertyDeclaration.ScopeMissing">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.PropertyDeclaration.Multiple">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Classes.ValidClassName.NotCamelCaps">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.PropertyDeclaration.VarUsed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclaration">
+  <severity>0</severity>
+ </rule>
+ <!-- These following sniffs can automatically be fixed by phpcbf -->
+ <rule ref="PSR2.Methods.FunctionCallSignature.SpaceBeforeCloseBracket">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.WhiteSpace.DisallowTabIndent.TabsUsed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.FunctionCallSignature.SpaceAfterOpenBracket">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.Files.LineEndings.InvalidEOLChar">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.WhiteSpace.ScopeIndent.Incorrect">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.ControlStructures.InlineControlStructure.NotAllowed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing.SpaceBeforeComma">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterKeyword">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing.NoSpaceAfterComma">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceAfterDefault">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeEquals">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.FunctionCallSignature.SpaceBeforeOpenBracket">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.WhiteSpace.ScopeIndent.IncorrectExact">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakIndent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpenBrace">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseParenthesis">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceAfterArrow">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.ClassDeclaration.OpenBraceNewLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.WhiteSpace.DisallowTabIndent.NonIndentTabsUsed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineCASE">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.ControlStructureSpacing.SpaceBeforeCloseBrace">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonDEFAULT">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.FunctionCallSignature.Indent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceAfterOpen">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.NoSpaceBeforeArrow">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.AsNotLower">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.Indent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.PHP.LowerCaseKeyword.Found">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.Formatting.DisallowMultipleStatements.SameLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.SwitchDeclaration.BreakNotNewLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.SwitchDeclaration.SpaceBeforeColonCASE">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.FunctionCallSignature.MultipleArgumentsE">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.FunctionCallSignature.ContentAfterOpenBracket">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.FunctionCallSignature.CloseBracketLine">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.FunctionCallSignature.MultipleArguments">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Methods.MethodDeclaration.AbstractAfterVisibility">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBetween">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.PHP.LowerCaseConstant.Found">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Classes.ClassDeclaration.OpenBraceNotAlone">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.BraceIndent">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.ControlStructures.SwitchDeclaration.BodyOnNextLineDEFAULT">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Files.EndFileNewline.TooMany">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpaceBeforeComma">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeArg">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.ContentAfterBrace">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Files.EndFileNewline.NoneFound">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpacingBeforeAs">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Files.ClosingTag.NotAllowed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing.NoSpaceBeforeArg">
+  <severity>0</severity>
+ </rule>
+ <rule ref="PSR2.Files.ClosingTag.NotAllowed">
+  <severity>0</severity>
+ </rule>
+ <rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceBeforeOpenParen">
+  <severity>0</severity>
+ </rule>
+</ruleset>


### PR DESCRIPTION
I've added the actual coding standards based on PSR2 that this library is coded after. If accepted we could fix some of the coding standard issues quite easily with `phpcbf`
