### PR TITLE
Upgrade facebook graph version to v2.12

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -47,7 +47,7 @@ class Facebook extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $apiBaseUrl = 'https://graph.facebook.com/v2.8/';
+    protected $apiBaseUrl = 'https://graph.facebook.com/v2.12/';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1056
| Patch: Bug Fix?          |
| Major: Breaking Change?  | [x] 
| Minor: New Feature?      | [x]

BC: If you still use v2.8, it's recommended upgrade to at least v2.12 of Graph API.
See https://developers.facebook.com/docs/graph-api/changelog/