### PR TITLE
Issue #1056: Upgrade facebook graph version to v2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HybridAuth 2.13.0
+# HybridAuth 2.14.0
 
 [![Join the chat at https://gitter.im/hybridauth/hybridauth](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hybridauth/hybridauth?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -15,7 +15,7 @@
  */
 class Hybrid_Auth {
 
-	public static $version = "2.13.0";
+	public static $version = "2.14.0";
 
 	/**
 	 * Configuration array

--- a/hybridauth/Hybrid/Providers/Facebook.php
+++ b/hybridauth/Hybrid/Providers/Facebook.php
@@ -59,7 +59,7 @@ class Hybrid_Providers_Facebook extends Hybrid_Provider_Model {
         $this->api = new FacebookSDK([
             'app_id' => $this->config["keys"]["id"],
             'app_secret' => $this->config["keys"]["secret"],
-            'default_graph_version' => 'v2.8',
+            'default_graph_version' => !empty($this->config['default_graph_version']) ? $this->config['default_graph_version'] : 'v2.12',
             'trustForwarded' => $trustForwarded,
         ]);
     }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1056
| Patch: Bug Fix?          |
| Major: Breaking Change?  | [x] 
| Minor: New Feature?      | [x]

BC: If you still use v2.8, it's recommended upgrade to at least v2.12 of Graph API.
See https://developers.facebook.com/docs/graph-api/changelog/

btw, if you still want to use own version of Graph API, you can do it via Hybridauth config - `default_graph_version`.

e.g 
```php
$config = [
  "base_url" => "http://mywebsite.com/path/to/hybridauth/",
  "providers" => [
    "Facebook" => [
      "enabled" => true,
      "default_graph_version" => "PUT_YOURS_HERE", // e.g v3.0
      "keys"    => [
        "id" => "PUT_YOURS_HERE", 
        "secret" => "PUT_YOURS_HERE",
      ],
    ],
  ],
];
```
