### PR TITLE
Map response to Data\Collection object to use the get method

### DIFF
--- a/src/Provider/MicrosoftGraph.php
+++ b/src/Provider/MicrosoftGraph.php
@@ -82,6 +82,7 @@ class MicrosoftGraph extends OAuth2
                 throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
             }
             foreach ($data->filter('value')->toArray() as $entry) {
+                $entry = new Data\Collection($entry);
                 $userContact              = new User\Contact();
                 $userContact->identifier  = $entry->get('id');
                 $userContact->displayName = $entry->get('displayName');


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes. ` Uncaught Error: Call to undefined method stdClass::get() in /vendor/hybridauth/hybridauth/src/Provider/MicrosoftGraph.php:87`
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Documentation PR         | 

<!-- Describe your changes below in as much detail as possible -->
Bug fix for the MicrosoftGraph provider. 
