### PR TITLE
add support for variable namespace alias for SREG attributes - fixes …

### DIFF
--- a/src/Thirdparty/OpenID/LightOpenID.php
+++ b/src/Thirdparty/OpenID/LightOpenID.php
@@ -1043,17 +1043,19 @@ class LightOpenID
     {
         $attributes = array();
         $sreg_to_ax = array_flip(self::$ax_to_sreg);
-        foreach (explode(',', $this->data['openid_signed']) as $key) {
-            $keyMatch = 'sreg.';
-            if (strncmp($key, $keyMatch, strlen($keyMatch)) !== 0) {
-                continue;
+        if ($alias = $this->getNamespaceAlias('http://openid.net/extensions/sreg/1.1', 'sreg')) {
+            foreach (explode(',', $this->data['openid_signed']) as $key) {
+                $keyMatch = $alias . '.';
+                if (strncmp($key, $keyMatch, strlen($keyMatch)) !== 0) {
+                    continue;
+                }
+                $key = substr($key, strlen($keyMatch));
+                if (!isset($sreg_to_ax[$key])) {
+                    # The field name isn't part of the SREG spec, so we ignore it.
+                    continue;
+                }
+                $attributes[$sreg_to_ax[$key]] = $this->data['openid_' . $alias . '_' . $key];
             }
-            $key = substr($key, strlen($keyMatch));
-            if (!isset($sreg_to_ax[$key])) {
-                # The field name isn't part of the SREG spec, so we ignore it.
-                continue;
-            }
-            $attributes[$sreg_to_ax[$key]] = $this->data['openid_sreg_' . $key];
         }
         return $attributes;
     }


### PR DESCRIPTION
…SREG attributes not extracted if SREG namespace attribute name is not "openid_ns_sreg"

## Summary

* Patch for #

- [x] Tested
  - [-] Unit tests
  - [-] Style
- [-] Documentation (PR # )

## Goal

Support SREG attributes if namespace attribute name is NOT "openid_ns_sreg" by replacing hard coded SREG namespace attribute name with SREG namespace detection (see getAxAttributes()).

## Description

Makes working:

openid_ns_ext1=http://openid.net/extensions/sreg/1.1
openid_ext1_nickname=sebastian.mendel