### PR TITLE
Add Following and Follower count for Twitter and Instagram

### DIFF
--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -64,7 +64,7 @@ class Instagram extends OAuth2
         $userProfile->photoURL    = $data->get('profile_picture');
         $userProfile->webSiteURL  = $data->get('website');
         $userProfile->displayName = $data->get('full_name');
-        $userProfile->follower_count  = $data->get('counts')->followed_by;//->get('');
+        $userProfile->follower_count  = $data->get('counts')->followed_by;
         $userProfile->following_count = $data->get('counts')->follows;
 
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -64,6 +64,8 @@ class Instagram extends OAuth2
         $userProfile->photoURL    = $data->get('profile_picture');
         $userProfile->webSiteURL  = $data->get('website');
         $userProfile->displayName = $data->get('full_name');
+        $userProfile->follower_count  = $data->get('counts')->followed_by;//->get('');
+        $userProfile->following_count = $data->get('counts')->follows;
 
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');
 

--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -99,6 +99,8 @@ class Twitter extends OAuth1
         $userProfile->emailVerified = $data->get('email');
         $userProfile->webSiteURL    = $data->get('url');
         $userProfile->region        = $data->get('location');
+        $userProfile->follower_count  = $data->get('followers_count');
+        $userProfile->following_count = $data->get('friends_count');
 
         $userProfile->profileURL    = $data->exists('screen_name')
                                         ? ('http://twitter.com/' . $data->get('screen_name'))

--- a/src/User/Profile.php
+++ b/src/User/Profile.php
@@ -167,6 +167,20 @@ final class Profile
     * @var string
     */
     public $zip = null;
+    
+    /**
+    * Number of follower
+    *
+    * @var integer
+    */
+    public $follower_count = null;
+
+    /**
+    * Number of following
+    *
+    * @var integer
+    */
+    public $following_count = null;
 
     /**
     * Prevent the providers adapters from adding new fields.


### PR DESCRIPTION
## Summary
* Addition


- [ x] Tested
  - [-] Unit tests


## Goal
Add Following and Follower count for Twitter and Instagram


## Description
Add ability to read Following and Follower count for Twitter and Instagram.
Added two new properties for Following and Follower count  in user profile class .