### PR TITLE
Proper Steam profile URL

### DIFF
--- a/src/Provider/Steam.php
+++ b/src/Provider/Steam.php
@@ -10,7 +10,6 @@ namespace Hybridauth\Provider;
 use Hybridauth\Adapter\OpenID;
 use Hybridauth\Exception\UnexpectedApiResponseException;
 use Hybridauth\Data;
-use Hybridauth\User;
 
 /**
  * Steam OpenID provider adapter.
@@ -28,104 +27,118 @@ use Hybridauth\User;
 
  *   $userProfile = $adapter->getUserProfile();
  */
-class Steam extends OpenID
-{
+class Steam extends OpenID {
     /**
-    * {@inheritdoc}
-    */
-    protected $openidIdentifier = 'http://steamcommunity.com/openid';
+     * {@inheritdoc}
+     */
+    protected $openidIdentifier = 'https://steamcommunity.com/openid';
 
     /**
-    * {@inheritdoc}
-    */
-    public function authenticateFinish()
-    {
+     * @var string User profile URL template use in sprintf().
+     */
+    protected $profileUrlTemplate = 'https://steamcommunity.com/profiles/%s/';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function authenticateFinish() {
         parent::authenticateFinish();
 
-        $userProfile = $this->storage->get($this->providerId . '.user');
+        $userProfile = $this->storage->get( $this->providerId . '.user' );
 
-        $userProfile->identifier = str_ireplace(array('http://steamcommunity.com/openid/id/', 'https://steamcommunity.com/openid/id/'), '', $userProfile->identifier);
-
-        if (! $userProfile->identifier) {
-            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+        if ( !preg_match( '/\/(\d{1,})$/m', $userProfile->identifier, $matches ) ) {
+            throw new UnexpectedApiResponseException( 'Provider API returned an unexpected response.' );
         }
 
+        $userProfile->identifier = trim( $matches[1] );
+
         try {
-            $apiKey = $this->config->filter('keys')->get('secret');
+            $apiKey = $this->config->filter( 'keys' )->get( 'secret' );
 
             // if api key is provided, we attempt to use steam web api
-            if ($apiKey) {
-                $result = $this->getUserProfileWebAPI($apiKey, $userProfile->identifier);
-            }
-            // otherwise we fallback to community data
-            else {
-                $result = $this->getUserProfileLegacyAPI($userProfile->identifier);
+            if ( $apiKey ) {
+                $result = $this->getUserProfileWebAPI( $apiKey, $userProfile->identifier );
+            } else {
+                $result = $this->getUserProfileLegacyAPI( $userProfile->identifier );
             }
 
             // fetch user profile
-            foreach ($result as $k => $v) {
+            foreach ( $result as $k => $v ) {
                 $userProfile->$k = $v ?: $userProfile->$k;
             }
-        }
-        // these data are not mandatory, so keep it quite
-        catch (\Exception $e) {
+        } // these data are not mandatory, so keep it quite
+        catch ( \Exception $e ) {
         }
 
         // store user profile
-        $this->storage->set($this->providerId . '.user', $userProfile);
+        $this->storage->set( $this->providerId . '.user', $userProfile );
     }
 
     /**
-    * Fetch user profile on Steam web API
-    */
-    public function getUserProfileWebAPI($apiKey, $steam64)
-    {
+     * Fetch user profile on Steam web API
+     *
+     * @return array User data.
+     */
+    public function getUserProfileWebAPI( $apiKey, $steam64 ) {
         $apiUrl = 'http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=' . $apiKey . '&steamids=' . $steam64;
 
-        $response = $this->httpClient->request($apiUrl);
+        $response = $this->httpClient->request( $apiUrl );
 
-        $data = json_decode($response);
+        $data = json_decode( $response );
 
-        $data = isset($data->response->players[0]) ? $data->response->players[0] : null;
+        $data = isset( $data->response->players[0] ) ? $data->response->players[0] : null;
 
-        $data = new Data\Collection($data);
+        $data = new Data\Collection( $data );
 
         $userProfile = [];
 
-        $userProfile['displayName'] = (string)$data->get('personaname');
-        $userProfile['firstName'] = (string)$data->get('realname');
-        $userProfile['photoURL'] = (string)$data->get('avatarfull');
-        $userProfile['profileURL'] = (string)$data->get('profileurl');
-        $userProfile['country'] = (string)$data->get('loccountrycode');
+        $profileUrl = (string) $data->get( 'profileurl' );
+
+        if ( empty( $profileUrl ) ) {
+            $profileUrl = sprintf( $this->profileUrlTemplate, $steam64 );
+        }
+
+        $userProfile['displayName'] = (string) $data->get( 'personaname' );
+        $userProfile['firstName']   = (string) $data->get( 'realname' );
+        $userProfile['photoURL']    = (string) $data->get( 'avatarfull' );
+        $userProfile['profileURL']  = $profileUrl;
+        $userProfile['country']     = (string) $data->get( 'loccountrycode' );
 
         return $userProfile;
     }
 
     /**
-    * Fetch user profile on community API
-    */
-    public function getUserProfileLegacyAPI($steam64)
-    {
-        libxml_use_internal_errors(false);
+     * Fetch user profile on community API
+     *
+     * @param string $steam64 Steam ID, e.g. 76561198123452.
+     *
+     * @return array User data.
+     */
+    public function getUserProfileLegacyAPI( $steam64 ) {
+        libxml_use_internal_errors( false );
 
         $apiUrl = 'http://steamcommunity.com/profiles/' . $steam64 . '/?xml=1';
 
-        $response = $this->httpClient->request($apiUrl);
+        $response = $this->httpClient->request( $apiUrl );
 
-        $data = new \SimpleXMLElement($response);
+        $data = new \SimpleXMLElement( $response );
 
-        $data = new Data\Collection($data);
+        $data = new Data\Collection( $data );
 
         $userProfile = [];
 
-        $userProfile['displayName'] = (string)$data->get('steamID');
-        $userProfile['firstName'] = (string)$data->get('realname');
-        $userProfile['photoURL'] = (string)$data->get('avatarFull');
-        $userProfile['description'] = (string)$data->get('summary');
-        $userProfile['region'] = (string)$data->get('location');
-        $userProfile['profileURL'] = (string)$data->get('customURL')
-          ? 'http://steamcommunity.com/id/' . (string)$data->get('customURL')
-          : 'http://steamcommunity.com/profiles/' . $steam64;
+        $profileUrl = (string) $data->get( 'customURL' );
+
+        if ( empty( $profileUrl ) ) {
+            $profileUrl = sprintf( $this->profileUrlTemplate, $steam64 );
+        }
+
+        $userProfile['displayName'] = (string) $data->get( 'steamID' );
+        $userProfile['firstName']   = (string) $data->get( 'realname' );
+        $userProfile['photoURL']    = (string) $data->get( 'avatarFull' );
+        $userProfile['description'] = (string) $data->get( 'summary' );
+        $userProfile['region']      = (string) $data->get( 'location' );
+        $userProfile['profileURL']  = $profileUrl;
 
         return $userProfile;
     }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Yes
| Patch: Bug Fix?          | Somewhat
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Documentation PR         | Nah

Steam does not provide any data except identity of the user as they consider this as "sensitive data". 

From the provided identity, it is possible to build profile URL and the old implementation did not work very well as identity itself was as the full profile URL and profile URL was empty. 

Now identity is the ID itself and profile URL is real profile URL.
