### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "phpunit/phpunit": "~4.1"
+        "phpunit/phpunit": "~4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Data/CollectionTest.php
+++ b/tests/Data/CollectionTest.php
@@ -2,7 +2,7 @@
 
 use Hybridauth\Data\Collection;
 
-class CollectionTest extends \PHPUnit_Framework_TestCase
+class CollectionTest extends \PHPUnit\Framework\TestCase
 {
     public function some_random_id()
     {

--- a/tests/Data/ParserTest.php
+++ b/tests/Data/ParserTest.php
@@ -2,7 +2,7 @@
 
 use Hybridauth\Data\Parser;
 
-class ParserTest extends \PHPUnit_Framework_TestCase
+class ParserTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {

--- a/tests/HybridauthTest.php
+++ b/tests/HybridauthTest.php
@@ -2,7 +2,7 @@
 
 use Hybridauth\Hybridauth;
 
-class HybridauthTest extends \PHPUnit_Framework_TestCase
+class HybridauthTest extends \PHPUnit\Framework\TestCase
 {
     public function test_pass()
     {

--- a/tests/Storage/SessionTest.php
+++ b/tests/Storage/SessionTest.php
@@ -4,7 +4,7 @@ use Hybridauth\Storage\Session;
 
 session_start(); // they will hate me for this..
 
-class SessionTest extends \PHPUnit_Framework_TestCase
+class SessionTest extends \PHPUnit\Framework\TestCase
 {
     public function some_random_session_data()
     {

--- a/tests/User/ActivityTest.php
+++ b/tests/User/ActivityTest.php
@@ -2,7 +2,7 @@
 
 use Hybridauth\User\Activity;
 
-class ActivityTest extends \PHPUnit_Framework_TestCase
+class ActivityTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {

--- a/tests/User/ContactTest.php
+++ b/tests/User/ContactTest.php
@@ -2,7 +2,7 @@
 
 use Hybridauth\User\Contact;
 
-class ContactTest extends \PHPUnit_Framework_TestCase
+class ContactTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {

--- a/tests/User/ProfileTest.php
+++ b/tests/User/ProfileTest.php
@@ -2,7 +2,7 @@
 
 use Hybridauth\User\Profile;
 
-class ProfileTest extends \PHPUnit_Framework_TestCase
+class ProfileTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {


### PR DESCRIPTION
## Summary

Use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`.

(select one:)
* Addition

- [x] Tested
  - [x] Unit tests
  - [ ] Style
- [ ] Documentation (PR # )

## Goal

This will help us when migrating to PHPUnit 6, that are now namespaced.

## Description

Use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase` while extending TestCases.

Just need to bump into [PHPUnit 4.8.35](https://github.com/sebastianbergmann/phpunit/blob/4.8/ChangeLog-4.8.md#4835---2017-02-06) that supports this namespace.