### PR TITLE
Update Blizzard provider to work with their new API

### DIFF
--- a/src/Provider/Blizzard.php
+++ b/src/Provider/Blizzard.php
@@ -25,7 +25,7 @@ class Blizzard extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $apiBaseUrl = 'https://us.api.battle.net/';
+    protected $apiBaseUrl = 'https://us.battle.net/';
 
     /**
      * {@inheritdoc}
@@ -40,14 +40,14 @@ class Blizzard extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $apiDocumentation = 'https://dev.battle.net/docs/read/oauth';
+    protected $apiDocumentation = 'https://develop.battle.net/documentation';
 
     /**
      * {@inheritdoc}
      */
     public function getUserProfile()
     {
-        $response = $this->apiRequest('account/user');
+        $response = $this->apiRequest('oauth/userinfo');
 
         $data = new Data\Collection($response);
 

--- a/src/Provider/BlizzardAPAC.php
+++ b/src/Provider/BlizzardAPAC.php
@@ -20,7 +20,7 @@ class BlizzardAPAC extends Blizzard
     /**
      * {@inheritdoc}
      */
-    protected $apiBaseUrl = 'https://apac.api.battle.net/';
+    protected $apiBaseUrl = 'https://apac.battle.net/';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/BlizzardEU.php
+++ b/src/Provider/BlizzardEU.php
@@ -20,7 +20,7 @@ class BlizzardEU extends Blizzard
     /**
      * {@inheritdoc}
      */
-    protected $apiBaseUrl = 'https://eu.api.battle.net/';
+    protected $apiBaseUrl = 'https://eu.battle.net/';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | No
| Documentation PR         | No

<!-- Describe your changes below in as much detail as possible -->

Blizzard have opened up their new developer portal, and the old one will be discontinued on January 6, 2019. More information can be found [here](https://us.battle.net/forums/en/bnet/topic/20769317376), but the gist of it is that the base URL is changing, as well as the route for fetching the authenticated user's information has changed. Also, app developers will need to set up new app credentials on a regular Battle.net account.

I have already implemented these changes at work, and they are getting the job done for our Battle.net login. However, for this upstream change I wasn't sure about what procedure would work best; creating additional providers, or updating the current one.

In this PR I did opt for updating the current one, as this is most likely the desired solution after the old API is obsolete. It will however not work with the deprecated API, and is thus a breaking change. Please advise what you think is the best approach.