### PR TITLE
Handling the case when REQUEST_URI contains the FQDN

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -402,7 +402,12 @@ class Hybrid_Auth {
 		$url = $protocol . $_SERVER['HTTP_HOST'];
 
 		if ($request_uri) {
-			$url .= $_SERVER['REQUEST_URI'];
+			// If $_SERVER['REQUEST_URI'] is already a FQDN, use it
+			if (stripos($_SERVER['REQUEST_URI'], $url) === 0) {
+				$url = $_SERVER['REQUEST_URI'];
+			} else {
+				$url .= $_SERVER['REQUEST_URI'];
+			}
 		} else {
 			$url .= $_SERVER['PHP_SELF'];
 		}


### PR DESCRIPTION
When requests are proxied, Apache will place the fully qualified URL in the REQUEST_URI variable. If you don't check for it, then you can run into issues when concatenating REQUEST_URI to the hostname. The problem is discussed in [this StackOverflow question](https://stackoverflow.com/a/8041626/4245525).

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | I wasn't able to find a related issue, and I didn't think I should create one when I already know the solution.
| Patch: Bug Fix?          | Fixes a bug in how the current URL is generated when operating behind a proxy
| Major: Breaking Change?  | Nope
| Minor: New Feature?      | Nope
| Documentation PR         | Nope

This patch fixes the issue by setting the current URL to the value of REQUEST_URI instead of concatenating the protocol, hostname, and REQUEST_URI. It only does this when REQUEST_URI already starts with the protocol and hostname.
