### PR TITLE
[OK] Add scope "GET_EMAIL"

### DIFF
--- a/src/Provider/Odnoklassniki.php
+++ b/src/Provider/Odnoklassniki.php
@@ -51,6 +51,11 @@ class Odnoklassniki extends OAuth2
     * {@inheritdoc}
     */
     protected $accessTokenUrl = 'https://api.ok.ru/oauth/token.do';
+    
+    /**
+	 * {@inheritdoc}
+	 */
+	protected $scope = 'GET_EMAIL';
 
     /**
     * {@inheritdoc}


### PR DESCRIPTION
Odnoklassniki does not provide the user's email openly. You must contact technical support to get your rights.

I contacted them and they gave me rights and wrote:

"You need to request GET_EMAIL in the scope parameter when performing OAuth authorization and fields=email when getting user information."