### PR TITLE
Duplicate conditional expression in Sina.php

### DIFF
--- a/additional-providers/hybridauth-sina/thirdparty/Sina/Sina.php
+++ b/additional-providers/hybridauth-sina/thirdparty/Sina/Sina.php
@@ -214,7 +214,7 @@ class WeiboOAuth {
      */ 
     function oAuthRequest($url, $method, $parameters , $multi = false) { 
 
-        if (strrpos($url, 'http://') !== 0 && strrpos($url, 'http://') !== 0) { 
+        if (strrpos($url, 'http://') !== 0) { 
             $url = "{$this->host}{$url}.{$this->format}"; 
         } 
 


### PR DESCRIPTION
One of these expressions can be removed, unless it was supposed to be `https`?