### PR TITLE
Update PHP Doc Blocks in Auth.php

### DIFF
--- a/hybridauth/Hybrid/Auth.php
+++ b/hybridauth/Hybrid/Auth.php
@@ -49,7 +49,7 @@ class Hybrid_Auth {
 	 * refer to the Configuration section:
 	 * http://hybridauth.sourceforge.net/userguide/Configuration.html
 	 *
-	 * @param array $config Configuration array or path to a configratuion file
+	 * @param array|string $config Configuration array or path to a configratuion file
 	 */
 	function __construct($config) {
 		Hybrid_Auth::initialize($config);
@@ -58,7 +58,7 @@ class Hybrid_Auth {
 	/**
 	 * Try to initialize Hybrid_Auth with given $config hash or file
 	 *
-	 * @param array $config Configuration array or path to a configratuion file
+	 * @param array|string $config Configuration array or path to a configratuion file
 	 * @return void
 	 * @throws Exception
 	 */
@@ -217,7 +217,7 @@ class Hybrid_Auth {
 	 *           google_service: can be "Users" for Google user accounts service or "Apps" for Google hosted Apps
 	 *
 	 * @param string $providerId ID of the provider
-	 * @param array  $params      Params
+	 * @param array|null  $params      Params
 	 * @return
 	 */
 	public static function authenticate($providerId, $params = null) {
@@ -238,7 +238,7 @@ class Hybrid_Auth {
 	/**
 	 * Return the adapter instance for an authenticated provider
 	 *
-	 * @param string $providerId ID of the provider
+	 * @param string|null $providerId ID of the provider
 	 * @return Hybrid_Provider_Adapter
 	 */
 	public static function getAdapter($providerId = null) {
@@ -250,7 +250,7 @@ class Hybrid_Auth {
 	 * Setup an adapter for a given provider
 	 *
 	 * @param string $providerId ID of the provider
-	 * @param array  $params     Adapter params
+	 * @param array|null  $params     Adapter params
 	 * @return Hybrid_Provider_Adapter
 	 */
 	public static function setup($providerId, $params = null) {


### PR DESCRIPTION
This change set updates a few Types in PHP Doc Blocks to better reflect what's possible. I was recently running a fairly large project through [Phan static analysis](https://github.com/phan/phan) and a few issues came up in the Hybrid Auth class specifically around `__construct()` and `initialize()` specifying they _only_ accept arrays. In reality they both accept both arrays or a string.

Comments have been updated to reflect this. Additionally, optional parameters that default to `null` have had their Doc Blocks updated as well.

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | None
| Patch: Bug Fix?          | Not really
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
