### PR TITLE
Fix for Logger

### DIFF
--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -166,12 +166,11 @@ class Hybridauth
         }
 
         $config = $providersConfig[$name];
-        
-        $config = $config + array(
-            'debug_mode'=> $this->config['debug_mode'],
-            'debug_file'=> $this->config['debug_file']
-        );
-        
+        $config += [
+            'debug_mode' => $this->config['debug_mode'],
+            'debug_file' => $this->config['debug_file'],
+        ];
+
         if (! isset($config['callback']) && isset($this->config['callback'])) {
             $config['callback'] = $this->config['callback'];
         }

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -166,7 +166,12 @@ class Hybridauth
         }
 
         $config = $providersConfig[$name];
-
+        
+        $config = $config + array(
+            'debug_mode'=> $this->config['debug_mode'],
+            'debug_file'=> $this->config['debug_file']
+        );
+        
         if (! isset($config['callback']) && isset($this->config['callback'])) {
             $config['callback'] = $this->config['callback'];
         }


### PR DESCRIPTION

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Fix for logger
| Major: Breaking Change?  |
| Minor: New Feature?      |

Since Logger initialization evoke during AbstractAdapter __construct ,
we need transfer config['debug_mode'] and config['debug_file'] to the provider, thereby transfer them AbstractAdapter __construct
