### PR TITLE
Set emailVerified for Twitter provider

### DIFF
--- a/hybridauth/Hybrid/Providers/Twitter.php
+++ b/hybridauth/Hybrid/Providers/Twitter.php
@@ -131,7 +131,8 @@ class Hybrid_Providers_Twitter extends Hybrid_Provider_Model_OAuth1 {
 		$this->user->profile->webSiteURL = (property_exists($response, 'url')) ? $response->url : "";
 		$this->user->profile->region = (property_exists($response, 'location')) ? $response->location : "";
 		if($includeEmail) $this->user->profile->email = (property_exists($response, 'email')) ? $response->email : "";
-
+		if($includeEmail) $this->user->profile->emailVerified = (property_exists($response, 'email')) ? $response->email : "";
+		
 		return $this->user->profile;
 	}
 


### PR DESCRIPTION
If an e-mail address is returned by Twitter, it's considered verified as per their documentation of the verify_credentials endpoint.