### PR TITLE
Ensure the access_token exist in the dataStore

### DIFF
--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -646,7 +646,9 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             $url = $this->apiBaseUrl . $url;
         }
 
-        $this->apiRequestParameters[ $this->accessTokenName ] = $this->getStoredData('access_token');
+        if($this->getStoredData('access_token')) {
+            $this->apiRequestParameters[$this->accessTokenName] = $this->getStoredData('access_token');
+        }
 
         $parameters = array_replace($this->apiRequestParameters, (array) $parameters);
         $headers = array_replace($this->apiRequestHeaders, (array) $headers);


### PR DESCRIPTION
Added an if condition to ensure the access token does exist in the data store / session before adding it to request parameters.

Not having this condition actually broke my implementation.

Harmless code change. Please merge.

cc @StorytellerCZ @miled 