### PR TITLE
PSR-7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "gitter": "https://gitter.im/hybridauth/hybridauth"
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "zendframework/zend-diactoros": "^1.4||^2.0"
     },
     "require-dev": {
         "ext-curl": "*",
@@ -29,7 +30,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-           "HybridauthTest\\Hybridauth\\": "test/"
+           "HybridauthTest\\Hybridauth\\": "tests/"
         }
     },
     "extra": {

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -18,6 +18,8 @@ use Hybridauth\Logger\Logger;
 use Hybridauth\HttpClient\HttpClientInterface;
 use Hybridauth\HttpClient\Curl as HttpClient;
 use Hybridauth\Data;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\ServerRequestFactory;
 
 /**
  * Class AbstractAdapter
@@ -365,5 +367,35 @@ abstract class AbstractAdapter implements AdapterInterface
                 '. Raw Provider API response: '.$this->httpClient->getResponseBody().'.'
             );
         }
+    }
+
+    /**
+     * @param ServerRequestInterface|null $request
+     *
+     * @return ServerRequestInterface
+     */
+    protected function generateRequest(ServerRequestInterface $request = null)
+    {
+        if ($request === null) {
+            $request = ServerRequestFactory::fromGlobals()->withAttribute('HYBRIDAUTH::GENERATED', true);
+        }
+
+        return $request;
+    }
+
+    protected function isGeneratedRequest(ServerRequestInterface $request)
+    {
+        return $request->getAttribute('HYBRIDAUTH::GENERATED', false) === true;
+    }
+
+    /**
+     * @param                        $paramKey
+     * @param ServerRequestInterface $request
+     *
+     * @return mixed|null
+     */
+    protected function getQueryParamFromRequest($paramKey, ServerRequestInterface $request)
+    {
+        return array_key_exists($paramKey, $request->getQueryParams()) ? $request->getQueryParams()[$paramKey] : null;
     }
 }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -10,6 +10,8 @@ namespace Hybridauth\Adapter;
 use Hybridauth\HttpClient\HttpClientInterface;
 use Hybridauth\Storage\StorageInterface;
 use Hybridauth\Logger\LoggerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Interface AdapterInterface
@@ -19,9 +21,12 @@ interface AdapterInterface
     /**
      * Initiate the appropriate protocol and process/automate the authentication or authorization flow.
      *
-     * @return boolean|null
+     * @param ServerRequestInterface|null $request
+     *
+     * @return boolean|ResponseInterface|null If already connected, returns true.
+     * If $request is not null a RedirectResponse is returned.
      */
-    public function authenticate();
+    public function authenticate(ServerRequestInterface $request = null);
 
     /**
      * Returns TRUE if the user is connected


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | Yes

**Breaking Change:**
Changed signature of `Hybridauth\Adapter\AdapterInterface::authenticate` so it accepts a `Psr\Http\Message\ServerRequestInterface $request = null`.

**Description:**
Changed adapters (OpenID, OAuth1, OAuth2) accordingly to new method signature.
If a `$request !== null` is passed to `Hybridauth\Adapter\AdapterInterface::authenticate` it will return a RedirectResponse which can than be handled separately.

Allows easy integration into all PSR-15 applications.
Also solves a bug when using custom session handlers like `zendframework/zend-expressive-session` or `psr7-sessions/storageless` where sessions are persisted at the end of the execution chain (which is after `::authenticateBegin` is called where a redirect is forced).