### PR TITLE
Add Slack provider

### DIFF
--- a/src/Data/Collection.php
+++ b/src/Data/Collection.php
@@ -135,8 +135,8 @@ final class Collection
     {
         $properties = [];
 
-        foreach ($this->collection as $property) {
-            $properties[] = $property;
+        foreach ($this->collection as $key => $value) {
+            $properties[] = $key;
         }
 
         return $properties;
@@ -151,8 +151,8 @@ final class Collection
     {
         $values = [];
 
-        foreach ($this->collection as $property) {
-            $values[] = $this->get($property);
+        foreach ($this->collection as $value) {
+            $values[] = $value;
         }
 
         return $values;

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -1,0 +1,85 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2019 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Provider;
+
+use Hybridauth\Adapter\OAuth2;
+use Hybridauth\Exception\UnexpectedApiResponseException;
+use Hybridauth\Data;
+use Hybridauth\User;
+
+/**
+ * Slack OAuth2 provider adapter.
+ */
+class Slack extends OAuth2
+{
+    /**
+    * {@inheritdoc}
+    */
+    public $scope = 'identity.basic identity.email identity.avatar';
+
+    /**
+     {@inheritdoc}
+    */
+    protected $apiBaseUrl = 'https://slack.com/';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $authorizeUrl = 'https://slack.com/oauth/authorize';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $accessTokenUrl = 'https://slack.com/api/oauth.access';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected $apiDocumentation = 'https://api.slack.com/docs/sign-in-with-slack';
+
+    /**
+    * {@inheritdoc}
+    */
+    public function getUserProfile()
+    {
+        $response = $this->apiRequest('api/users.identity');
+
+        $data = new Data\Collection($response);
+
+        if (! $data->exists('ok') || ! $data->get('ok')) {
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+        }
+
+        $userProfile = new User\Profile();
+
+        $userProfile->identifier  = $data->filter('user')->get('id');
+        $userProfile->displayName = $data->filter('user')->get('name');
+        $userProfile->email       = $data->filter('user')->get('email');
+        $userProfile->photoURL    = $this->findLargestImage($data);
+
+        return $userProfile;
+    }
+
+    private function findLargestImage(Data\Collection $data)
+    {
+        $maxSize = 0;
+        foreach ($data->filter('user')->properties() as $property) {
+            if (preg_match('^image_(\\d+)$', $property, $matches) === 1) {
+                $availableSize = (int) $matches[1];
+                if ($maxSize < $availableSize) {
+                    $maxSize = $availableSize;
+                }
+            }
+        }
+        if ($maxSize > 0) {
+            return $data->filter('user')->get('image_' . $maxSize);
+        }
+        return null;
+    }
+
+}

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -17,71 +17,77 @@ use Hybridauth\User;
  */
 class Slack extends OAuth2
 {
+
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public $scope = 'identity.basic identity.email identity.avatar';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://slack.com/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://slack.com/oauth/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://slack.com/api/oauth.access';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://api.slack.com/docs/sign-in-with-slack';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('api/users.identity');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('ok') || ! $data->get('ok')) {
+        if (!$data->exists('ok') || !$data->get('ok')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->filter('user')->get('id');
+        $userProfile->identifier = $data->filter('user')->get('id');
         $userProfile->displayName = $data->filter('user')->get('name');
-        $userProfile->email       = $data->filter('user')->get('email');
-        $userProfile->photoURL    = $this->findLargestImage($data);
+        $userProfile->email = $data->filter('user')->get('email');
+        $userProfile->photoURL = $this->findLargestImage($data);
 
         return $userProfile;
     }
 
     /**
-    * Returns the url of the image with the highest resolution in the user object.
-    *
-    * Slack sends multiple image urls with different resolutions. As they make no guarantees
-    * which resolutions will be included we have to search all <code>image_*</code> properties
-    * for the one with the highest resolution. The resolution is attached to the property
-     * name such as <code>image_32</code> or <code>image_192</code>.
-    *
-    * @param Data\Collection $data response object as returned by <code>api/users.identity</code>
-    * @return string|null the value of the <code>image_*</code> property with the highest resolution.
-    */
+     * Returns the url of the image with the highest resolution in the user
+     * object.
+     *
+     * Slack sends multiple image urls with different resolutions. As they make
+     * no guarantees which resolutions will be included we have to search all
+     * <code>image_*</code> properties for the one with the highest resolution.
+     * The resolution is attached to the property name such as
+     * <code>image_32</code> or <code>image_192</code>.
+     *
+     * @param Data\Collection $data response object as returned by
+     *     <code>api/users.identity</code>
+     *
+     * @return string|null the value of the <code>image_*</code> property with
+     *     the highest resolution.
+     */
     private function findLargestImage(Data\Collection $data)
     {
         $maxSize = 0;
         foreach ($data->filter('user')->properties() as $property) {
             if (preg_match('/^image_(\d+)$/', $property, $matches) === 1) {
-                $availableSize = (int) $matches[1];
+                $availableSize = (int)$matches[1];
                 if ($maxSize < $availableSize) {
                     $maxSize = $availableSize;
                 }
@@ -92,5 +98,4 @@ class Slack extends OAuth2
         }
         return null;
     }
-
 }

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -69,7 +69,7 @@ class Slack extends OAuth2
     {
         $maxSize = 0;
         foreach ($data->filter('user')->properties() as $property) {
-            if (preg_match('^image_(\\d+)$', $property, $matches) === 1) {
+            if (preg_match('/^image_(\d+)$/', $property, $matches) === 1) {
                 $availableSize = (int) $matches[1];
                 if ($maxSize < $availableSize) {
                     $maxSize = $availableSize;

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -23,7 +23,7 @@ class Slack extends OAuth2
     public $scope = 'identity.basic identity.email identity.avatar';
 
     /**
-     {@inheritdoc}
+    * {@inheritdoc}
     */
     protected $apiBaseUrl = 'https://slack.com/';
 
@@ -65,6 +65,17 @@ class Slack extends OAuth2
         return $userProfile;
     }
 
+    /**
+    * Returns the url of the image with the highest resolution in the user object.
+    *
+    * Slack sends multiple image urls with different resolutions. As they make no guarantees
+    * which resolutions will be included we have to search all <code>image_*</code> properties
+    * for the one with the highest resolution. The resolution is attached to the property
+     * name such as <code>image_32</code> or <code>image_192</code>.
+    *
+    * @param Data\Collection $data response object as returned by <code>api/users.identity</code>
+    * @return string|null the value of the <code>image_*</code> property with the highest resolution.
+    */
     private function findLargestImage(Data\Collection $data)
     {
         $maxSize = 0;

--- a/src/Provider/TwitchTV.php
+++ b/src/Provider/TwitchTV.php
@@ -55,7 +55,7 @@ class TwitchTV extends OAuth2
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
-        $users = $data->filter('data')->properties();
+        $users = $data->filter('data')->values();
         $user = new Data\Collection($users[0]);
 
         $userProfile = new User\Profile();


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Adds a provider for logging in with Slack

Adds a new provider for logging in with https://slack.com/.

In order to use it, a [Slack app](https://api.slack.com/docs/sign-in-with-slack) with the permission scopes `identity.basic`, `identity.email` and `identity.avatar` needs to be created. It is not necessary to add the app to a workspace (in fact it is not even possible if the app has only the `identity.*` scopes).
