### PR TITLE
[Steam] Fix broken authorization

### DIFF
--- a/additional-providers/hybridauth-steam/Providers/Steam.php
+++ b/additional-providers/hybridauth-steam/Providers/Steam.php
@@ -63,8 +63,13 @@ class Hybrid_Providers_Steam extends Hybrid_Provider_Model_OpenID
     {
         $apiUrl = 'http://steamcommunity.com/profiles/' . $this->user->profile->identifier . '/?xml=1';
 
-        $data = @file_get_contents($apiUrl);
-        $data = @ new SimpleXMLElement($data);
+	try {
+            $data = @file_get_contents($apiUrl);
+            $data = @ new SimpleXMLElement($data);
+	} catch(Exception $e) {
+	    Hybrid_Logger::error( "Steam::getUserProfileLegacyAPI() error: ", $e->getMessage());
+	    return false;
+	}
 
         if (!is_object($data)) {
             return false;


### PR DESCRIPTION

## Summary

* Addition

- [x] Tested

## Goal

Prevent broken authorization

## Description

Steam responds with HTTP/500 instead of xml from time to time, so we should handle exceptions thrown in SimpleXML to prevent broken authorization
