### PR TITLE
Fixed error message delivery

### DIFF
--- a/hybridauth/Hybrid/Provider_Model_OAuth2.php
+++ b/hybridauth/Hybrid/Provider_Model_OAuth2.php
@@ -119,7 +119,7 @@ class Hybrid_Provider_Model_OAuth2 extends Hybrid_Provider_Model {
     try {
       $this->api->authenticate($code);
     } catch (Exception $e) {
-      throw new Exception("User profile request failed! {$this->providerId} returned an error: $e", 6);
+      throw new Exception("User profile request failed! {$this->providerId} returned an error: " . $e->getMessage(), 6);
     }
 
     // check if authenticated


### PR DESCRIPTION
Do not pass whole exception object as a message because it contains execution stack which
is sensitive information.