### PR TITLE
Support R/O scope for Gmail contats as well

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -195,7 +195,7 @@ class Google extends OAuth2
         $parameters = ['max-results' => 500] + $parameters;
 
         // Google Gmail and Android contacts
-        if (false !== strpos($this->scope, '/m8/feeds/')) {
+        if (false !== strpos($this->scope, '/m8/feeds/') || false !== strpos($this->scope, '/auth/contacts.readonly')) {
             return $this->getGmailContacts($parameters);
         }
 


### PR DESCRIPTION
## Summary

* Patch for Google provider

- [x] Tested

## Goal

Need R/O access to Gmail contacts

## Description

If I need R/O access to Gmail contacts, I have to specify scope https://www.googleapis.com/auth/contacts.readonly (https://developers.google.com/google-apps/contacts/v3/), but then I can't get this data via $google->getUserContacts() call. Either getGmailContacts has to be public, or we need to update getUserContacts method to support this R/O scope as well. I provided update for the second case.
Thanks!
