### PR TITLE
Remove php 5.3 from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6


### PR DESCRIPTION
## Summary

`facebook/graph-sdk` requires PHP 5.4, so doesn't make sense to run tests on PHP 5.3

It's from travis-ci logs:
```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - facebook/graph-sdk 5.5.0 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.4 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.3 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.2 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.1 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.0 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - Installation request for facebook/graph-sdk ^5.4 -> satisfiable by facebook/graph-sdk[5.4.0, 5.4.1, 5.4.2, 5.4.3, 5.4.4, 5.5.0].
```