### PR TITLE
LinkedIn V2 API changes for 2.13.0 version

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,8 @@
 see https://github.com/hybridauth/hybridauth/releases
+
+v2.13.1 
+Files affected
+/var/www/html/hybridauthnew/hybridauth/hybridauth/Hybrid/Providers/LinkedIn.php
+/var/www/html/hybridauthnew/hybridauth/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+
+Files modified for LinkedIn v2 API

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HybridAuth 2.13.0
+# HybridAuth 2.13.1
 
 [![Join the chat at https://gitter.im/hybridauth/hybridauth](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hybridauth/hybridauth?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hybridauth/hybridauth",
+    "name": "ym-careers/hybridauth",
     "description": "Open source social sign on PHP library.",
     "keywords": ["hybridauth", "login", "oauth", "social", "openid", "facebook", "google", "twitter", "yahoo"],
     "homepage": "http://hybridauth.sourceforge.net",
@@ -7,8 +7,8 @@
     "license": "(MIT or GPL-3.0+)",
     "authors": [
         {
-            "name": "Miled",
-            "email": "hybridauth@gmail.com"
+            "name": "ajay tidake",
+            "email": "ajay.tidake@communitybrands.com"
         }
     ],
     "support": {

--- a/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+++ b/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
@@ -132,7 +132,7 @@ class OAuth2Client
       $url = $this->api_base_url . $url;
     }
 
-    $parameters[$this->sign_token_name] = $this->access_token;
+    //$parameters[$this->sign_token_name] = $this->access_token;
     $response = null;
 
     switch( $method ){
@@ -207,9 +207,9 @@ class OAuth2Client
     Hybrid_Logger::info( "Enter OAuth2Client::request( $url )" );
     Hybrid_Logger::debug( "OAuth2Client::request(). dump request params: ", serialize( $params ) );
 
-	$urlEncodedParams = http_build_query($params, '', '&');
+    $urlEncodedParams = http_build_query($params, '', '&');
 
-    if( $type == "GET" ){
+    if( $type == "GET" && !empty($urlEncodedParams) ){
       $url = $url . ( strpos( $url, '?' ) ? '&' : '?' ) . $urlEncodedParams;
     }
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Added support for LinkedIn V2 API for v2.13.0
| Minor: New Feature?      |
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->

<!-- Describe your changes below in as much detail as possible -->
As we know from March 01, 2019 LinkedIn going to stop V1 API support. Before that, we need to update all API endpoint with V2 support. Might be you are working on that and in future, you going to release the new version with V2 support. But till now we don't have a solution for that. 
I have updated Hybridauth V2.13.0 version to support LinkedIn V2 API.
Files Affected:
**hybridauth/Hybrid/Providers/LinkedIn.php**
**hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php**

Changes:
1. hybridauth/Hybrid/Providers/LinkedIn.php
- Scope updated
- V2 endpoint updated
- fields updated for SignIn Request
- New CURL request added for the email address

2. hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php**
- I am not getting why we passing bearer token as a parameter. Because below that code available to pass token in curl header.