### PR TITLE
Add 'authorize_url_parameters' config support to OAuth 1 providers

### DIFF
--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -96,6 +96,13 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     protected $consumerToken = null;
 
     /**
+    * Authorization Url Parameters
+    *
+    * @var boolean
+    */
+    protected $AuthorizeUrlParameters = [];
+
+    /**
     * @var string
     */
     protected $requestTokenMethod = 'POST';
@@ -297,13 +304,16 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     */
     protected function getAuthorizeUrl($parameters = [])
     {
-        $defaults = [
-            'oauth_token' => $this->getStoredData('request_token')
-        ];
+        $this->AuthorizeUrlParameters = !empty($parameters)
+                    ? $parameters
+                    : array_replace(
+                        (array) $this->AuthorizeUrlParameters,
+                        (array) $this->config->get('authorize_url_parameters')
+                    );
 
-        $parameters = array_replace($defaults, (array)$parameters);
+        $this->AuthorizeUrlParameters['oauth_token'] = $this->getStoredData('request_token');
 
-        return $this->authorizeUrl . '?' . http_build_query($parameters, '', '&');
+        return $this->authorizeUrl . '?' . http_build_query($this->AuthorizeUrlParameters, '', '&');
     }
 
     /**


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |  No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Documentation PR         | No

Add config handling for authorize_url_parameters in OAuth 1 providers

Allows usage for things like Twitter force_login
> Forces the user to enter their credentials to ensure the correct users account is authorized.
https://developer.twitter.com/en/docs/basics/authentication/api-reference/authenticate.html
