### PR TITLE
Fixed $userProfile->identifier https issue

### DIFF
--- a/src/Provider/Steam.php
+++ b/src/Provider/Steam.php
@@ -44,7 +44,7 @@ class Steam extends OpenID
 
         $userProfile = $this->storage->get($this->providerId . '.user');
 
-        $userProfile->identifier = str_ireplace('http://steamcommunity.com/openid/id/', '', $userProfile->identifier);
+        $userProfile->identifier = str_ireplace(array('http://steamcommunity.com/openid/id/', 'https://steamcommunity.com/openid/id/'), '', $userProfile->identifier);
 
         if (! $userProfile->identifier) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->

<!-- Describe your changes below in as much detail as possible -->

When authenticating with steam, ->identifier may have https in and will not omit the url, giving the entire url instead of just the steam64id