### PR TITLE
return profileURL in Instagram adapter

### DIFF
--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -78,7 +78,8 @@ class Instagram extends OAuth2
         $userProfile->webSiteURL  = $data->get('website');
         $userProfile->displayName = $data->get('full_name');
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');
-
+        $userProfile->profileURL = "https://instagram.com/{$data->get('username')}";
+        
         $userProfile->data = (array) $data->get('counts');
 
         return $userProfile;


### PR DESCRIPTION
Instagram URL did not expose profileUrl, this PR addresses that.