### PR TITLE
[Documentation] Fix disqus widget and issue with http / https

### DIFF
--- a/apidoc.html
+++ b/apidoc.html
@@ -562,12 +562,12 @@ echo $twitter_user_profile-&gt;profileURL;
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
         var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
         var disqus_identifier = 'apidoc';
-        var disqus_url = 'http://hybridauth.sourceforge.net/apidoc.html';
+        var disqus_url = 'https://hybridauth.github.io/hybridauth/apidoc.html';
 
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
           var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+          dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
           (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
         </script>
@@ -583,6 +583,6 @@ echo $twitter_user_profile-&gt;profileURL;
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/apidoc.html
+++ b/apidoc.html
@@ -7,7 +7,7 @@
   <title>HybridAuth API Documentation</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/apidoc.html
+++ b/apidoc.html
@@ -7,7 +7,7 @@
   <title>HybridAuth API Documentation</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -3,7 +3,7 @@ $(function () {
 
 	gr = [ 'white_ffffff', 'red_aa0000', 'green_007200', 'darkblue_121621', 'orange_ff7600', 'gray_6d6d6d' ]
 
-	$('nav').append( "<a class='hidden-xs' href='https://github.com/hybridauth/hybridauth'><img id='ribbon' alt='Fork me on GitHub' style='position: fixed; top: 0px; right: 0pt; z-index: 2; border: 0pt none; margin: 0; padding: 0;' src='http://s3.amazonaws.com/github/ribbons/forkme_right_" + gr[ 1 ]+ ".png' /></a>" )
+	$('nav').append( "<a class='hidden-xs' href='https://github.com/hybridauth/hybridauth'><img id='ribbon' alt='Fork me on GitHub' style='position: fixed; top: 0px; right: 0pt; z-index: 2; border: 0pt none; margin: 0; padding: 0;' src='https://s3.amazonaws.com/github/ribbons/forkme_right_" + gr[ 1 ]+ ".png' /></a>" )
 
   //$('.nav').after( '<ul class="nav secondary-nav"><form action="http://hybridauth.sourceforge.net/search.html" method="get"><input type="text" name="q" placeholder="Search" /></form></ul>' )
 

--- a/google-group.html
+++ b/google-group.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Help & Support</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">
@@ -80,6 +80,6 @@
 	</div>
 
 </div> <!-- /container -->
- 
+
 </body>
 </html>

--- a/google-group.html
+++ b/google-group.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Help & Support</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>HybridAuth, Open Source Social Sign On PHP Library</title>
 
   <!--[if lt IE 9]>
-    <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
 	<link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>HybridAuth, Open Source Social Sign On PHP Library</title>
 
   <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
 	<link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">
@@ -81,7 +81,7 @@
 					<a class="addthis_button_favorites"></a>
 					<a class="addthis_button_compact"></a>
 					</div>
-					<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid=ra-4eb971af501a445f"></script>
+					<script type="text/javascript" src="https://s7.addthis.com/js/250/addthis_widget.js#pubid=ra-4eb971af501a445f"></script>
 					<!-- AddThis Button END -->
 				</div>
 

--- a/licenses.html
+++ b/licenses.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Licenses</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/licenses.html
+++ b/licenses.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Licenses</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/plugins.html
+++ b/plugins.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Plugins</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/plugins.html
+++ b/plugins.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Plugins</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/plugins.html
+++ b/plugins.html
@@ -308,12 +308,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'plugins';
-						var disqus_url = 'http://hybridauth.sourceforge.net/plugins.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/plugins.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>

--- a/roadmap.html
+++ b/roadmap.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Roadmap</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">
@@ -61,7 +61,7 @@
         <div class="col-md-12">
           <h2>v2.x.x</h2>
           <p>In maintainance mode.</p>
-          
+
           <h2><a href="https://github.com/hybridauth/hybridauth/tree/3.0.0-Remake" target="_blank">v3.0.0</a></h2>
           <ul>
             <li>

--- a/roadmap.html
+++ b/roadmap.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Roadmap</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/search.html
+++ b/search.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Search</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">
@@ -60,7 +60,7 @@
       <div class="row">
         <div class="col-md-12">
           <div id="cse" style="width: 100%;text-align:center;">Loading Google CSE..</div>
-          <script src="http://www.google.com/jsapi" type="text/javascript"></script>
+          <script src="https://www.google.com/jsapi" type="text/javascript"></script>
           <script type="text/javascript">
             google.load('search', '1', {language : 'en'});
             google.setOnLoadCallback(function() {
@@ -94,7 +94,7 @@
               }
             }, true);
           </script>
-          <link rel="stylesheet" href="http://www.google.com/cse/style/look/default.css" type="text/css" />
+          <link rel="stylesheet" href="https://www.google.com/cse/style/look/default.css" type="text/css" />
           <style type="text/css">
             .gsc-control-cse {
               font-family: Arial, sans-serif;
@@ -239,6 +239,6 @@
     </div>
   </div>
 </div> <!-- /container -->
- 
+
 </body>
 </html>

--- a/search.html
+++ b/search.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Search</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/support.html
+++ b/support.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Help & Support</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">
@@ -89,6 +89,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Help & Support</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/userguide.html
+++ b/userguide.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Userguide</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/userguide.html
+++ b/userguide.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Userguide</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="assets/css/bootstrap.min.css">

--- a/userguide.html
+++ b/userguide.html
@@ -257,12 +257,12 @@
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
         var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
         var disqus_identifier = 'userguide';
-        var disqus_url = 'http://hybridauth.sourceforge.net/userguide.html';
+        var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide.html';
 
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
           var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+          dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
           (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
         </script>

--- a/userguide/Access_IDps_APIs.html
+++ b/userguide/Access_IDps_APIs.html
@@ -121,12 +121,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Access_IDps_APIs';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Access_IDps_APIs.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Access_IDps_APIs.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -142,6 +142,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Access_IDps_APIs.html
+++ b/userguide/Access_IDps_APIs.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Social networks APIs</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Access_IDps_APIs.html
+++ b/userguide/Access_IDps_APIs.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Social networks APIs</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Configuration.html
+++ b/userguide/Configuration.html
@@ -179,12 +179,12 @@ $hybridauth = new Hybrid_Auth( $config );
         /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
         var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
         var disqus_identifier = 'Configuration';
-        var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Configuration.html';
+        var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Configuration.html';
 
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
           var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-          dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+          dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
           (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
         </script>
@@ -200,6 +200,6 @@ $hybridauth = new Hybrid_Auth( $config );
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Configuration.html
+++ b/userguide/Configuration.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Overview</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Configuration.html
+++ b/userguide/Configuration.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Overview</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Debugging_and_Logging.html
+++ b/userguide/Debugging_and_Logging.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Debugging and Logging</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -94,6 +94,6 @@ array(
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Debugging_and_Logging.html
+++ b/userguide/Debugging_and_Logging.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Debugging and Logging</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Errors_and_Exceptions_Handling.html
+++ b/userguide/Errors_and_Exceptions_Handling.html
@@ -118,12 +118,12 @@ Ooophs, we got an error: User profile request failed! User not connected to Twit
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Errors_and_Exceptions_Handling';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Errors_and_Exceptions_Handling.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Errors_and_Exceptions_Handling.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -139,6 +139,6 @@ Ooophs, we got an error: User profile request failed! User not connected to Twit
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Errors_and_Exceptions_Handling.html
+++ b/userguide/Errors_and_Exceptions_Handling.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Errors and Exception Handling</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Errors_and_Exceptions_Handling.html
+++ b/userguide/Errors_and_Exceptions_Handling.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Errors and Exception Handling</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Examples_and_Demos.html
+++ b/userguide/Examples_and_Demos.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Examples and Demos</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Examples_and_Demos.html
+++ b/userguide/Examples_and_Demos.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Examples and Demos</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -119,6 +119,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Extend_New_Provider.html
+++ b/userguide/Extend_New_Provider.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Extending HybridAuth</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -175,6 +175,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Extend_New_Provider.html
+++ b/userguide/Extend_New_Provider.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Extending HybridAuth</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/HybridAuth_Sessions.html
+++ b/userguide/HybridAuth_Sessions.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Sessions</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/HybridAuth_Sessions.html
+++ b/userguide/HybridAuth_Sessions.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Sessions</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/HybridAuth_Sessions.html
+++ b/userguide/HybridAuth_Sessions.html
@@ -189,12 +189,12 @@ CREATE TABLE `users_connections` (
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'HybridAuth_Sessions';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/HybridAuth_Sessions.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/HybridAuth_Sessions.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -210,6 +210,6 @@ CREATE TABLE `users_connections` (
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/HybridAuth_endpoint_URL.html
+++ b/userguide/HybridAuth_endpoint_URL.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Endpoint URL</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/HybridAuth_endpoint_URL.html
+++ b/userguide/HybridAuth_endpoint_URL.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Endpoint URL</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -93,6 +93,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_500px.html
+++ b/userguide/IDProvider_info_500px.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - 500px Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_500px.html
+++ b/userguide/IDProvider_info_500px.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - 500px Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -98,6 +98,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_AOL.html
+++ b/userguide/IDProvider_info_AOL.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - AOL Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -127,6 +127,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_AOL.html
+++ b/userguide/IDProvider_info_AOL.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - AOL Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Discord.html
+++ b/userguide/IDProvider_info_Discord.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Discord Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -129,6 +129,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Discord.html
+++ b/userguide/IDProvider_info_Discord.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Discord Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Dribbble.html
+++ b/userguide/IDProvider_info_Dribbble.html
@@ -111,12 +111,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Dribbble';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Dribbble.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Dribbble.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -132,6 +132,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Dribbble.html
+++ b/userguide/IDProvider_info_Dribbble.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Dribbble Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Dribbble.html
+++ b/userguide/IDProvider_info_Dribbble.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Dribbble Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Facebook.html
+++ b/userguide/IDProvider_info_Facebook.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Facebook Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Facebook.html
+++ b/userguide/IDProvider_info_Facebook.html
@@ -219,12 +219,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Facebook';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Facebook.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Facebook.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>

--- a/userguide/IDProvider_info_Facebook.html
+++ b/userguide/IDProvider_info_Facebook.html
@@ -7,10 +7,10 @@
   <title>HybridAuth - Facebook Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+  <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
   <link rel="stylesheet" type="text/css" href="../assets/css/prettify.css">
   <link rel="stylesheet" type="text/css" href="../assets/css/css.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
@@ -201,9 +201,9 @@
           </ol>
   				<hr />
   				<div style="display: flex;">
-  					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/facebook/1.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/facebook/1.png" class="span4 thumbnail"></a>
-  					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/facebook/2.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/facebook/2.png" class="span4 thumbnail"></a>
-  					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/facebook/3.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/facebook/3.png" class="span4 thumbnail"></a>
+  					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/facebook/1.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/facebook/1.png" class="span4 thumbnail"></a>
+  					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/facebook/2.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/facebook/2.png" class="span4 thumbnail"></a>
+  					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/facebook/3.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/facebook/3.png" class="span4 thumbnail"></a>
   				</div>
 			</div>
     </div>

--- a/userguide/IDProvider_info_FamilySearch.html
+++ b/userguide/IDProvider_info_FamilySearch.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - FamilySearch Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_FamilySearch.html
+++ b/userguide/IDProvider_info_FamilySearch.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - FamilySearch Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -101,6 +101,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Foursquare.html
+++ b/userguide/IDProvider_info_Foursquare.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Foursquare Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Foursquare.html
+++ b/userguide/IDProvider_info_Foursquare.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Foursquare Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Foursquare.html
+++ b/userguide/IDProvider_info_Foursquare.html
@@ -119,12 +119,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Foursquare';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Foursquare.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Foursquare.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -140,6 +140,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Geni.html
+++ b/userguide/IDProvider_info_Geni.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Geni Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Geni.html
+++ b/userguide/IDProvider_info_Geni.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Geni Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -102,6 +102,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Github.html
+++ b/userguide/IDProvider_info_Github.html
@@ -111,12 +111,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Github';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Github.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Github.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -132,6 +132,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Github.html
+++ b/userguide/IDProvider_info_Github.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Github Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Github.html
+++ b/userguide/IDProvider_info_Github.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Github Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Goodreads.html
+++ b/userguide/IDProvider_info_Goodreads.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Goodreads Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -126,6 +126,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Goodreads.html
+++ b/userguide/IDProvider_info_Goodreads.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Goodreads Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Google.html
+++ b/userguide/IDProvider_info_Google.html
@@ -197,12 +197,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Google';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Google.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Google.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -218,6 +218,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Google.html
+++ b/userguide/IDProvider_info_Google.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Google Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -179,9 +179,9 @@
 
 				<hr />
 				<div style="display: flex;">
-					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/google/1.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/google/1.png" class="span4 thumbnail"></a>
-					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/google/2.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/google/2.png" class="span4 thumbnail"></a>
-					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/google/3.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/google/3.png" class="span4 thumbnail"></a>
+					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/google/1.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/google/1.png" class="span4 thumbnail"></a>
+					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/google/2.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/google/2.png" class="span4 thumbnail"></a>
+					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/google/3.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/google/3.png" class="span4 thumbnail"></a>
 				</div>
 			</div>
     </div>

--- a/userguide/IDProvider_info_Google.html
+++ b/userguide/IDProvider_info_Google.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Google Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Identica.html
+++ b/userguide/IDProvider_info_Identica.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Identica Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -128,6 +128,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Identica.html
+++ b/userguide/IDProvider_info_Identica.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Identica Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_IdqOAuth2.html
+++ b/userguide/IDProvider_info_IdqOAuth2.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - idQ Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_IdqOAuth2.html
+++ b/userguide/IDProvider_info_IdqOAuth2.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - idQ Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Instagram.html
+++ b/userguide/IDProvider_info_Instagram.html
@@ -109,12 +109,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Instagram';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Instagram.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Instagram.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -130,6 +130,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Instagram.html
+++ b/userguide/IDProvider_info_Instagram.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Instagram Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Instagram.html
+++ b/userguide/IDProvider_info_Instagram.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Instagram Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_LastFM.html
+++ b/userguide/IDProvider_info_LastFM.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - LastFM Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_LastFM.html
+++ b/userguide/IDProvider_info_LastFM.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - LastFM Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -130,6 +130,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_LinkedIn.html
+++ b/userguide/IDProvider_info_LinkedIn.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - LinkedIn Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_LinkedIn.html
+++ b/userguide/IDProvider_info_LinkedIn.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - LinkedIn Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -158,6 +158,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Live.html
+++ b/userguide/IDProvider_info_Live.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Windows Live Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Live.html
+++ b/userguide/IDProvider_info_Live.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Windows Live Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Live.html
+++ b/userguide/IDProvider_info_Live.html
@@ -117,12 +117,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Live';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Live.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Live.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -138,6 +138,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Mailru.html
+++ b/userguide/IDProvider_info_Mailru.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Mail.ru Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -91,6 +91,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Mailru.html
+++ b/userguide/IDProvider_info_Mailru.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Mail.ru Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Murmur.html
+++ b/userguide/IDProvider_info_Murmur.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Murmur Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -106,6 +106,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Murmur.html
+++ b/userguide/IDProvider_info_Murmur.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Murmur Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_MyHeritage.html
+++ b/userguide/IDProvider_info_MyHeritage.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - MyHeritage Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_MyHeritage.html
+++ b/userguide/IDProvider_info_MyHeritage.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - MyHeritage Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -102,6 +102,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Odnoklassniki.html
+++ b/userguide/IDProvider_info_Odnoklassniki.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Odnoklassniki Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Odnoklassniki.html
+++ b/userguide/IDProvider_info_Odnoklassniki.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Odnoklassniki Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -91,6 +91,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_OpenID.html
+++ b/userguide/IDProvider_info_OpenID.html
@@ -161,12 +161,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_OpenID';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_OpenID.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_OpenID.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -182,6 +182,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_OpenID.html
+++ b/userguide/IDProvider_info_OpenID.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - OpenID</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_OpenID.html
+++ b/userguide/IDProvider_info_OpenID.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - OpenID</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Pixnet.html
+++ b/userguide/IDProvider_info_Pixnet.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Pixnet Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Pixnet.html
+++ b/userguide/IDProvider_info_Pixnet.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Pixnet Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -104,6 +104,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Plurk.html
+++ b/userguide/IDProvider_info_Plurk.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Plurk Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Plurk.html
+++ b/userguide/IDProvider_info_Plurk.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Plurk Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -104,6 +104,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_QQ.html
+++ b/userguide/IDProvider_info_QQ.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - QQ Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -104,6 +104,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_QQ.html
+++ b/userguide/IDProvider_info_QQ.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - QQ Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Sina.html
+++ b/userguide/IDProvider_info_Sina.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Sina Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Sina.html
+++ b/userguide/IDProvider_info_Sina.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Sina Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -104,7 +104,7 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>
 

--- a/userguide/IDProvider_info_Skyrock.html
+++ b/userguide/IDProvider_info_Skyrock.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Skyrock Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Skyrock.html
+++ b/userguide/IDProvider_info_Skyrock.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Skyrock Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -96,6 +96,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Steam.html
+++ b/userguide/IDProvider_info_Steam.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Steam Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Steam.html
+++ b/userguide/IDProvider_info_Steam.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Steam Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Steam.html
+++ b/userguide/IDProvider_info_Steam.html
@@ -95,12 +95,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Steam';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Steam.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Steam.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -116,6 +116,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Stripe.html
+++ b/userguide/IDProvider_info_Stripe.html
@@ -7,7 +7,7 @@
     <title>HybridAuth - Stripe Authentication</title>
 
     <!--[if lt IE 9]>
-    <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
     <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Stripe.html
+++ b/userguide/IDProvider_info_Stripe.html
@@ -7,7 +7,7 @@
     <title>HybridAuth - Stripe Authentication</title>
 
     <!--[if lt IE 9]>
-    <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
 
     <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Tumblr.html
+++ b/userguide/IDProvider_info_Tumblr.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Tumblr Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -127,6 +127,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Tumblr.html
+++ b/userguide/IDProvider_info_Tumblr.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Tumblr Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_TwitchTV.html
+++ b/userguide/IDProvider_info_TwitchTV.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - TwitchTV Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_TwitchTV.html
+++ b/userguide/IDProvider_info_TwitchTV.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - TwitchTV Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_TwitchTV.html
+++ b/userguide/IDProvider_info_TwitchTV.html
@@ -108,12 +108,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_TwitchTV';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_TwitchTV.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_TwitchTV.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -129,6 +129,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Twitter.html
+++ b/userguide/IDProvider_info_Twitter.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Twitter Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Twitter.html
+++ b/userguide/IDProvider_info_Twitter.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Twitter Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -129,9 +129,9 @@
 
 				<hr />
 				<div style="display: flex;">
-					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/twitter/1.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/twitter/1.png" class="span4 thumbnail"></a>
-					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/twitter/2.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/twitter/2.png" class="span4 thumbnail"></a>
-					<a href="http://hybridauth.sourceforge.net/userguide/img/setup/twitter/3.png"><img src="http://hybridauth.sourceforge.net/userguide/img/setup/twitter/3.png" class="span4 thumbnail"></a>
+					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/twitter/1.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/twitter/1.png" class="span4 thumbnail"></a>
+					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/twitter/2.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/twitter/2.png" class="span4 thumbnail"></a>
+					<a href="https://hybridauth.github.io/hybridauth/userguide/img/setup/twitter/3.png"><img src="https://hybridauth.github.io/hybridauth/userguide/img/setup/twitter/3.png" class="span4 thumbnail"></a>
 				</div>
 
 			</div>

--- a/userguide/IDProvider_info_Twitter.html
+++ b/userguide/IDProvider_info_Twitter.html
@@ -148,12 +148,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'IDProvider_info_Twitter';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Twitter.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Twitter.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -169,6 +169,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Vimeo.html
+++ b/userguide/IDProvider_info_Vimeo.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Vimeo Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -137,6 +137,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Vimeo.html
+++ b/userguide/IDProvider_info_Vimeo.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Vimeo Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Vkontakte.html
+++ b/userguide/IDProvider_info_Vkontakte.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Vkontakte Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Vkontakte.html
+++ b/userguide/IDProvider_info_Vkontakte.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Vkontakte Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -96,6 +96,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Yahoo.html
+++ b/userguide/IDProvider_info_Yahoo.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Yahoo Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Yahoo.html
+++ b/userguide/IDProvider_info_Yahoo.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Yahoo Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/IDProvider_info_Yahoo.html
+++ b/userguide/IDProvider_info_Yahoo.html
@@ -188,14 +188,14 @@
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
             var disqus_identifier = 'IDProvider_info_Yahoo';
-            var disqus_url = 'http://hybridauth.sourceforge.net/userguide/IDProvider_info_Yahoo.html';
+            var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Yahoo.html';
 
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function () {
               var dsq = document.createElement('script');
               dsq.type = 'text/javascript';
               dsq.async = true;
-              dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+              dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
               (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
           </script>

--- a/userguide/IDProvider_info_Yandex.html
+++ b/userguide/IDProvider_info_Yandex.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Yandex Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -91,6 +91,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/IDProvider_info_Yandex.html
+++ b/userguide/IDProvider_info_Yandex.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Yandex Authentication</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Integrating_HybridAuth_SignIn.html
+++ b/userguide/Integrating_HybridAuth_SignIn.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Simple Sign-In script</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Integrating_HybridAuth_SignIn.html
+++ b/userguide/Integrating_HybridAuth_SignIn.html
@@ -239,12 +239,12 @@ To authentificate a user with Twitter all what we have to do here is the first s
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Integrating_HybridAuth_SignIn';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Integrating_HybridAuth_SignIn.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Integrating_HybridAuth_SignIn.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -260,6 +260,6 @@ To authentificate a user with Twitter all what we have to do here is the first s
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Integrating_HybridAuth_SignIn.html
+++ b/userguide/Integrating_HybridAuth_SignIn.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Simple Sign-In script</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Integrating_HybridAuth_Social_Login.html
+++ b/userguide/Integrating_HybridAuth_Social_Login.html
@@ -312,12 +312,12 @@ function create_new_hybridauth_user( $email, $first_name, $last_name, $provider_
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Integrating_HybridAuth_Social_Login';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Integrating_HybridAuth_Social_Login.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Integrating_HybridAuth_Social_Login.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -333,6 +333,6 @@ function create_new_hybridauth_user( $email, $first_name, $last_name, $provider_
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Integrating_HybridAuth_Social_Login.html
+++ b/userguide/Integrating_HybridAuth_Social_Login.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Simple Sign-In Script</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Integrating_HybridAuth_Social_Login.html
+++ b/userguide/Integrating_HybridAuth_Social_Login.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Simple Sign-In Script</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Integrating_OpenID_Providers.html
+++ b/userguide/Integrating_OpenID_Providers.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Other OpenID providers</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -106,6 +106,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Integrating_OpenID_Providers.html
+++ b/userguide/Integrating_OpenID_Providers.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Other OpenID providers</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/OpenID_Relying_Party_Discovery.html
+++ b/userguide/OpenID_Relying_Party_Discovery.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - OpenID and Relying Party Discovery</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/OpenID_Relying_Party_Discovery.html
+++ b/userguide/OpenID_Relying_Party_Discovery.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - OpenID and Relying Party Discovery</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -145,6 +145,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Overview.html
+++ b/userguide/Overview.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Overview</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">
@@ -111,6 +111,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Overview.html
+++ b/userguide/Overview.html
@@ -7,7 +7,7 @@
   <title>HybridAuth Overview</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Plugin_Elgg_Social_Login.html
+++ b/userguide/Plugin_Elgg_Social_Login.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Ellg Social Login</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Plugin_Elgg_Social_Login.html
+++ b/userguide/Plugin_Elgg_Social_Login.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Ellg Social Login</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Plugin_WordPress_Social_Login.html
+++ b/userguide/Plugin_WordPress_Social_Login.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <script type="text/javascript">
-function redirect(){ window.top.location.href="http://hybridauth.sourceforge.net/wsl/index.html"; }
+function redirect(){ window.top.location.href="https://hybridauth.github.io/hybridauth/wsl/index.html"; }
 </script>
 </head>
 <body onload="redirect()">

--- a/userguide/Profile_Data_User_Activity.html
+++ b/userguide/Profile_Data_User_Activity.html
@@ -168,12 +168,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Profile_Data_User_Activity';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Activity.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Profile_Data_User_Activity.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -189,6 +189,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Profile_Data_User_Activity.html
+++ b/userguide/Profile_Data_User_Activity.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - User Activity Stream</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Activity.html
+++ b/userguide/Profile_Data_User_Activity.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - User Activity Stream</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Contacts.html
+++ b/userguide/Profile_Data_User_Contacts.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - User Contacts</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Contacts.html
+++ b/userguide/Profile_Data_User_Contacts.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - User Contacts</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Contacts.html
+++ b/userguide/Profile_Data_User_Contacts.html
@@ -145,12 +145,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Profile_Data_User_Contacts';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Contacts.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Profile_Data_User_Contacts.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -166,6 +166,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Profile_Data_User_Profile.html
+++ b/userguide/Profile_Data_User_Profile.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - User Profile</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Profile.html
+++ b/userguide/Profile_Data_User_Profile.html
@@ -231,12 +231,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Profile_Data_User_Profile';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Profile.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Profile_Data_User_Profile.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -252,6 +252,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/Profile_Data_User_Profile.html
+++ b/userguide/Profile_Data_User_Profile.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - User Profile</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Status.html
+++ b/userguide/Profile_Data_User_Status.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Update User Status</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Status.html
+++ b/userguide/Profile_Data_User_Status.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Update User Status</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../assets/css/bootstrap.min.css">

--- a/userguide/Profile_Data_User_Status.html
+++ b/userguide/Profile_Data_User_Status.html
@@ -112,12 +112,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'Profile_Data_User_Status';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/Profile_Data_User_Status.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/Profile_Data_User_Status.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>
@@ -133,6 +133,6 @@
 			<p>HybridAuth website was made using <a href="http://getbootstrap.com/">Bootstrap</a> and <a href="http://jquery.com/">jQuery</a>. Project hosting provided by <a href="http://github.com/">Github</a>.</p>
 		</footer>
 	</div>
-	<!-- /container --> 
+	<!-- /container -->
 </body>
 </html>

--- a/userguide/tuts/advanced-access-facebook-api.html
+++ b/userguide/tuts/advanced-access-facebook-api.html
@@ -175,12 +175,12 @@ Array
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'advanced-access-facebook-api';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/tuts/advanced-access-facebook-api.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/tuts/advanced-access-facebook-api.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>

--- a/userguide/tuts/advanced-access-facebook-api.html
+++ b/userguide/tuts/advanced-access-facebook-api.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Advance access to Facebook API</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">

--- a/userguide/tuts/advanced-access-facebook-api.html
+++ b/userguide/tuts/advanced-access-facebook-api.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Advance access to Facebook API</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">
@@ -205,7 +205,7 @@ piwik_idsite = 1;
 piwik_url = pkBaseURL + "piwik.php";
 piwik_log(piwik_action_name, piwik_idsite, piwik_url);
 </script>
-<object><noscript><p><img src="http://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
+<object><noscript><p><img src="https://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
 <script type="text/javascript">
 var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
@@ -216,6 +216,6 @@ var pageTracker = _gat._getTracker("UA-11037160-1");
 pageTracker._trackPageview();
 } catch(err) {}</script>
 <script type="text/javascript"> var sc_project=7312365; var sc_invisible=1; var sc_security="30da00f3"; </script>
-<script type="text/javascript" src="http://www.statcounter.com/counter/counter.js"></script>
+<script type="text/javascript" src="https://www.statcounter.com/counter/counter.js"></script>
 </body>
 </html>

--- a/userguide/tuts/advanced-access-google-api.html
+++ b/userguide/tuts/advanced-access-google-api.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Advance access to Google API</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">
@@ -146,7 +146,7 @@ piwik_idsite = 1;
 piwik_url = pkBaseURL + "piwik.php";
 piwik_log(piwik_action_name, piwik_idsite, piwik_url);
 </script>
-<object><noscript><p><img src="http://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
+<object><noscript><p><img src="https://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
 <script type="text/javascript">
 var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
@@ -157,6 +157,6 @@ var pageTracker = _gat._getTracker("UA-11037160-1");
 pageTracker._trackPageview();
 } catch(err) {}</script>
 <script type="text/javascript"> var sc_project=7312365; var sc_invisible=1; var sc_security="30da00f3"; </script>
-<script type="text/javascript" src="http://www.statcounter.com/counter/counter.js"></script>
+<script type="text/javascript" src="https://www.statcounter.com/counter/counter.js"></script>
 </body>
 </html>

--- a/userguide/tuts/advanced-access-google-api.html
+++ b/userguide/tuts/advanced-access-google-api.html
@@ -116,12 +116,12 @@ Then, we need to add '<b>https://www.googleapis.com/auth/analytics.readonly</b>"
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'advanced-access-google-api';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/tuts/advanced-access-google-api.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/tuts/advanced-access-google-api.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>

--- a/userguide/tuts/advanced-access-google-api.html
+++ b/userguide/tuts/advanced-access-google-api.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Advance access to Google API</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">

--- a/userguide/tuts/change-hybridauth-endpoint-url.html
+++ b/userguide/tuts/change-hybridauth-endpoint-url.html
@@ -74,7 +74,7 @@
 					For MVC frameworks like CakePHP and CodeIgniter, developers usually drop the <code>hybridauth</code> package inside the <code>public</code> directory.
 					This means the callback or return URL for a provider, (ex. Google) look something like this:
 				</p>
-				
+
 				<p><span style="color:green">http://mywebsite.com/hybridauth/index.php<strong>?hauth.done=Google</strong></span></p>
 
 				<p>However, it's possible to fully customize the HybridAuth Endpoint URL by rewrapping the endpoint. This means your endpoint URL could look something like (example #1):</p>
@@ -100,13 +100,13 @@
 <pre class="prettyprint linenums">
 &lt;?php
 	class UsersAuthentication extends Controller {
-		
+
 		function hybridauth_endpoint() {
 			 include "/path/to/framework/application/vendors/hybridauth/index.php";
 		}
 
 		function signin_with_hybridauth( $provider ) {
-			 
+
 			$config = "/path/to/framework/application/vendors/hybridauth/config.php";
 			include "/path/to/framework/application/vendors/hybridauth/Hybrid/Auth.php";
 
@@ -127,7 +127,7 @@
 				<p>If we assume your website domain is <span style="color:green">http://mywebsite.com/</span> and your application url is <span style="color:green">http://mywebsite.com/<b>app/</b></span> then:</p>
 				<p>HybridAuth Endpoint will be (<code>base_url</code> on configuration):<br /><span style="color:green">http://mywebsite.com/app/<b>usersauthentication/hybridauth_endpoint/</b></span></p>
 				<p>And you could provide it as callback url for your external applications. ex:<br /><span style="color:green">http://mywebsite.com/app/usersauthentication/hybridauth_endpoint/<b>?hauth.done=Google</b></span></p>
-			
+
 				<hr />
 
 				<h3>Example #2 (advanced)</h3>
@@ -141,7 +141,7 @@
 
 				<p>
 					We'll need to manually adjust the <code>$_REQUEST</code> variable, since this is where HybridAuth looks for the
-					<code>hauth_start</code> and <code>hauth_done</code> keys, which it uses to determine if we are starting the auth 
+					<code>hauth_start</code> and <code>hauth_done</code> keys, which it uses to determine if we are starting the auth
 					process, or we have been redirected back from the service provider. It also tells HybridAuth which provider we are dealing with.
 				</p>
 
@@ -153,9 +153,9 @@
 <pre class="prettyprint linenums">
 &lt;?php
 	class UsersAuthentication extends Controller {
-		 
+
 		function hybridauth_endpoint( $action, $provider ) {
-			 
+
 			include "/path/to/framework/application/vendors/hybridauth/Hybrid/Auth.php";
 			include "/path/to/framework/application/vendors/hybridauth/Hybrid/Endpoint.php";
 
@@ -167,7 +167,7 @@
 		}
 
 		function signin_with_hybridauth( $provider ) {
-			 
+
 			$config = "/path/to/framework/application/vendors/hybridauth/config.php";
 			include "/path/to/framework/application/vendors/hybridauth/Hybrid/Auth.php";
 
@@ -198,7 +198,7 @@
 				<p>HybridAuth Endpoint will be (<code>base_url</code> on configuration):<br /><span style="color:green">http://mywebsite.com/app/<b>usersauthentication/hybridauth_endpoint/</b></span></p>
 				<p>HybridAuth will redirect users logging in via Google to (this will load the <code>Hybrid_Endpoint</code> and start the auth process):<br /><span style="color:green">http://mywebsite.com/app/usersauthentication/hybridauth_endpoint/<b>start/google</b></span></p>
 				<p>And you could provide it as callback url for your external applications. ex:<br /><span style="color:green">http://mywebsite.com/app/usersauthentication/hybridauth_endpoint/<b>done/google</b></span></p>
-			
+
 			</div><!-- //.col-md-12 -->
 		</div>
 	</div>
@@ -213,12 +213,12 @@
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'change-hybridauth-endpoint-url';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/tuts/change-hybridauth-endpoint-url.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/tuts/change-hybridauth-endpoint-url.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>

--- a/userguide/tuts/change-hybridauth-endpoint-url.html
+++ b/userguide/tuts/change-hybridauth-endpoint-url.html
@@ -7,7 +7,7 @@
 	<title>HybridAuth - How to change HybridAuth endpoint URL?</title>
 
 	<!--[if lt IE 9]>
-	<script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
 	<![endif]-->
 
 	<link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">

--- a/userguide/tuts/change-hybridauth-endpoint-url.html
+++ b/userguide/tuts/change-hybridauth-endpoint-url.html
@@ -7,7 +7,7 @@
 	<title>HybridAuth - How to change HybridAuth endpoint URL?</title>
 
 	<!--[if lt IE 9]>
-	<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+	<script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
 
 	<link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">
@@ -243,7 +243,7 @@ piwik_idsite = 1;
 piwik_url = pkBaseURL + "piwik.php";
 piwik_log(piwik_action_name, piwik_idsite, piwik_url);
 </script>
-<object><noscript><p><img src="http://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
+<object><noscript><p><img src="https://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
 <script type="text/javascript">
 var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
@@ -254,6 +254,6 @@ var pageTracker = _gat._getTracker("UA-11037160-1");
 pageTracker._trackPageview();
 } catch(err) {}</script>
 <script type="text/javascript"> var sc_project=7312365; var sc_invisible=1; var sc_security="30da00f3"; </script>
-<script type="text/javascript" src="http://www.statcounter.com/counter/counter.js"></script>
+<script type="text/javascript" src="https://www.statcounter.com/counter/counter.js"></script>
 </body>
 </html>

--- a/userguide/tuts/integrating-openid-providers.html
+++ b/userguide/tuts/integrating-openid-providers.html
@@ -140,12 +140,12 @@ $user_data = $adapter-&gt;getUserProfile();
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'integrating-openid-providers';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/tuts/integrating-openid-providers.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/tuts/integrating-openid-providers.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>

--- a/userguide/tuts/integrating-openid-providers.html
+++ b/userguide/tuts/integrating-openid-providers.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Authenticate users with OpenID providers</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">
@@ -173,7 +173,7 @@ $user_data = $adapter-&gt;getUserProfile();
 	piwik_url = pkBaseURL + "piwik.php";
 	piwik_log(piwik_action_name, piwik_idsite, piwik_url);
 	</script>
-	<object><noscript><p><img src="http://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
+	<object><noscript><p><img src="https://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
 	<script type="text/javascript">
 	var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 	document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));

--- a/userguide/tuts/integrating-openid-providers.html
+++ b/userguide/tuts/integrating-openid-providers.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - Authenticate users with OpenID providers</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">

--- a/userguide/tuts/specific-provider-wrapper.html
+++ b/userguide/tuts/specific-provider-wrapper.html
@@ -114,12 +114,12 @@ You can also use this in case you want to use your own adapter implementation fo
 					/* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
 						var disqus_shortname = 'hybridauth'; // required: replace example with your forum shortname
 						var disqus_identifier = 'specific-provider-wrapper';
-						var disqus_url = 'http://hybridauth.sourceforge.net/userguide/tuts/specific-provider-wrapper.html';
+						var disqus_url = 'https://hybridauth.github.io/hybridauth/userguide/tuts/specific-provider-wrapper.html';
 
 					/* * * DON'T EDIT BELOW THIS LINE * * */
 						(function() {
 							var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-							dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+							dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 							(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 						})();
 				</script>

--- a/userguide/tuts/specific-provider-wrapper.html
+++ b/userguide/tuts/specific-provider-wrapper.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - How to use a specific provider wrapper</title>
 
   <!--[if lt IE 9]>
-  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">

--- a/userguide/tuts/specific-provider-wrapper.html
+++ b/userguide/tuts/specific-provider-wrapper.html
@@ -7,7 +7,7 @@
   <title>HybridAuth - How to use a specific provider wrapper</title>
 
   <!--[if lt IE 9]>
-  <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
 
   <link rel="stylesheet" type="text/css" href="../../assets/css/bootstrap.min.css">
@@ -73,7 +73,7 @@
 
 <p>
 Some providers like Yahoo and Google have been changed from supporting the OpenID to Oauth.
-To continue using the old OpenID's adapters you can simply download the <a href="http://hybridauth.sourceforge.net/download.html">additional providers package</a> and use the "hybridauth-yahoo-openid" and "hybridauth-google-openid" to replace the current ones.
+To continue using the old OpenID's adapters you can simply download the <a href="https://hybridauth.github.io/hybridauth/download.html">additional providers package</a> and use the "hybridauth-yahoo-openid" and "hybridauth-google-openid" to replace the current ones.
 </p>
 
 <p>
@@ -144,7 +144,7 @@ piwik_idsite = 1;
 piwik_url = pkBaseURL + "piwik.php";
 piwik_log(piwik_action_name, piwik_idsite, piwik_url);
 </script>
-<object><noscript><p><img src="http://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
+<object><noscript><p><img src="https://sourceforge.net/apps/piwik/hybridauth/piwik.php?idsite=1" alt="piwik"/></p></noscript></object>
 <script type="text/javascript">
 var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
 document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
@@ -155,6 +155,6 @@ var pageTracker = _gat._getTracker("UA-11037160-1");
 pageTracker._trackPageview();
 } catch(err) {}</script>
 <script type="text/javascript"> var sc_project=7312365; var sc_invisible=1; var sc_security="30da00f3"; </script>
-<script type="text/javascript" src="http://www.statcounter.com/counter/counter.js"></script>
+<script type="text/javascript" src="https://www.statcounter.com/counter/counter.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

* Addition

## Goal

Currently, if you go to any page of documentation where user can add comments by disqus. You will see an error in console like this:

```
IDProvider_info_Facebook.html:228 Mixed Content: The page at 'https://hybridauth.github.io/hybridauth/userguide/IDProvider_info_Facebook.html' was loaded over HTTPS, but requested an insecure script 'http://hybridauth.disqus.com/embed.js'. 
This request has been blocked; the content must be served over HTTPS.
```

so, disqus widget doesn't work, because all content redirects to https://hybridauth.github.io/hybridauth which is HTTPS, but widget loading from HTTP. There are also so many issues with http / https (e.g images don't work)

## Description

This PR includes:
- Replace http to https for loading embed.js
- Replace `http://hybridauth.sourceforge.net` to `https://hybridauth.github.io/hybridauth`, because direct link doesn't work properly, somehow I get 404, e.g http://hybridauth.sourceforge.net/plugins.html
- Replace http to https for images and some external resources.