### PR TITLE
apiRequest() sometimes return array hence this PHPDoc change

### DIFF
--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -502,7 +502,7 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     * @param array  $parameters
     * @param array  $headers
     *
-    * @return object
+    * @return mixed
     */
     public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [])
     {

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -633,7 +633,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     * @param array  $parameters
     * @param array  $headers
     *
-    * @return object
+    * @return mixed
     */
     public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [])
     {


### PR DESCRIPTION
After parsing by Data\Parser, result could be an array. Not always an object