### PR TITLE
Yahoo provider fix for firstname/lastname/e-mail

### DIFF
--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -122,9 +122,11 @@ class Yahoo extends OAuth2
 
         // E-mail is returned only with sdpp-w scope ( Read/Write (Public and Private) )
         foreach ($data->filter('emails')->toArray() as $item) {
-            if ($item->primary) {
-                $userProfile->email         = $item->handle;
-                $userProfile->emailVerified = $item->handle;
+            $item = new Data\Collection($item);
+
+            if ($item->get('primary')) {
+                $userProfile->email = $item->get('handle');
+                $userProfile->emailVerified = $item->get('handle');
             }
         }
 

--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -122,9 +122,9 @@ class Yahoo extends OAuth2
 
         // I ain't getting no emails on my tests. go figures..
         foreach ($data->filter('emails')->toArray() as $item) {
-            if ($data->get('primary')) {
-                $userProfile->email         = $data->get('handle');
-                $userProfile->emailVerified = $data->get('handle');
+            if ($item->primary) {
+                $userProfile->email         = $item->handle;
+                $userProfile->emailVerified = $item->handle;
             }
         }
 

--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -20,7 +20,7 @@ class Yahoo extends OAuth2
     /**
     * {@inheritdoc}
     */
-    protected $scope = 'sdps-r';
+    protected $scope = 'sdpp-w';
 
     /**
     * {@inheritdoc}
@@ -120,7 +120,7 @@ class Yahoo extends OAuth2
             $userProfile->gender = 'male';
         }
 
-        // I ain't getting no emails on my tests. go figures..
+        // E-mail is returned only with sdpp-w scope ( Read/Write (Public and Private) )
         foreach ($data->filter('emails')->toArray() as $item) {
             if ($item->primary) {
                 $userProfile->email         = $item->handle;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `Fixed Yahoo provider` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->

<!-- Describe your changes below in as much detail as possible -->

Fixed Yahoo provider not returning e-mails, added proper scope for returning firstname/lastname/e-mail. 'sdps-r' doesn't return much useful information except uid, nickname and avatar.