### PR TITLE
Fix Twitter follower and following counts

### DIFF
--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -109,8 +109,8 @@ class Twitter extends OAuth1
                                         : '';
 
         $userProfile->data = [
-          'followed_by' => $data->get('friends_count'),
-          'follows' => $data->get('followers_count'),
+          'followed_by' => $data->get('followers_count'),
+          'follows' => $data->get('friends_count'),
         ];
 
         return $userProfile;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1089 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Bug Fix for Twitter
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

The Twitter provider had the followers count and friends count reversed. "followers_count" from Twitter corresponds to "followed_by" and "friends_count" corresponds to "follows".
 