### PR TITLE
Facebook emailVerified should not test "verified"

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -120,7 +120,10 @@ class Facebook extends OAuth2
 
         $userProfile->photoURL = $this->apiBaseUrl . $userProfile->identifier . '/picture?width=' . $photoSize . '&height=' . $photoSize;
 
-        $userProfile->emailVerified = $data->get('verified') == 1 ? $userProfile->email : '';
+        // Don't use $data->get('verified') here, as Facebook will only return an email if it is validated first:
+        // https://developers.facebook.com/docs/graph-api/reference/v2.0/user
+        // "The User's primary email address listed on their profile. This field will not be returned if no valid email address is available."
+        $userProfile->emailVerified = !empty($userProfile->email);
 
         $userProfile = $this->fetchUserRegion($userProfile);
 

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -123,7 +123,7 @@ class Facebook extends OAuth2
         // Don't use $data->get('verified') here, as Facebook will only return an email if it is validated first:
         // https://developers.facebook.com/docs/graph-api/reference/v2.0/user
         // "The User's primary email address listed on their profile. This field will not be returned if no valid email address is available."
-        $userProfile->emailVerified = !empty($userProfile->email);
+        $userProfile->emailVerified = $userProfile->email;
 
         $userProfile = $this->fetchUserRegion($userProfile);
 


### PR DESCRIPTION
This fixes issue #1110

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1110
| Patch: Bug Fix?          | Bug Fix

<!-- Describe your changes below in as much detail as possible -->
Uses a simple test on the email field to know if the emailVerified should be true or not.
