### PR TITLE
Fix for Steam Provider Client

### DIFF
--- a/src/Provider/Steam.php
+++ b/src/Provider/Steam.php
@@ -11,6 +11,7 @@ use Hybridauth\Adapter\OpenID;
 use Hybridauth\Exception\UnexpectedApiResponseException;
 use Hybridauth\Data;
 use Hybridauth\User;
+use Hybridauth\Thirdparty\OpenID\LightOpenID;
 
 /**
  * Steam OpenID provider adapter.
@@ -34,6 +35,21 @@ class Steam extends OpenID
     * {@inheritdoc}
     */
     protected $openidIdentifier = 'http://steamcommunity.com/openid';
+    
+    /**
+    * {@inheritdoc}
+    */
+    protected function initialize()
+    {
+        $hostPort = parse_url($this->callback, PHP_URL_PORT);
+        $hostUrl  = $this->callback;
+
+        if ($hostPort) {
+            $hostUrl .= ':' . $hostPort;
+        }
+
+        $this->openIdClient = new LightOpenID($hostUrl, null);
+    }
 
     /**
     * {@inheritdoc}


### PR DESCRIPTION
Override OpenID initialize function in Steam Provider. Incorrect callback URL was set. After callback in OpenID.php authenticateFinish function called validate function that cause the openid error.

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Steam Provider working
| Patch: Bug Fix?          | Bug in OpenID library

Override OpenID initialize function in Steam Provider. Incorrect callback URL was set. After callback in OpenID.php authenticateFinish function called validate function that cause the openid error. 