### PR TITLE
Add DELETE request method support

### DIFF
--- a/src/HttpClient/Curl.php
+++ b/src/HttpClient/Curl.php
@@ -121,6 +121,15 @@ class Curl implements HttpClientInterface
             $uri = $uri . (strpos($uri, '?') ? '&' : '?') . http_build_query($parameters);
         }
 
+        if ('DELETE' == $method) {
+            unset($this->curlOptions[CURLOPT_POST]);
+            unset($this->curlOptions[CURLOPT_POSTFIELDS]);
+
+            $uri = $uri . (strpos($uri, '?') ? '&' : '?') . http_build_query($parameters);
+
+            $this->curlOptions[CURLOPT_CUSTOMREQUEST] = 'DELETE';
+        }
+
         if ('POST' == $method) {
             $body_content = http_build_query($parameters);
             if (isset($this->requestHeader['Content-Type']) && $this->requestHeader['Content-Type'] == 'application/json') {

--- a/src/HttpClient/Guzzle.php
+++ b/src/HttpClient/Guzzle.php
@@ -127,6 +127,10 @@ class Guzzle implements HttpClientInterface
                 $response = $this->client->get($uri, ['query' => $parameters, 'headers' => $this->requestHeader]);
             }
 
+            if ('DELETE' == $method) {
+                $response = $this->client->delete($uri, ['query' => $parameters, 'headers' => $this->requestHeader]);
+            }
+
             if ('POST' == $method) {
                 $body_content = 'form_params';
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Documentation PR         | No

Add support for DELETE request methods to both HttpClients to support API requests for deleting status updates, etc
