### PR TITLE
Store id instead of user_id because id can be used with the humanitar…

### DIFF
--- a/additional-providers/hybridauth-humanitarianid/Providers/HumanitarianId.php
+++ b/additional-providers/hybridauth-humanitarianid/Providers/HumanitarianId.php
@@ -83,7 +83,7 @@ class Hybrid_Providers_HumanitarianId extends Hybrid_Provider_Model_OAuth2
       throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
     }
 
-    $this->user->profile->identifier  = @ $data->user_id;
+    $this->user->profile->identifier  = @ $data->id;
     $this->user->profile->displayName = @ $data->name;
     $this->user->profile->email       = @ $data->email;
     $this->user->profile->firstName   = @ $data->given_name;


### PR DESCRIPTION
Using the 'id' value of user data object makes it possible to query the Humanitarian ID API.
The user_id seems to contain values from an older format which cannot be used to query the API.