### PR TITLE
Fix "Client ID and OAuth token do not match" with provider TwitchTV

### DIFF
--- a/src/Provider/TwitchTV.php
+++ b/src/Provider/TwitchTV.php
@@ -45,6 +45,16 @@ class TwitchTV extends OAuth2
     /**
      * {@inheritdoc}
      */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        $this->apiRequestHeaders['Client-ID'] = $this->clientId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('users');


### PR DESCRIPTION
**Problem:**

Apparently Twitch now needs the request header `Client-ID` additionally to `Authorization`.

If it's missing, `TwitchTV::apiRequest()` returns the following response:

`{"error":"Unauthorized","status":401,"message":"Client ID and OAuth token do not match"}.`

Here is the official statement on Twitch's developer pages regarding the change, which became active on May 1st: https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916

Solution:

Just add `$this->clientId` to the appropriate request header.

Issue: https://github.com/hybridauth/hybridauth/issues/1170