### PR TITLE
autoload - Windows & slash forgot?

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -43,7 +43,7 @@ spl_autoload_register(
         // replace the namespace prefix with the base directory, replace namespace
         // separators with directory separators in the relative class name, append
         // with .php
-        $file = $base_dir.str_replace('\\', '/', $relative_class).'.php';
+        $file = $base_dir.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $relative_class).'.php';
 
         // if the file exists, require it
         if (file_exists($file)) {


### PR DESCRIPTION
I added 2 `DIRECTORY_SEPARATOR`'s because:
1. Makes it compatible with windows server
  (I use linux server, but test everything at home with EasyPHPServer on Windows and people might use IIS in general too)
2. I'm not sure if this was a bug or typically windows again, but it seems that `__DIR__ `doesn't have a trailing directory separator, so we have to add one. If this is not the same on linux, the latter case some more coding needs to be done on the first `DIRECTORY_SEPARATOR` not to be doubled for linux