### PR TITLE
Fix error : code":32,"message":"Could not authenticate you."

### DIFF
--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -81,9 +81,9 @@ class Twitter extends OAuth1
      */
     public function getUserProfile()
     {
-		$response = $this->apiRequest('account/verify_credentials.json', 'GET', [
-    		'include_email' => $this->config->get('include_email') === false ? 'false' : 'true',
-		]);
+        $response = $this->apiRequest('account/verify_credentials.json', 'GET', [
+            'include_email' => $this->config->get('include_email') === false ? 'false' : 'true',
+        ]);
 
         $data = new Data\Collection($response);
 

--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -81,7 +81,7 @@ class Twitter extends OAuth1
      */
     public function getUserProfile()
     {
-        $response = $this->apiRequest('account/verify_credentials.json?include_email=true');
+        $response = $this->apiRequest('account/verify_credentials.json', 'GET', ['include_email' => $this->config->get('include_email') === false ? 'false' : 'true',]);
 
         $data = new Data\Collection($response);
 

--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -81,7 +81,9 @@ class Twitter extends OAuth1
      */
     public function getUserProfile()
     {
-        $response = $this->apiRequest('account/verify_credentials.json', 'GET', ['include_email' => $this->config->get('include_email') === false ? 'false' : 'true',]);
+		$response = $this->apiRequest('account/verify_credentials.json', 'GET', [
+    		'include_email' => $this->config->get('include_email') === false ? 'false' : 'true',
+		]);
 
         $data = new Data\Collection($response);
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | #1167
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
Fixes the error code":32,"message":"Could not authenticate you." by sending the include_email parameter in an array instead of directly in the query string.
