### PR TITLE
Vkontakte getUserProfile fields

### DIFF
--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -87,9 +87,10 @@ class Vkontakte extends OAuth2
     */
     public function getUserProfile()
     {
+        $photoField = 'photo_' . ($this->config->get('photo_size') ?: 'max_orig');
         $parameters = [
             'user_ids' => $this->getStoredData('user_id'),
-            'fields' => 'first_name,last_name,screen_name,sex,has_photo,photo_max_orig',
+            'fields' => 'first_name,last_name,screen_name,sex,has_photo,' . $photoField,
             'v' => '5.74',
             $this->accessTokenName => $this->getStoredData($this->accessTokenName),
         ];
@@ -113,7 +114,7 @@ class Vkontakte extends OAuth2
         $userProfile->firstName   = $data->get('first_name');
         $userProfile->lastName    = $data->get('last_name');
         $userProfile->displayName = $data->get('screen_name');
-        $userProfile->photoURL    = $data->get('has_photo') === 1 ? $data->get('photo_max_orig') : '';
+        $userProfile->photoURL    = $data->get('has_photo') === 1 ? $data->get($photoField) : '';
 
         $screen_name = 'https://vk.com/' . ($data->get('screen_name') ?: 'id' . $data->get('id'));
         $userProfile->profileURL  = $screen_name;

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -92,7 +92,7 @@ class Vkontakte extends OAuth2
             'user_ids' => $this->getStoredData('user_id'),
             // Required fields: id,first_name,last_name
             'fields' => 'screen_name,sex,has_photo,' . $photoField,
-            'v' => '5.74',
+            'v' => '5.95',
             $this->accessTokenName => $this->getStoredData($this->accessTokenName),
         ];
 

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -89,7 +89,7 @@ class Vkontakte extends OAuth2
     {
         $parameters = [
             'user_ids' => $this->getStoredData('user_id'),
-            'fields' => 'first_name,last_name,nickname,screen_name,sex,bdate,timezone,photo_rec,photo_big,photo_max_orig',
+            'fields' => 'first_name,last_name,screen_name,sex,photo_max_orig',
             'v' => '5.74',
             $this->accessTokenName => $this->getStoredData($this->accessTokenName),
         ];

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -90,7 +90,8 @@ class Vkontakte extends OAuth2
         $photoField = 'photo_' . ($this->config->get('photo_size') ?: 'max_orig');
         $parameters = [
             'user_ids' => $this->getStoredData('user_id'),
-            'fields' => 'first_name,last_name,screen_name,sex,has_photo,' . $photoField,
+            // Required fields: id,first_name,last_name
+            'fields' => 'screen_name,sex,has_photo,' . $photoField,
             'v' => '5.74',
             $this->accessTokenName => $this->getStoredData($this->accessTokenName),
         ];

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -89,7 +89,7 @@ class Vkontakte extends OAuth2
     {
         $parameters = [
             'user_ids' => $this->getStoredData('user_id'),
-            'fields' => 'first_name,last_name,screen_name,sex,photo_max_orig',
+            'fields' => 'first_name,last_name,screen_name,sex,has_photo,photo_max_orig',
             'v' => '5.74',
             $this->accessTokenName => $this->getStoredData($this->accessTokenName),
         ];
@@ -113,7 +113,7 @@ class Vkontakte extends OAuth2
         $userProfile->firstName   = $data->get('first_name');
         $userProfile->lastName    = $data->get('last_name');
         $userProfile->displayName = $data->get('screen_name');
-        $userProfile->photoURL    = $data->get('photo_max_orig');
+        $userProfile->photoURL    = $data->get('has_photo') === 1 ? $data->get('photo_max_orig') : '';
 
         $screen_name = 'https://vk.com/' . ($data->get('screen_name') ?: 'id' . $data->get('id'));
         $userProfile->profileURL  = $screen_name;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes

### Improvements for Vkontakte getUserProfile.

**Updated API version to latest, getUserProfile.**

**Removed unnecessary unused fields and required fields, getUserProfile.**

**Added check for "photoUrl" using the has_photo field, getUserProfile.**

**Added support "photo_size" parameter for provider config.**
See examples for other providers: 
- [Foursquare.php#L85](https://github.com/hybridauth/hybridauth/blob/b515c3fae7669e9774718129754f334ebf3009e8/src/Provider/Foursquare.php#L85)
- [Foursquare.php#L120](https://github.com/hybridauth/hybridauth/blob/b515c3fae7669e9774718129754f334ebf3009e8/src/Provider/Foursquare.php#L120)
- [Google.php#L121](https://github.com/hybridauth/hybridauth/blob/6123c31700bda7acd49cef7f1f0c138b60f39070/src/Provider/Google.php#L121)
- [Facebook.php#L119](https://github.com/hybridauth/hybridauth/blob/8fb76f197c862d1f996ac7eb79f4efda243f8f74/src/Provider/Facebook.php#L119)