### PR TITLE
make google image size configurable like facebook

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -122,7 +122,8 @@ class Google extends OAuth2
         $userProfile->emailVerified = $data->get('verified') ? $userProfile->email : '';
 
         if ($data->filter('image')->exists('url')) {
-            $userProfile->photoURL = substr($data->filter('image')->get('url'), 0, -2) . 150;
+             $photoSize = $this->config->get('photo_size') ?: '150';
+            $userProfile->photoURL = substr($data->filter('image')->get('url'), 0, -2) . $photoSize;
         }
 
         if (! $userProfile->email && $data->exists('emails')) {

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -122,7 +122,7 @@ class Google extends OAuth2
         $userProfile->emailVerified = $data->get('verified') ? $userProfile->email : '';
 
         if ($data->filter('image')->exists('url')) {
-             $photoSize = $this->config->get('photo_size') ?: '150';
+            $photoSize = $this->config->get('photo_size') ?: '150';
             $userProfile->photoURL = substr($data->filter('image')->get('url'), 0, -2) . $photoSize;
         }
 


### PR DESCRIPTION
## Summary

(select one:)

* Addition


- [ ] Tested
  - [ ] Unit tests
  - [ ] Style
- [ ] Documentation (PR # )

## Goal

My client only want profile pictures larger then 480px. This pull request makes the image size of the google provider configurable.

## Description

I took the same method as the Facebook provider. Thus adding a photo_size to the config array enables you to change the image size. 
