### PR TITLE
[LinkedIn] Removed unset() which breaks PHP 7.1 compatibility

### DIFF
--- a/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
+++ b/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php
@@ -170,15 +170,6 @@ class LinkedIn {
 	}
 
 	/**
-   * The class destructor.
-   *
-   * Explicitly clears LinkedIn object from memory upon destruction.
-	 */
-  public function __destruct() {
-    unset($this);
-	}
-
-	/**
 	 * Bookmark a job.
 	 *
 	 * Calling this method causes the current user to add a bookmark for the


### PR DESCRIPTION
Fixes:

Fatal error: Cannot unset $this in /var/www/html2/anytimecaring/vendor/hybridauth/hybridauth/hybridauth/Hybrid/thirdparty/LinkedIn/LinkedIn.php on line 178