### PR TITLE
Allow setting custom start & done endpoints

### DIFF
--- a/hybridauth/Hybrid/Provider_Adapter.php
+++ b/hybridauth/Hybrid/Provider_Adapter.php
@@ -153,11 +153,15 @@ class Hybrid_Provider_Adapter {
 		# for default HybridAuth endpoint url hauth_login_start_url
 		# 	auth.start  required  the IDp ID
 		# 	auth.time   optional  login request timestamp
-		$this->params["login_start"] = $HYBRID_AUTH_URL_BASE . ( strpos($HYBRID_AUTH_URL_BASE, '?') ? '&' : '?' ) . "hauth.start={$this->id}&hauth.time={$this->params["hauth_time"]}";
+		if (!isset($this->params["login_start"]) ) {
+			$this->params["login_start"] = $HYBRID_AUTH_URL_BASE . ( strpos($HYBRID_AUTH_URL_BASE, '?') ? '&' : '?' ) . "hauth.start={$this->id}&hauth.time={$this->params["hauth_time"]}";
+		}
 
 		# for default HybridAuth endpoint url hauth_login_done_url
 		# 	auth.done   required  the IDp ID
-		$this->params["login_done"] = $HYBRID_AUTH_URL_BASE . ( strpos($HYBRID_AUTH_URL_BASE, '?') ? '&' : '?' ) . "hauth.done={$this->id}";
+		if (!isset($this->params["login_done"]) ) {
+			$this->params["login_done"] = $HYBRID_AUTH_URL_BASE . ( strpos($HYBRID_AUTH_URL_BASE, '?') ? '&' : '?' ) . "hauth.done={$this->id}";
+		}
 
 		if (isset($this->params["hauth_return_to"])) {
 			Hybrid_Auth::storage()->set("hauth_session.{$this->id}.hauth_return_to", $this->params["hauth_return_to"]);


### PR DESCRIPTION
This PR allows setting custom `login_start` and `login_done` params, so that we can set the URL the user is redirected to when starting auth and when being redirected back from the provider. Note - this serves a different purpose than `hauth_return_to`. Let me explain...

Our use case may be a bit different than the majority, but we are migrating a WooCommerce plugin from OpAuth to HybridAuth. OpAuth uses different callback endpoints than HybridAuth. Some providers only allow redirecting back to specific endpoints (urls), even if the domain matches. One such example is Google. If the users of our plugin were to update their plugins to a newer version which uses HybridAuth, then some of their social login buttons would stop working, since the callback url is different from what it used to be. Ideally, we'd like to avoid this situation and give our users some time to update their callback urls without breaking the social logins. For this, we would need to make sure the callback urls match with the previous version. This is why we need a way to customize the actual endpoint URLs. 

This change does not break or change any existing functionality, but will merely allow more advanced use-cases.