### PR TITLE
Provide a setPageStatus for facebook

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -150,7 +150,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setUserStatus($status)
+    public function getUserPages()
     {
         throw new NotImplementedException('Provider does not support this feature.');
     }
@@ -159,6 +159,22 @@ abstract class AbstractAdapter implements AdapterInterface
      * {@inheritdoc}
      */
     public function getUserActivity($stream)
+    {
+        throw new NotImplementedException('Provider does not support this feature.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUserStatus($status)
+    {
+        throw new NotImplementedException('Provider does not support this feature.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPageStatus($status, $pageId)
     {
         throw new NotImplementedException('Provider does not support this feature.');
     }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -50,6 +50,13 @@ interface AdapterInterface
     public function getUserContacts();
 
     /**
+     * Retrieve the connected user pages|companies|groups list
+     *
+     * @return array
+     */
+    public function getUserPages();
+
+    /**
      * Retrieve the user activity stream
      *
      * @param string $stream
@@ -66,6 +73,16 @@ interface AdapterInterface
      * @return mixed API response
      */
     public function setUserStatus($status);
+
+    /**
+     * Post a status on page|company|group wall.
+     *
+     * @param string|array $status
+     * @param string $pageId
+     *
+     * @return mixed API response
+     */
+    public function setPageStatus($status, $pageId);
 
     /**
      * Send a signed request to provider API

--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -521,7 +521,7 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [])
     {
         if (strrpos($url, 'http://') !== 0 && strrpos($url, 'https://') !== 0) {
-            $url = $this->apiBaseUrl . $url;
+            $url = rtrim($this->apiBaseUrl, '/') . '/' . ltrim($url, '/');
         }
 
         $parameters = array_replace($this->apiRequestParameters, (array)$parameters);

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -666,7 +666,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         }
 
         if (strrpos($url, 'http://') !== 0 && strrpos($url, 'https://') !== 0) {
-            $url = $this->apiBaseUrl . $url;
+            $url = rtrim($this->apiBaseUrl, '/') . '/' . ltrim($url, '/');
         }
 
         $parameters = array_replace($this->apiRequestParameters, (array) $parameters);


### PR DESCRIPTION
Resolves #910 

It also improves a pages support on Hybridauth Provider level. For now, only Facebook provider supports post to pages. Later it can be improved for LinkedIn with Companies, etc..