### PR TITLE
Add apple provider

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -1,0 +1,109 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2017 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+use Hybridauth\Adapter\OAuth2;
+
+/**
+ * Apple OAuth2 provider adapter.
+ *
+ * Example:
+ *
+ *   $config = [
+ *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys'     => [ 'private_key' => '', 'id' => '', 'team_id' => '', 'key_id' => '', 'secret' => '' ],
+ *   ];
+ *
+ *   $adapter = new Hybridauth\Provider\Apple( $config );
+ *
+ *   $adapter->authenticate();
+ *
+ *   $accessToken = $adapter->getAccessToken();
+ */
+class Apple extends OAuth2
+{
+    /**
+     * {@inheritdoc}
+     */
+    public $scope = 'name email';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiBaseUrl = 'https://appleid.apple.com/auth/';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $authorizeUrl = 'https://appleid.apple.com/auth/authorize';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $accessTokenUrl = 'https://appleid.apple.com/auth/token';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://developer.apple.com/documentation/sign_in_with_apple';
+
+    /**
+    * {@inheritdoc}
+    */
+    protected function initialize(){
+
+        parent::initialize();
+        $this->AuthorizeUrlParameters['response_mode'] = 'form_post';
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessToken()
+    {
+        $tokenNames = [
+            'access_token',
+            'id_token',
+            'access_token_secret',
+            'token_type',
+            'refresh_token',
+            'expires_in',
+            'expires_at',
+        ];
+
+        $tokens = [];
+
+        foreach ($tokenNames as $name) {
+            if ($this->getStoredData($name)) {
+                $tokens[ $name ] = $this->getStoredData($name);
+            }
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function validateAccessTokenExchange($response)
+    {
+        $collection = parent::validateAccessTokenExchange($response);
+
+        $this->storeData('id_token', $collection->get('id_token'));
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserProfile()
+    {
+
+    }
+
+}

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -61,7 +61,29 @@ class Apple extends OAuth2
         $this->AuthorizeUrlParameters['response_mode'] = 'form_post';
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthorizeUrl($parameters = [])
+    {
+        $this->AuthorizeUrlParameters = !empty($parameters)
+            ? $parameters
+            : array_replace(
+                (array) $this->AuthorizeUrlParameters,
+                (array) $this->config->get('authorize_url_parameters')
+            );
 
+        if ($this->supportRequestState) {
+            if (!isset($this->AuthorizeUrlParameters['state'])) {
+                $this->AuthorizeUrlParameters['state'] = 'HA-' . str_shuffle('ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890');
+            }
+
+            $this->storeData('authorization_state', $this->AuthorizeUrlParameters['state']);
+        }
+
+        return $this->authorizeUrl . '?' . http_build_query($this->AuthorizeUrlParameters, '', '&', PHP_QUERY_RFC3986);
+    }
+    
     /**
      * {@inheritdoc}
      */

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -5,6 +5,8 @@
 *  (c) 2017 Hybridauth authors | https://hybridauth.github.io/license.html
 */
 
+namespace Hybridauth\Provider;
+
 use Hybridauth\Adapter\OAuth2;
 
 /**
@@ -53,8 +55,8 @@ class Apple extends OAuth2
     /**
     * {@inheritdoc}
     */
-    protected function initialize(){
-
+    protected function initialize()
+    {
         parent::initialize();
         $this->AuthorizeUrlParameters['response_mode'] = 'form_post';
     }
@@ -105,5 +107,4 @@ class Apple extends OAuth2
     {
 
     }
-
 }

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -105,6 +105,6 @@ class Apple extends OAuth2
      */
     public function getUserProfile()
     {
-
+        return null;
     }
 }


### PR DESCRIPTION
Hello,

Apple provider adapter.

configuration:
```
 $config = [
 'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
  'keys'     => [ 'private_key' => '', 'id' => '', 'team_id' => '', 'key_id' => '', 'secret' => '' ],
 ];

$adapter = new Hybridauth\Provider\Apple( $config );
$adapter->authenticate();
$accessToken = $adapter->getAccessToken();
print_r($accessToken);
```

you need to create an Apple private key for Sign in with Apple service first.
create client_secret you can use https://github.com/lcobucci/jwt library to generate JWT with ES256 encryption.
```
$privateKey = file_get_contents(__DIR__.'/private_key.pem');
$clientId = '';
$teamId = '';
$keyId = '';
$alg = 'ES256';
$secret = (string) (new Builder())
						->withHeader('kid', $keyId)
						->withHeader('type', 'JWT')
						->withHeader('alg', $alg)
						->issuedBy($teamId) 
						->issuedAt(time()) 
                        ->expiresAt(time() + 3600)
                        ->permittedFor('https://appleid.apple.com') 
                        ->relatedTo($clientId)
                        ->getToken(new Sha256(), new Key($privateKey)); 
```
