### PR TITLE
Odnoklassniki missed tokenRefreshParameters

### DIFF
--- a/src/Provider/Odnoklassniki.php
+++ b/src/Provider/Odnoklassniki.php
@@ -54,6 +54,19 @@ class Odnoklassniki extends OAuth2
     /**
     * {@inheritdoc}
     */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        $this->tokenRefreshParameters += [
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret
+        ];
+    }
+
+    /**
+    * {@inheritdoc}
+    */
     public function getUserProfile()
     {
         $fields = array(


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

https://apiok.ru/en/ext/oauth/server

5. Using a refresh_token With a refresh_token you can obtain an access_token via the simplified procedure by sending one POST query to:

https://api.ok.ru/oauth/token.do?refresh_token={refresh_token}&client_id={client_id}&client_secret={client_secret}&grant_type={grant_type}

