### PR TITLE
setApiEndpoints() must be an instance of Hybridauth\Data\Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## [Hybridauth](https://hybridauth.github.io/) 3.0-rc8
+## [Hybridauth](https://hybridauth.github.io/) 3.0-rc9
 
 [![Build Status](https://travis-ci.org/hybridauth/hybridauth.svg?branch=master)](https://travis-ci.org/hybridauth/hybridauth) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/hybridauth/hybridauth/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/hybridauth/hybridauth/?branch=master) [![Latest Stable Version](https://poser.pugx.org/hybridauth/hybridauth/v/stable.png)](https://packagist.org/packages/hybridauth/hybridauth) [![Join the chat at https://gitter.im/hybridauth/hybridauth](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hybridauth/hybridauth?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/docs/developer-ref-user-authentication.md
+++ b/docs/developer-ref-user-authentication.md
@@ -59,11 +59,11 @@ $config = [
     * Hybridauth allows you to overwrite all the provider's API end point, which might be useful in some cases like when
     * there is a need to use a different API version for example.
     */
-    'endpoints' => new Hybridauth\Data\Collection([
+    'endpoints' => [
         'api_base_url' => 'https://www.googleapis.com/plus/v1/',
         'authorize_url' => 'https://accounts.google.com/o/oauth2/auth',
         'access_token_url' => 'https://accounts.google.com/o/oauth2/token',
-    ]),
+    ],
 
 
     /**

--- a/docs/developer-ref-user-authentication.md
+++ b/docs/developer-ref-user-authentication.md
@@ -59,11 +59,12 @@ $config = [
     * Hybridauth allows you to overwrite all the provider's API end point, which might be useful in some cases like when
     * there is a need to use a different API version for example.
     */
-    'endpoints' => [
-        'api_base_url'     => 'https://www.googleapis.com/plus/v1/',
-        'authorize_url'    => 'https://accounts.google.com/o/oauth2/auth',
+    'endpoints' => new Hybridauth\Data\Collection([
+        'api_base_url' => 'https://www.googleapis.com/plus/v1/',
+        'authorize_url' => 'https://accounts.google.com/o/oauth2/auth',
         'access_token_url' => 'https://accounts.google.com/o/oauth2/token',
-    ],
+    ]),
+
 
     /**
     * Optional: Custom Provider's Authorize Url Parameters


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Update docs
| Patch: Bug Fix?          | -
| Major: Breaking Change?  | -
| Minor: New Feature?      |
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->

``` php
Fatal error: Uncaught TypeError: Argument 1 passed to Hybridauth\Adapter\AbstractAdapter::setApiEndpoints() must be an instance of Hybridauth\Data\Collection, array given

```