### PR TITLE
configure() should be after setStorage()

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -100,14 +100,14 @@ abstract class AbstractAdapter implements AdapterInterface
 
         $this->config = new Data\Collection($config);
 
-        $this->configure();
-
         $this->setHttpClient($httpClient);
 
         $this->setStorage($storage);
 
         $this->setLogger($logger);
 
+        $this->configure();
+        
         $this->logger->debug(sprintf('Initialize %s, config: ', get_class($this)), $config);
 
         $this->initialize();

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -107,7 +107,7 @@ abstract class AbstractAdapter implements AdapterInterface
         $this->setLogger($logger);
 
         $this->configure();
-        
+
         $this->logger->debug(sprintf('Initialize %s, config: ', get_class($this)), $config);
 
         $this->initialize();


### PR DESCRIPTION
In case we send $config['tokens']['access_token'] to Facebook provider, 
./Adapter/OAuth2.php will try to save it into storage (line 251), which is not configure yet. 

```
if ($this->config->exists('tokens')) {
    $this->setAccessToken($this->config->get('tokens'));
}

public function setAccessToken($tokens = [])
{
    $this->clearStoredData();

    foreach ($tokens as $token => $value) {
        $this->storeData($token, $value);
    }

    // Re-initialize token parameters.
    $this->initialize();
}
```

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
