### PR TITLE
Add support for multipart requests for video upload support

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -126,7 +126,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [])
+    public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         throw new NotImplementedException('Provider does not support this feature.');
     }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -91,10 +91,11 @@ interface AdapterInterface
      * @param string $method
      * @param array $parameters
      * @param array $headers
+     * @param bool $multipart
      *
      * @return mixed
      */
-    public function apiRequest($url, $method = 'GET', $parameters = [], $headers = []);
+    public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [], $multipart = false);
 
     /**
      * Return oauth access tokens.

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -652,13 +652,14 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     * @param string $method
     * @param array $parameters
     * @param array $headers
+    * @param bool $multipart
     *
     * @return mixed
     * @throws \Hybridauth\Exception\HttpClientFailureException
     * @throws \Hybridauth\Exception\HttpRequestFailedException
     * @throws InvalidAccessTokenException
     */
-    public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [])
+    public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         // refresh tokens if needed
         if ($this->hasAccessTokenExpired() === true) {
@@ -676,7 +677,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             $url,
             $method,     // HTTP Request Method. Defaults to GET.
             $parameters, // Request Parameters
-            $headers     // Request Headers
+            $headers,    // Request Headers
+            $multipart   // Is request multipart
         );
 
         $this->validateApiResponse('Signed API request has returned an error');

--- a/src/HttpClient/Curl.php
+++ b/src/HttpClient/Curl.php
@@ -101,7 +101,7 @@ class Curl implements HttpClientInterface
     /**
     * {@inheritdoc}
     */
-    public function request($uri, $method = 'GET', $parameters = [], $headers = [])
+    public function request($uri, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         $this->requestHeader = array_replace($this->requestHeader, (array) $headers);
 
@@ -127,7 +127,7 @@ class Curl implements HttpClientInterface
                 break;
             case 'PUT':
             case 'POST':
-                $body_content = http_build_query($parameters);
+                $body_content = $multipart ? $parameters : http_build_query($parameters);
                 if (isset($this->requestHeader['Content-Type'])
                     && $this->requestHeader['Content-Type'] == 'application/json'
                 ) {

--- a/src/HttpClient/Guzzle.php
+++ b/src/HttpClient/Guzzle.php
@@ -144,22 +144,21 @@ class Guzzle implements HttpClientInterface
                     $body_content = $parameters;
                     if ($multipart) {
                         $body_content = [];
-                        foreach($parameters as $key => $val) {
-
+                        foreach ($parameters as $key => $val) {
                             if ($val instanceof \CURLFile) {
                                 $val = fopen($val->getFilename(), 'r');
                             }
 
                             $body_content[] = [
-                                    'name' => $key,
-                                    'contents' => $val,
+                                'name' => $key,
+                                'contents' => $val,
                             ];
                         }
                     }
 
                     $response = $this->client->request($method, $uri,
-                      $body_type => $body_content,
-                      'headers' => $this->requestHeader,
+                        $body_type => $body_content,
+                        'headers' => $this->requestHeader,
                     ]);
                     break;
             }
@@ -169,7 +168,7 @@ class Guzzle implements HttpClientInterface
             $this->responseClientError = $e->getMessage();
         }
 
-        if (! $this->responseClientError) {
+        if (!$this->responseClientError) {
             $this->responseBody     = $response->getBody();
             $this->responseHttpCode = $response->getStatusCode();
             $this->responseHeader   = $response->getHeaders();

--- a/src/HttpClient/Guzzle.php
+++ b/src/HttpClient/Guzzle.php
@@ -109,7 +109,7 @@ class Guzzle implements HttpClientInterface
     /**
     * {@inheritdoc}
     */
-    public function request($uri, $method = 'GET', $parameters = [], $headers = [])
+    public function request($uri, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         $this->requestHeader = array_replace($this->requestHeader, (array) $headers);
 
@@ -133,16 +133,32 @@ class Guzzle implements HttpClientInterface
                     break;
                 case 'PUT':
                 case 'POST':
-                    $body_content = 'form_params';
+                    $body_type = $multipart ? 'multipart' : 'form_params';
 
                     if (isset($this->requestHeader['Content-Type'])
                         && $this->requestHeader['Content-Type'] === 'application/json'
                     ) {
-                        $body_content = 'json';
+                        $body_type = 'json';
                     }
 
-                    $response = $this->client->request($method, $uri, [
-                      $body_content => $parameters,
+                    $body_content = $parameters;
+                    if ($multipart) {
+                        $body_content = [];
+                        foreach($parameters as $key => $val) {
+
+                            if ($val instanceof \CURLFile) {
+                                $val = fopen($val->getFilename(), 'r');
+                            }
+
+                            $body_content[] = [
+                                    'name' => $key,
+                                    'contents' => $val,
+                            ];
+                        }
+                    }
+
+                    $response = $this->client->request($method, $uri,
+                      $body_type => $body_content,
                       'headers' => $this->requestHeader,
                     ]);
                     break;

--- a/src/HttpClient/HttpClientInterface.php
+++ b/src/HttpClient/HttpClientInterface.php
@@ -21,10 +21,11 @@ interface HttpClientInterface
     * @param string $method
     * @param array  $parameters
     * @param array  $headers
+    * @param bool   $multipart
     *
     * @return mixed
     */
-    public function request($uri, $method = 'GET', $parameters = [], $headers = []);
+    public function request($uri, $method = 'GET', $parameters = [], $headers = [], $multipart = false);
 
     /**
     * Returns raw response from the server on success, FALSE on failure


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes
| Documentation PR         | No

Update Http interfaces to support multipart requests to support file uploads through apiRequest


```
$facebookAdapter->apiRequest('https://graph-video.facebook.com/xyz/videos',
                                  'POST',
                                  [
                                          'title'       => $videoTitle,
                                          'description' => $videoDescription,
                                          'source'      => new \CURLFile($videoPath),
                                  ],
                                  [],
                                  true
        );
```
