### PR TITLE
[Stripe] Add optional stripe_landing auth parameter

### DIFF
--- a/additional-providers/hybridauth-stripe/Providers/Stripe.php
+++ b/additional-providers/hybridauth-stripe/Providers/Stripe.php
@@ -52,6 +52,7 @@ class Hybrid_Providers_Stripe extends Hybrid_Provider_Model_OAuth2 {
       "scope",
       "access_type",
       "redirect_uri",
+      "stripe_landing",
     );
 
     foreach ($optionals as $parameter) {


### PR DESCRIPTION
## Goal

For Stripe it's possible to define what type of auth window to show initially - login or register.
Currently Hybridauth library does not allow to pass such parameter.

## Description

Add support of stripe_landing option for Stripe oauth callback.
See Stripe API for details (search by 'stripe_landing' word):
https://stripe.com/docs/connect/reference
