### PR TITLE
Fix fatal error during Facebook provider initialization (both for composer and non composer installation)

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -73,6 +73,7 @@ class Hybrid_Auth {
 
 		// build some need'd paths
 		$config["path_base"] = realpath(dirname(__FILE__)) . "/";
+		$config["path_vendor"] = realpath(dirname(__FILE__) . "/../../vendor");
 		$config["path_libraries"] = $config["path_base"] . "thirdparty/";
 		$config["path_resources"] = $config["path_base"] . "resources/";
 		$config["path_providers"] = $config["path_base"] . "Providers/";
@@ -353,7 +354,7 @@ class Hybrid_Auth {
 	 */
 	public static function redirect($url, $mode = "PHP") {
 		if(!$mode){
-			$mode = 'PHP';	
+			$mode = 'PHP';
 		}
 		Hybrid_Logger::info("Enter Hybrid_Auth::redirect( $url, $mode )");
 

--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -53,6 +53,14 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 
         $trustForwarded = isset($this->config['trustForwarded']) ? (bool)$this->config['trustForwarded'] : false;
 
+		// If Composer install was executed in the Hybridauth library use that
+		// autoloader.
+		if (file_exists(Hybrid_Auth::$config["path_vendor"] . '/autoload.php')) {
+			require_once Hybrid_Auth::$config["path_vendor"] . '/autoload.php';
+		}
+		else {
+			require_once Hybrid_Auth::$config["path_libraries"] . "Facebook/autoload.php";
+		}
         $this->api = new FacebookSDK([
             'app_id' => $this->config["keys"]["id"],
             'app_secret' => $this->config["keys"]["secret"],
@@ -123,7 +131,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
     function logout() {
         parent::logout();
     }
-    
+
     /**
     * Update user status
     *
@@ -146,7 +154,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 
           // if post on page, get access_token page
       } else {
-          
+
           foreach ($this->getUserPages(true) as $p) {
               if (isset($p['id']) && intval($p['id']) == intval($pageid)) {
                   $access_token = $p['access_token'];

--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -53,14 +53,13 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
 
         $trustForwarded = isset($this->config['trustForwarded']) ? (bool)$this->config['trustForwarded'] : false;
 
-		// If Composer install was executed in the Hybridauth library use that
-		// autoloader.
-		if (file_exists(Hybrid_Auth::$config["path_vendor"] . '/autoload.php')) {
-			require_once Hybrid_Auth::$config["path_vendor"] . '/autoload.php';
-		}
-		else {
-			require_once Hybrid_Auth::$config["path_libraries"] . "Facebook/autoload.php";
-		}
+        // If Composer install was executed in the Hybridauth library use that autoloader.
+        if (file_exists(Hybrid_Auth::$config["path_vendor"] . '/autoload.php')) {
+        	require_once Hybrid_Auth::$config["path_vendor"] . '/autoload.php';
+        }
+        else {
+        	require_once Hybrid_Auth::$config["path_libraries"] . "Facebook/autoload.php";
+        }
         $this->api = new FacebookSDK([
             'app_id' => $this->config["keys"]["id"],
             'app_secret' => $this->config["keys"]["secret"],


### PR DESCRIPTION
PR with fix for #698. Works well in both cases (composer and non-composer installation of Facebook SDK)