### PR TITLE
use linkedin original url as profile url

### DIFF
--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -60,8 +60,12 @@ class LinkedIn extends OAuth2
             'num-connections',
         ];
 
+        if( $this->config->get('photo_size')  == 'original' ){
+            $fields[] = 'picture-urls::(original)';
+        }
+        
         $response = $this->apiRequest('people/~:(' . implode(',', $fields) . ')', 'GET', ['format' => 'json']);
-
+        
         $data = new Data\Collection($response);
 
         if (! $data->exists('id')) {
@@ -79,6 +83,13 @@ class LinkedIn extends OAuth2
         $userProfile->description   = $data->get('headline');
         $userProfile->country       = $data->filter('location')->get('name');
 
+        if( $this->config->get('photo_size')  == 'original' ){
+            $originals = $data->get('pictureUrls');
+            if(count($originals->values) > 0){
+                $userProfile->photoURL = $originals->values[0];
+            }
+        }    
+        
         $userProfile->emailVerified = $userProfile->email;
 
         $userProfile->displayName   = trim($userProfile->firstName . ' ' . $userProfile->lastName);

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -1,15 +1,15 @@
 <?php
 /*!
-* Hybridauth
-* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
-*  (c) 2017 Hybridauth authors | https://hybridauth.github.io/license.html
-*/
+ * Hybridauth
+ * https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+ *  (c) 2017 Hybridauth authors | https://hybridauth.github.io/license.html
+ */
 
 namespace Hybridauth\Provider;
 
 use Hybridauth\Adapter\OAuth2;
-use Hybridauth\Exception\UnexpectedApiResponseException;
 use Hybridauth\Data;
+use Hybridauth\Exception\UnexpectedApiResponseException;
 use Hybridauth\User;
 
 /**
@@ -60,38 +60,38 @@ class LinkedIn extends OAuth2
             'num-connections',
         ];
 
-        if( $this->config->get('photo_size')  === 'original' ){
+        if ($this->config->get('photo_size') === 'original') {
             $fields[] = 'picture-urls::(original)';
         }
-        
-        $response = $this->apiRequest('people/~:(' . implode(',', $fields) . ')', 'GET', ['format' => 'json']);
-        $data = new Data\Collection($response);
 
-        if (! $data->exists('id')) {
+        $response = $this->apiRequest('people/~:(' . implode(',', $fields) . ')', 'GET', ['format' => 'json']);
+        $data     = new Data\Collection($response);
+
+        if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier    = $data->get('id');
-        $userProfile->firstName     = $data->get('firstName');
-        $userProfile->lastName      = $data->get('lastName');
-        $userProfile->photoURL      = $data->get('pictureUrl');
-        $userProfile->profileURL    = $data->get('publicProfileUrl');
-        $userProfile->email         = $data->get('emailAddress');
-        $userProfile->description   = $data->get('headline');
-        $userProfile->country       = $data->filter('location')->get('name');
+        $userProfile->identifier  = $data->get('id');
+        $userProfile->firstName   = $data->get('firstName');
+        $userProfile->lastName    = $data->get('lastName');
+        $userProfile->photoURL    = $data->get('pictureUrl');
+        $userProfile->profileURL  = $data->get('publicProfileUrl');
+        $userProfile->email       = $data->get('emailAddress');
+        $userProfile->description = $data->get('headline');
+        $userProfile->country     = $data->filter('location')->get('name');
 
-        if( $this->config->get('photo_size')  === 'original' ){
+        if ($this->config->get('photo_size') === 'original') {
             $originals = $data->get('pictureUrls');
-            if(!empty($originals->values)){
+            if (!empty($originals->values)) {
                 $userProfile->photoURL = $originals->values[0];
             }
-        }    
-        
+        }
+
         $userProfile->emailVerified = $userProfile->email;
 
-        $userProfile->displayName   = trim($userProfile->firstName . ' ' . $userProfile->lastName);
+        $userProfile->displayName = trim($userProfile->firstName . ' ' . $userProfile->lastName);
 
         $userProfile->data['connections'] = $data->get('numConnections');
 
@@ -105,14 +105,14 @@ class LinkedIn extends OAuth2
      */
     public function setUserStatus($status)
     {
-        $status = is_string($status) ? [ 'comment' => $status ] : $status;
+        $status = is_string($status) ? ['comment' => $status] : $status;
         if (!isset($status['visibility'])) {
             $status['visibility']['code'] = 'anyone';
         }
 
         $headers = [
             'Content-Type' => 'application/json',
-            'x-li-format' => 'json',
+            'x-li-format'  => 'json',
         ];
 
         $response = $this->apiRequest('people/~/shares?format=json', 'POST', $status, $headers);

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -65,7 +65,6 @@ class LinkedIn extends OAuth2
         }
         
         $response = $this->apiRequest('people/~:(' . implode(',', $fields) . ')', 'GET', ['format' => 'json']);
-        
         $data = new Data\Collection($response);
 
         if (! $data->exists('id')) {

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -60,7 +60,7 @@ class LinkedIn extends OAuth2
             'num-connections',
         ];
 
-        if( $this->config->get('photo_size')  == 'original' ){
+        if( $this->config->get('photo_size')  === 'original' ){
             $fields[] = 'picture-urls::(original)';
         }
         
@@ -83,9 +83,9 @@ class LinkedIn extends OAuth2
         $userProfile->description   = $data->get('headline');
         $userProfile->country       = $data->filter('location')->get('name');
 
-        if( $this->config->get('photo_size')  == 'original' ){
+        if( $this->config->get('photo_size')  === 'original' ){
             $originals = $data->get('pictureUrls');
-            if(count($originals->values) > 0){
+            if(!empty($originals->values)){
                 $userProfile->photoURL = $originals->values[0];
             }
         }    


### PR DESCRIPTION
## Summary

(select one:)

* Addition


- [ ] Tested
  - [ ] Unit tests
  - [ ] Style
- [ ] Documentation (PR # )

## Goal

The original picture url is in most cases larger than the linkedIn profile picture. This PR uses the config file to request the original picture url.

Caveat: The original picture url dimensions is not always square. 

## Description

Add `photo_size => 'original'` to the linkedIn config array to use this.
