### PR TITLE
Fix Vkontakte provider for get profile data

### DIFF
--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -93,7 +93,14 @@ class Vkontakte extends OAuth2
             'v' => '5.74',
         ];
 
+        $accessToken = $this->getStoredData($this->accessTokenName);
+        $this->apiRequestParameters[$this->accessTokenName] = $accessToken;
+
         $response = $this->apiRequest('users.get', 'GET', $parameters);
+
+        if(property_exists($response, 'error')) {
+            throw new UnexpectedApiResponseException($response->error->error_msg);
+        }
 
         $data = new Collection($response->response[0]);
 

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -91,14 +91,12 @@ class Vkontakte extends OAuth2
             'user_ids' => $this->getStoredData('user_id'),
             'fields' => 'first_name,last_name,nickname,screen_name,sex,bdate,timezone,photo_rec,photo_big,photo_max_orig',
             'v' => '5.74',
+            $this->accessTokenName => $this->getStoredData($this->accessTokenName),
         ];
-
-        $accessToken = $this->getStoredData($this->accessTokenName);
-        $this->apiRequestParameters[$this->accessTokenName] = $accessToken;
 
         $response = $this->apiRequest('users.get', 'GET', $parameters);
 
-        if(property_exists($response, 'error')) {
+        if (property_exists($response, 'error')) {
             throw new UnexpectedApiResponseException($response->error->error_msg);
         }
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | fix #963  
| Patch: Bug Fix?          | yes
| Major: Breaking Change?  | no
| Minor: New Feature?      | no
| Documentation PR         | 

for obtaining profile data, access_token is required
correct check on the server response containing the error was added
