### PR TITLE
Add "state" parameter to LinkedIn Provider

### DIFF
--- a/hybridauth/Hybrid/Providers/LinkedIn.php
+++ b/hybridauth/Hybrid/Providers/LinkedIn.php
@@ -35,7 +35,14 @@ class Hybrid_Providers_LinkedIn extends Hybrid_Provider_Model_OAuth2 {
         if (is_array($this->scope)) {
             $this->scope = implode(" ", $this->scope);
         }
-        parent::loginBegin();
+        if (isset($this->scope)) {
+            $extra_params['scope'] = $this->scope;
+        }
+        if (!isset($this->state)) {
+            $this->state = hash("sha256",(uniqid(rand(), TRUE)));
+        }
+        $extra_params['state'] = $this->state;
+        Hybrid_Auth::redirect($this->api->authorizeUrl($extra_params));
     }
 
     /**


### PR DESCRIPTION
Addresses https://github.com/hybridauth/hybridauth/issues/988

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | #988
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No, just bug fix (stricter CSRF protection in force at LinkedIn

This fix is based on the code for the QQ provider: https://github.com/hybridauth/hybridauth/blob/v2/additional-providers/hybridauth-qq/Providers/QQ.php#L56-L71