### PR TITLE
Update bitbucket - take out unnecessary echo

### DIFF
--- a/additional-providers/hybridauth-bitbucket/Providers/BitBucket.php
+++ b/additional-providers/hybridauth-bitbucket/Providers/BitBucket.php
@@ -65,7 +65,6 @@ class Hybrid_Providers_BitBucket extends Hybrid_Provider_Model_OAuth2
             
             foreach ($emails->values as $email) {
                 if ($email->is_primary) {
-                    echo $email->email;
                     $this->user->profile->email = $email->email;
                     $this->user->profile->emailVerified = (bool)$email->is_confirmed;
                     break;


### PR DESCRIPTION
This echo statement shouldn't be here.  If someone wants to echo something they can get the data from the function since it returns it.  It shouldn't be in the core files.  It was added in 081ce1a9500c53e5fc00db23574040a9374ced62 and merged into master b203c4d5e2ad6400e36adbb1c94627d8fe3da63f .