### PR TITLE
Allow POST method in OAuth2 authentification

### DIFF
--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -298,7 +298,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         try {
             $this->authenticateCheckError();
 
-            $code = filter_input(INPUT_GET, 'code');
+            $code = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
 
             if (empty($code)) {
                 $this->authenticateBegin();
@@ -367,8 +367,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             [HttpClient\Util::getCurrentUrl(true)]
         );
 
-        $state = filter_input(INPUT_GET, 'state');
-        $code = filter_input(INPUT_GET, 'code');
+        $state = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'state');
+        $code = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
 
         /**
         * Authorization Request State


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Closes #1065
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Documentation PR         | No

Support of POST HTTP method for OAuth2 authentification