### PR TITLE
[Facebook] Fix wrong country data

### DIFF
--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -169,7 +169,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
             $regionArr = explode(',', $this->user->profile->region);
             if (count($regionArr) > 1) {
                 $this->user->profile->city = trim($regionArr[0]);
-                $this->user->profile->country = trim($regionArr[1]);
+                $this->user->profile->country = trim(end($regionArr));
             }
         }
 


### PR DESCRIPTION
The region info does not always have the same amount of info. That means
the index $regionArr[1]  is not always the country. I changed it to
fetch the last value of the array wich will most surely be the country.