### PR TITLE
Use authorization header instead of query parameter for call to accou…

### DIFF
--- a/additional-providers/hybridauth-humanitarianid/Providers/HumanitarianId.php
+++ b/additional-providers/hybridauth-humanitarianid/Providers/HumanitarianId.php
@@ -78,7 +78,10 @@ class Hybrid_Providers_HumanitarianId extends Hybrid_Provider_Model_OAuth2
    * load the user profile from the IDp api client
   */
   function getUserProfile() {
-    $data = $this->api->api( "account.json" );
+    $this->api->curl_header = array(
+      "Authorization: Bearer {$this->api->access_token}",
+    );
+    $data = $this->api->post( "account.json" );
     if ( ! isset( $data->id ) ){
       throw new Exception( "User profile request failed! {$this->providerId} returned an invalid response.", 6 );
     }


### PR DESCRIPTION
…nt.json

Removed the access_token from the GET parameters and put it in the Authorization header instead.
