### PR TITLE
Fix PHP Notice when $_SERVER["QUERY_STRING"] is not defined.

### DIFF
--- a/hybridauth/Hybrid/Endpoint.php
+++ b/hybridauth/Hybrid/Endpoint.php
@@ -27,7 +27,7 @@ class Hybrid_Endpoint {
 			// with /index.php?hauth.done={provider}?{args}...
 			// >here we need to parse $_SERVER[QUERY_STRING]
 			$request = $_REQUEST;
-			if (strrpos($_SERVER["QUERY_STRING"], '?')) {
+			if (isset($_SERVER["QUERY_STRING"]) && strrpos($_SERVER["QUERY_STRING"], '?')) {
 				$_SERVER["QUERY_STRING"] = str_replace("?", "&", $_SERVER["QUERY_STRING"]);
 				parse_str($_SERVER["QUERY_STRING"], $request);
 			}


### PR DESCRIPTION
Feel free to merge my request, it fixes annoying notice when new HYBRID_ENDPOINT is spawned.

This issue happens when using XING Provider.