### PR TITLE
Remove oauth1 authorization parameters from request body

### DIFF
--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -583,7 +583,6 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
         );
 
         $uri        = $request->get_normalized_http_url();
-        $parameters = array_replace($parameters, $request->parameters);
         $headers    = array_replace($request->to_header(), (array) $headers);
 
         $response = $this->httpClient->request(


### PR DESCRIPTION
I had an issue where the AWeber adapter I built was throwing a 401 error because the oauth parameters like oauth_signature were being added to the request body.

Removing that line fixed the issue.

| Q                        | A
| ------------------------ | ---
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
