### PR TITLE
Add vendor folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/.idea
-/hybridauth/config.php
+.idea
+hybridauth/config.php
+vendor
 /examples/signin_signup/application.config.php
 /nbproject/
 /.imdone/config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.idea
-hybridauth/config.php
-vendor
+/.idea
+/vendor
+/hybridauth/config.php
 /examples/signin_signup/application.config.php
 /nbproject/
 /.imdone/config.json


### PR DESCRIPTION
## Summary
* Addition

## Goal

It was strange for me why `vendor` folder was not ignored in git. It doesn't make sense to have all `vendor` libraries in git.

## Description

Add `vendor` folder to `.gitignore`.
