### PR TITLE
Corrected array syntax for PHP 7.4 compatibility

### DIFF
--- a/src/Thirdparty/OAuth/OAuthSignatureMethod.php
+++ b/src/Thirdparty/OAuth/OAuthSignatureMethod.php
@@ -59,7 +59,7 @@ abstract class OAuthSignatureMethod
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
         for ($i = 0; $i < strlen($signature); $i ++) {
-            $result |= ord($built {$i}) ^ ord($signature {$i});
+            $result |= ord($built [$i]) ^ ord($signature [$i]);
         }
 
         return $result == 0;

--- a/src/Thirdparty/OAuth/OAuthSignatureMethod.php
+++ b/src/Thirdparty/OAuth/OAuthSignatureMethod.php
@@ -59,7 +59,7 @@ abstract class OAuthSignatureMethod
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
         for ($i = 0; $i < strlen($signature); $i ++) {
-            $result |= ord($built [$i]) ^ ord($signature [$i]);
+            $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 
         return $result == 0;


### PR DESCRIPTION
Re: #1127

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1127 
| Patch: Bug Fix?          | PHP 7.4 Enhancement
| Major: Breaking Change?  | N/A
| Minor: New Feature?      | N/A

Curly brace syntax to access arrays will be going away. Changed to 'standard' [ ] syntax.

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
