### PR TITLE
update tumblr endpoints

### DIFF
--- a/src/Provider/Tumblr.php
+++ b/src/Provider/Tumblr.php
@@ -20,22 +20,22 @@ class Tumblr extends OAuth1
     /**
     * {@inheritdoc}
     */
-    protected $apiBaseUrl = 'http://api.tumblr.com/v2/';
+    protected $apiBaseUrl = 'https://api.tumblr.com/v2/';
 
     /**
     * {@inheritdoc}
     */
-    protected $authorizeUrl = 'http://www.tumblr.com/oauth/authorize';
+    protected $authorizeUrl = 'https://www.tumblr.com/oauth/authorize';
 
     /**
     * {@inheritdoc}
     */
-    protected $requestTokenUrl = 'http://www.tumblr.com/oauth/request_token';
+    protected $requestTokenUrl = 'https://www.tumblr.com/oauth/request_token';
 
     /**
     * {@inheritdoc}
     */
-    protected $accessTokenUrl = 'http://www.tumblr.com/oauth/access_token';
+    protected $accessTokenUrl = 'https://www.tumblr.com/oauth/access_token';
 
     /**
     * {@inheritdoc}


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `Wrong Tumblr endpoints`  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->

<!-- Describe your changes below in as much detail as possible -->
Updates the endpoints of the Tumblr provider as described in https://www.tumblr.com/docs/en/api/v2 and issue #980. Http was used, but changed to https.

Hopefully I'm doing this in the right way.