### PR TITLE
Workaround for Windows Live authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hybridauth/hybridauth",
+    "name": "mourjan/hybridauth",
     "description": "Open source social sign on PHP library.",
     "keywords": ["hybridauth", "login", "oauth", "social", "openid", "facebook", "google", "twitter", "yahoo"],
     "homepage": "http://hybridauth.sourceforge.net",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "mourjan/hybridauth",
+    "name": "hybridauth/hybridauth",
     "description": "Open source social sign on PHP library.",
     "keywords": ["hybridauth", "login", "oauth", "social", "openid", "facebook", "google", "twitter", "yahoo"],
     "homepage": "http://hybridauth.sourceforge.net",

--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -352,6 +352,9 @@ class Hybrid_Auth {
 	 * @param string $mode PHP|JS
 	 */
 	public static function redirect($url, $mode = "PHP") {
+		if(!$mode){
+			$mode = 'PHP';	
+		}
 		Hybrid_Logger::info("Enter Hybrid_Auth::redirect( $url, $mode )");
 
 		// Ensure session is saved before sending response, see https://github.com/symfony/symfony/pull/12341

--- a/hybridauth/Hybrid/Provider_Adapter.php
+++ b/hybridauth/Hybrid/Provider_Adapter.php
@@ -159,6 +159,12 @@ class Hybrid_Provider_Adapter {
 		# 	auth.done   required  the IDp ID
 		$this->params["login_done"] = $HYBRID_AUTH_URL_BASE . ( strpos($HYBRID_AUTH_URL_BASE, '?') ? '&' : '?' ) . "hauth.done={$this->id}";
 
+		# workaround to solve windows live authentication since microsoft disallowed redirect urls to contain any parameters
+		# http://mywebsite.com/path_to_hybridauth/?hauth.done=Live will not work
+		if ($this->id=="Live") { 
+			$this->params["login_done"] = $HYBRID_AUTH_URL_BASE."live.php"; 
+		}
+		
 		if (isset($this->params["hauth_return_to"])) {
 			Hybrid_Auth::storage()->set("hauth_session.{$this->id}.hauth_return_to", $this->params["hauth_return_to"]);
 		}

--- a/hybridauth/live.php
+++ b/hybridauth/live.php
@@ -1,0 +1,13 @@
+<?php
+/**
+* HybridAuth
+* http://hybridauth.sourceforge.net | http://github.com/hybridauth/hybridauth
+* (c) 2009-2015, HybridAuth authors | http://hybridauth.sourceforge.net/licenses.html
+*/
+// ------------------------------------------------------------------------
+//	HybridAuth End Point
+// ------------------------------------------------------------------------
+$_REQUEST['hauth_done'] = 'Live';
+require_once( "Hybrid/Auth.php" );
+require_once( "Hybrid/Endpoint.php" );
+Hybrid_Endpoint::process();


### PR DESCRIPTION
A while ago, Microsoft enforced their oauth security by disallowing redirect url to contain any parameters.
Hence the following redirect url does not work:
http://mywebsite.com/path_to_hybridauth/?hauth.done=Live

A workaound created by @tohweesiang was to provide another redirect url format in the case of Live authentication, so the redirect url will become like:
http://mywebsite.com/path_to_hybridauth/live.php

If this pull request is accepted than [Hybridauth's documentation for Windows Live](http://hybridauth.sourceforge.net/userguide/IDProvider_info_Live.html) should be changed as well,

regards