### PR TITLE
remove continue keyword. Let fetch paging from api

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -181,12 +181,10 @@ class Facebook extends OAuth2
                 throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
             }
 
-            if ($data->filter('data')->isEmpty()) {
-                continue;
-            }
-
-            foreach ($data->filter('data')->toArray() as $item) {
-                $contacts[] = $this->fetchUserContact($item);
+            if (!$data->filter('data')->isEmpty()) {
+                foreach ($data->filter('data')->toArray() as $item) {
+                    $contacts[] = $this->fetchUserContact($item);
+                }
             }
 
             if ($data->filter('paging')->exists('next')) {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | undefined variable: pagedList in vendor/hybridauth/hybridauth/src/Provider/Facebook.php on line 199,
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->

<!-- Describe your changes below in as much detail as possible -->
Remove `continue;` keyword so `$pagedList` can be set 
