### PR TITLE
vkontakte doesn't return email field on getProfile call

### DIFF
--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -33,6 +33,11 @@ class Vkontakte extends OAuth2
     protected $accessTokenUrl = 'https://api.vk.com/oauth/token';
 
     /**
+	 * {@inheritdoc}
+	 */
+	protected $scope = 'email';
+    
+    /**
     * Need to store user_id as token for later use
     *
     * {@inheritdoc}


### PR DESCRIPTION
without setting $scape='email' function getProfile doesn't return field email from vkontakte oauth2 service

## Summary

(select one:)
* Addition

- [x] Tested
  - [ ] Unit tests
  - [ ] Style
- [ ] Documentation (PR # )

## Goal

bug fix

## Description


