### PR TITLE
Remove array shorthand constructor from LinkedIn provider

### DIFF
--- a/hybridauth/Hybrid/Providers/LinkedIn.php
+++ b/hybridauth/Hybrid/Providers/LinkedIn.php
@@ -30,7 +30,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 		}
 
 		if (empty($this->config['fields'])) {
-			$this->config['fields'] = [
+			$this->config['fields'] = array(
 				'id',
 				'first-name',
 				'last-name',
@@ -40,7 +40,7 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model {
 				'date-of-birth',
 				'phone-numbers',
 				'summary',
-			];
+			);
 		}
 
 		if (!class_exists('OAuthConsumer', false)) {


### PR DESCRIPTION
Shorthand arrays are PHP 5.4+, however the rest of this lib seems to be aimed for 5.2+, so I've replace the shorthand version with the usual `array()`.