### PR TITLE
Fix Travis CI build (fix phpcs and remove php 5.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/additional-providers/hybridauth-disqus/Providers/Disqus.php
+++ b/additional-providers/hybridauth-disqus/Providers/Disqus.php
@@ -25,7 +25,6 @@ class Hybrid_Providers_Disqus extends Hybrid_Provider_Model_OAuth2
 		$this->api->api_base_url  = "https://disqus.com/api/3.0/";
 		$this->api->authorize_url = "https://disqus.com/api/oauth/2.0/authorize";	   
 		$this->api->token_url     = "https://disqus.com/api/oauth/2.0/access_token/";
-		
 	}
 
 	/**

--- a/additional-providers/hybridauth-draugiem/Providers/Draugiem.php
+++ b/additional-providers/hybridauth-draugiem/Providers/Draugiem.php
@@ -51,7 +51,6 @@ class Hybrid_Providers_Draugiem extends Hybrid_Provider_Model
 
 			$this->user_id = $user['uid'];
 		}
-
 	}
 
    /**
@@ -61,7 +60,6 @@ class Hybrid_Providers_Draugiem extends Hybrid_Provider_Model
 	{
 
 		Hybrid_Auth::redirect($this->api->getLoginUrl($this->endpoint));
-
 	}
  
    /**
@@ -81,7 +79,6 @@ class Hybrid_Providers_Draugiem extends Hybrid_Provider_Model
 		$this->setUserConnected();
 		
 		Hybrid_Auth::storage()->set( "hauth_session.{$this->providerId}.user", $this->user );
-
 	}
 
    /**

--- a/additional-providers/hybridauth-draugiem/thirdparty/Draugiem/DraugiemApi.php
+++ b/additional-providers/hybridauth-draugiem/thirdparty/Draugiem/DraugiemApi.php
@@ -540,7 +540,6 @@ class DraugiemApi {
 	<?php
 			exit;
 		}
-
 	}
 
 

--- a/additional-providers/hybridauth-dribbble/Providers/Dribbble.php
+++ b/additional-providers/hybridauth-dribbble/Providers/Dribbble.php
@@ -24,7 +24,6 @@ class Hybrid_Providers_Dribbble extends Hybrid_Provider_Model_OAuth2
 		$this->api->api_base_url  = "https://api.dribbble.com/v1/";
 		$this->api->authorize_url = "https://dribbble.com/oauth/authorize";	   
 		$this->api->token_url     = "https://dribbble.com/oauth/token";
-		
 	}
 
 	/**

--- a/additional-providers/hybridauth-dropbox/Providers/Dropbox.php
+++ b/additional-providers/hybridauth-dropbox/Providers/Dropbox.php
@@ -24,7 +24,6 @@ class Hybrid_Providers_Dropbox extends Hybrid_Provider_Model_OAuth2
 		$this->api->api_base_url  = "https://api.dropbox.com/1/";
 		$this->api->authorize_url = "https://www.dropbox.com/1/oauth2/authorize";
 		$this->api->token_url     = "https://api.dropbox.com/1/oauth2/token"; 
-
 	}
 
 	/**

--- a/additional-providers/hybridauth-murmur/Providers/Murmur.php
+++ b/additional-providers/hybridauth-murmur/Providers/Murmur.php
@@ -112,7 +112,6 @@ class Hybrid_Providers_Murmur extends Hybrid_Provider_Model_OAuth1
 		}
 		
 		return $contacts;
-		
 	}
 	
 	/**

--- a/additional-providers/hybridauth-pixnet/Providers/Pixnet.php
+++ b/additional-providers/hybridauth-pixnet/Providers/Pixnet.php
@@ -101,7 +101,6 @@ class Hybrid_Providers_Pixnet extends Hybrid_Provider_Model_OAuth1
 		}
 		
 		return $contacts;
-		
 	}
 	
 	/**

--- a/additional-providers/hybridauth-sina/thirdparty/Sina/Sina.php
+++ b/additional-providers/hybridauth-sina/thirdparty/Sina/Sina.php
@@ -223,7 +223,7 @@ class WeiboOAuth {
         $request->sign_request($this->sha1_method, $this->consumer, $this->token); 
         switch ($method) { 
         case 'GET': 
-            //echo $request->to_url(); 
+                //echo $request->to_url(); 
             return $this->http($request->to_url(), 'GET'); 
         default: 
             return $this->http($request->get_normalized_http_url(), $method, $request->to_postdata($multi) , $multi ); 
@@ -251,18 +251,18 @@ class WeiboOAuth {
 
         switch ($method) { 
         case 'POST': 
-            curl_setopt($ci, CURLOPT_POST, TRUE); 
-            if (!empty($postfields)) { 
-                curl_setopt($ci, CURLOPT_POSTFIELDS, $postfields); 
-                //echo "=====post data======\r\n";
-                //echo $postfields;
-            } 
+                curl_setopt($ci, CURLOPT_POST, TRUE); 
+                if (!empty($postfields)) { 
+                    curl_setopt($ci, CURLOPT_POSTFIELDS, $postfields); 
+                    //echo "=====post data======\r\n";
+                    //echo $postfields;
+                    } 
             break; 
         case 'DELETE': 
-            curl_setopt($ci, CURLOPT_CUSTOMREQUEST, 'DELETE'); 
-            if (!empty($postfields)) { 
-                $url = "{$url}?{$postfields}"; 
-            } 
+                curl_setopt($ci, CURLOPT_CUSTOMREQUEST, 'DELETE'); 
+                if (!empty($postfields)) { 
+                    $url = "{$url}?{$postfields}"; 
+                    } 
         } 
 
         $header_array = array(); 
@@ -341,7 +341,6 @@ class WeiboOAuth {
         { 
             return $this->$method($url , $param ); 
         } 
-
     } 
 } 
 ?>

--- a/additional-providers/hybridauth-sina/thirdparty/Sina/saetv2.ex.class.php
+++ b/additional-providers/hybridauth-sina/thirdparty/Sina/saetv2.ex.class.php
@@ -10,7 +10,7 @@
  */
 if (!class_exists('OAuthException', false)) {
   class OAuthException extends Exception {
-    // pass
+        // pass
   }
 }
 
@@ -324,18 +324,18 @@ class SaeTOAuthV2 {
 	}
 
 	switch ($method) {
-		case 'GET':
-			$url = $url . '?' . http_build_query($parameters);
-			return $this->http($url, 'GET');
-		default:
-			$headers = array();
-			if (!$multi && (is_array($parameters) || is_object($parameters)) ) {
-				$body = http_build_query($parameters);
-			} else {
-				$body = self::build_http_query_multi($parameters);
-				$headers[] = "Content-Type: multipart/form-data; boundary=" . self::$boundary;
-			}
-			return $this->http($url, $method, $body, $headers);
+            case 'GET':
+                $url = $url . '?' . http_build_query($parameters);
+                return $this->http($url, 'GET');
+            default:
+                $headers = array();
+                if (!$multi && (is_array($parameters) || is_object($parameters)) ) {
+                    $body = http_build_query($parameters);
+                } else {
+                    $body = self::build_http_query_multi($parameters);
+                    $headers[] = "Content-Type: multipart/form-data; boundary=" . self::$boundary;
+                }
+                return $this->http($url, $method, $body, $headers);
 	}
 	}
 
@@ -1361,7 +1361,6 @@ class SaeTClientV2
 		$params['comment_ori'] = $comment_ori;
 
 		return $this->oauth->post( 'comments/reply', $params );
-
 	}
 
 	/**
@@ -3206,7 +3205,6 @@ class SaeTClientV2
 		}
 
 		return $this->oauth->$method($url, $params );
-
 	}
 
 	/**

--- a/additional-providers/hybridauth-slack/Providers/Slack.php
+++ b/additional-providers/hybridauth-slack/Providers/Slack.php
@@ -25,7 +25,6 @@ class Hybrid_Providers_Slack extends Hybrid_Provider_Model_OAuth2
 		$this->api->authorize_url = "https://slack.com/oauth/authorize";
 		$this->api->token_url     = "https://slack.com/api/oauth.access"; 
 		$this->api->sign_token_name = "token";
-
 	}
 
 	/**

--- a/additional-providers/hybridauth-stackexchange/Providers/StackExchange.php
+++ b/additional-providers/hybridauth-stackexchange/Providers/StackExchange.php
@@ -19,14 +19,13 @@ class Hybrid_Providers_StackExchange extends Hybrid_Provider_Model_OAuth2
   */
   function initialize() 
   {
-    $this->compressed = true;
-    parent::initialize();
+        $this->compressed = true;
+        parent::initialize();
     
-    // Provider api end-points
-    $this->api->api_base_url  = "https://api.stackexchange.com/2.2/";
-    $this->api->authorize_url = "https://stackexchange.com/oauth";     
-    $this->api->token_url     = "https://stackexchange.com/oauth/access_token";
-    
+        // Provider api end-points
+        $this->api->api_base_url  = "https://api.stackexchange.com/2.2/";
+        $this->api->authorize_url = "https://stackexchange.com/oauth";     
+        $this->api->token_url     = "https://stackexchange.com/oauth/access_token";
   }
 
   /**
@@ -34,35 +33,35 @@ class Hybrid_Providers_StackExchange extends Hybrid_Provider_Model_OAuth2
   */
   function getUserProfile()
   {
-    // refresh tokens if needed 
-    $this->refreshToken();
-    try{
-      $response = $this->api->get( "me" , array('key' => $this->config['keys']['key'], 'site' => $this->config['site']));
-    }
-    catch(StackExchange $e){
-      throw new Exception( "User profile request failed! {$this->providerId} returned an error: $e", 6 );
-    }
-    // check the last HTTP status code returned
-    if ($this->api->http_code != 200){
-      throw new Exception( "User profile request failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 6 );
-    }
-    if (!is_object($response)){
-      throw new Exception( "User profile request failed! {$this->providerId} api returned an invalid response.", 6 );
-    }
-    //
-    $data = $response->items[0];
+        // refresh tokens if needed 
+        $this->refreshToken();
+        try{
+            $response = $this->api->get( "me" , array('key' => $this->config['keys']['key'], 'site' => $this->config['site']));
+            }
+        catch(StackExchange $e){
+            throw new Exception( "User profile request failed! {$this->providerId} returned an error: $e", 6 );
+            }
+        // check the last HTTP status code returned
+        if ($this->api->http_code != 200){
+            throw new Exception( "User profile request failed! {$this->providerId} returned an error. " . $this->errorMessageByStatus( $this->api->http_code ), 6 );
+            }
+        if (!is_object($response)){
+            throw new Exception( "User profile request failed! {$this->providerId} api returned an invalid response.", 6 );
+            }
+        //
+        $data = $response->items[0];
     
-    if (!isset($data->account_id)){
-      throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
-    }
+        if (!isset($data->account_id)){
+            throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
+            }
 
-    $this->user->profile->identifier  = @ $data->account_id; 
-    $this->user->profile->displayName = @ $data->display_name;
-    $this->user->profile->photoURL    = @ $data->profile_image;
-    $this->user->profile->profileURL  = @ $data->link; 
-    $this->user->profile->region      = @ $data->location;
-    $this->user->profile->age         = @ $data->age;
+        $this->user->profile->identifier  = @ $data->account_id; 
+        $this->user->profile->displayName = @ $data->display_name;
+        $this->user->profile->photoURL    = @ $data->profile_image;
+        $this->user->profile->profileURL  = @ $data->link; 
+        $this->user->profile->region      = @ $data->location;
+        $this->user->profile->age         = @ $data->age;
 
-    return $this->user->profile;
+        return $this->user->profile;
   }
 }

--- a/additional-providers/hybridauth-steam/Providers/Steam.php
+++ b/additional-providers/hybridauth-steam/Providers/Steam.php
@@ -76,7 +76,7 @@ class Hybrid_Providers_Steam extends Hybrid_Provider_Model_OpenID
       			$this->user->profile->profileURL = 'http://steamcommunity.com/id/' . (string) $data->customURL . '/';
     		}
     		else {
-      			$this->user->profile->profileURL = "http://steamcommunity.com/profiles/{$this->user->profile->identifier}/";
+            $this->user->profile->profileURL = "http://steamcommunity.com/profiles/{$this->user->profile->identifier}/";
     		}
 		
 		$this->user->profile->webSiteURL		=	"";
@@ -99,6 +99,5 @@ class Hybrid_Providers_Steam extends Hybrid_Provider_Model_OpenID
 		$this->user->profile->region			=	property_exists($data, 'location') ? (string)$data->location : '';
 		$this->user->profile->city				=	"";
 		$this->user->profile->zip				=	"";
-
     }
 }

--- a/additional-providers/hybridauth-strava/Providers/strava.php
+++ b/additional-providers/hybridauth-strava/Providers/strava.php
@@ -19,7 +19,6 @@ class Hybrid_Providers_Strava extends Hybrid_Provider_Model_OAuth2
 		$this->api->api_base_url  = "https://www.strava.com/api/v3/";
 		$this->api->authorize_url = "https://www.strava.com/oauth/authorize";	   
 		$this->api->token_url     = "https://www.strava.com/oauth/token";
-		
 	}
 
 	/**

--- a/additional-providers/hybridauth-stripe/Providers/Stripe.php
+++ b/additional-providers/hybridauth-stripe/Providers/Stripe.php
@@ -233,6 +233,7 @@ class Hybrid_Providers_Stripe extends Hybrid_Provider_Model_OAuth2 {
 
     // Constant not defined in PHP < 5.5.
     if (!defined('CURL_SSLVERSION_TLSv1')) {
+      // @codingStandardsIgnoreLine
       define('CURL_SSLVERSION_TLSv1', 1);
     }
 

--- a/additional-providers/hybridauth-wordpress/Providers/WordPress.php
+++ b/additional-providers/hybridauth-wordpress/Providers/WordPress.php
@@ -24,7 +24,6 @@ class Hybrid_Providers_WordPress extends Hybrid_Provider_Model_OAuth2
 		$this->api->api_base_url  = "https://public-api.wordpress.com/rest/v1/";
 		$this->api->authorize_url = "https://public-api.wordpress.com/oauth2/authorize";	   
 		$this->api->token_url     = "https://public-api.wordpress.com/oauth2/token";
-		
 	}
 
 	/**

--- a/additional-providers/hybridauth-xuite/Providers/Xuite.php
+++ b/additional-providers/hybridauth-xuite/Providers/Xuite.php
@@ -32,7 +32,6 @@ class Hybrid_Providers_Xuite extends Hybrid_Provider_Model_OAuth2
 		$this->api->token_url     = 'https://my.xuite.net/service/account/token.php';
 
 		$this->api->curl_authenticate_method  = "GET";
-
 	}
 
 	function xuite_api_param($config,$param) {
@@ -47,7 +46,6 @@ class Hybrid_Providers_Xuite extends Hybrid_Provider_Model_OAuth2
 		$api_sig = md5($token);
 		$url_get_str = sprintf("?api_sig=%s&%s",$api_sig,http_build_query($param, '', '&'));
 		return $url_get_str;
-
 	}
 	
 	// 無法使用原生的 api->api 是因為會多加上 access_token 參數, 而 xuite 要自己組
@@ -58,7 +56,7 @@ class Hybrid_Providers_Xuite extends Hybrid_Provider_Model_OAuth2
     Hybrid_Logger::debug( "OAuth2Client::xuite_request(). dump request params: ", print_r( $params , true) );
 
     if( $type == "GET" ){
-      $url = $url . ( strpos( $url, '?' ) ? '&' : '?' ) . http_build_query($params, '', '&');
+              $url = $url . ( strpos( $url, '?' ) ? '&' : '?' ) . http_build_query($params, '', '&');
     }
 
     $this->http_info = array();
@@ -77,17 +75,17 @@ class Hybrid_Providers_Xuite extends Hybrid_Provider_Model_OAuth2
     curl_setopt($ch, CURLOPT_HTTPHEADER     , $this->curl_header );
 
     if($this->curl_proxy){
-      curl_setopt( $ch, CURLOPT_PROXY        , $this->curl_proxy);
+              curl_setopt( $ch, CURLOPT_PROXY        , $this->curl_proxy);
     }
 
     if( $type == "POST" ){
-      curl_setopt($ch, CURLOPT_POST, 1);
-      if($params) curl_setopt( $ch, CURLOPT_POSTFIELDS, $params );
+              curl_setopt($ch, CURLOPT_POST, 1);
+              if($params) curl_setopt( $ch, CURLOPT_POSTFIELDS, $params );
     }
 
     $response = curl_exec($ch);
     if( $response === FALSE ) {
-        Hybrid_Logger::error( "OAuth2Client::request(). curl_exec error: ", curl_error($ch) );
+            Hybrid_Logger::error( "OAuth2Client::request(). curl_exec error: ", curl_error($ch) );
     }
     Hybrid_Logger::debug( "OAuth2Client::request(). dump request info: ", serialize( curl_getinfo($ch) ) );
     //happyman


### PR DESCRIPTION
## Goal

Now, every Travis CI build to branch v2 failed, because of wrong coding standards in some files and not supported php 5.3 by facebook/graph-sdk.

## Description

1. This PR fixes Coding Standards by running:
`phpcbf --standard=phpcs.xml additional-providers hybridauth`

2. This PR fixes an error with `facebook/graph-sdk requires PHP 5.4`
It's from travis-ci logs:
```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - facebook/graph-sdk 5.5.0 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.4 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.3 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.2 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.1 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - facebook/graph-sdk 5.4.0 requires php ^5.4|^7.0 -> your PHP version (5.3.29) does not satisfy that requirement.
    - Installation request for facebook/graph-sdk ^5.4 -> satisfiable by facebook/graph-sdk[5.4.0, 5.4.1, 5.4.2, 5.4.3, 5.4.4, 5.5.0].
```
