### PR TITLE
Another Apple provider

### DIFF
--- a/APPLE.md
+++ b/APPLE.md
@@ -48,8 +48,7 @@ This is your Account ID at the top right of the account information (2nd line)
 
 ## Differences to other providers
 
-* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your team id, key id and key file in your configuration.
-
+* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your team id, key id and key file in your configuration.    
 However the secret is generated, **you still have to configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I didn't want change things there since I am not involved in the project.
 
 

--- a/APPLE.md
+++ b/APPLE.md
@@ -54,5 +54,5 @@ See https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-app
 
 User information is **only** sent by Apple in the POST request as response to the first `authenticate()` call as a JSON Objekt in `$_POST['user']`. Make sure you save this information, there is no way to get it delivered a second time.
 
-Different to Facebook and Google, Apple sends the code value as a **POST** request.
-
+Because a scope is defined, Apple always sends the `code` value as a **POST** request. Therefore the `response_mode` is currently hardcoded set to `form_post` (@todo make it configurable). Facebook and Google return the code as a query parameter.
+@todo We could get the code as a query parameter if no scope is used.

--- a/APPLE.md
+++ b/APPLE.md
@@ -40,7 +40,7 @@ This is your Account ID at the top right of the account information (2nd line)
 
 ## Differences to other providers
 
-The secret is generated from a signed JWT token. Instead of a secret you have to provide your team id, key id and key file.
+* The secret is generated from a signed JWT token. Instead of a secret you have to provide your team id, key id and key file.
 
 ```
     "providers" => [
@@ -58,8 +58,7 @@ The secret is generated from a signed JWT token. Instead of a secret you have to
     ]
 ```
 
-To generate the token, additional libraries are required:   
-`composer require firebase/php-jwt`
-`composer require codercat/jwk-to-pem`
+* Although the secret is generated, **you have to configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I didn't want change things there since I am not involved in the project.
 
-The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined). If a scope is defined, Apple **always** sends the `code` value as a **POST** request. Facebook and Google return the code as a query parameter.
+* The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined).    
+If a scope is defined, Apple **always** sends the `code` value as a **POST** request (Facebook and Google return the code as a query parameter).

--- a/APPLE.md
+++ b/APPLE.md
@@ -2,7 +2,7 @@
 
 ## Dependencies
  * `composer require firebase/php-jwt`
- * `composer require codercat/jwk-to-pem`
+ * `composer require phpseclib/phpseclib`
 
 ## Online documentation
 

--- a/APPLE.md
+++ b/APPLE.md
@@ -48,7 +48,7 @@ This is your Account ID at the top right of the account information (2nd line)
 
 ## Differences to other providers
 
-* The secret is generated from a signed JWT token. Instead of a secret you have to provide your team id, key id and key file.
+* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your team id, key id and key file.
 
 ```
     "providers" => [
@@ -69,7 +69,7 @@ This is your Account ID at the top right of the account information (2nd line)
 
 * Although the secret is generated, **you have to configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I didn't want change things there since I am not involved in the project.
 
-* The token returned after authentication is a signed JWT object. Validating the signature is optional (default: true) and requires an a additional library and an additional lookup (@todo caching).    
+* The token returned after authentication is a signed JWT. Validating the signature is optional (default: true) and requires an a additional library and an additional lookup (@todo caching).    
 Validation can be disabled by setting.   `"verifyTokenSignature" => false`.  
 in the Configuration.
 

--- a/APPLE.md
+++ b/APPLE.md
@@ -12,9 +12,13 @@ https://sarunw.com/posts/sign-in-with-apple-2/
 
 ## Enable email delivery
 
+Sign in to https://developer.apple.com/account/resources
+
 Click on "More ..." and add domains and email addresses (requires SPF and DKIM, probably also an Apple ID in .well-known)
 
 ## Keys & IDs
+
+Sign in to Sign in to https://developer.apple.com/account/resources
 
 ### Identifiers
 

--- a/APPLE.md
+++ b/APPLE.md
@@ -38,16 +38,6 @@ This gets you a key ID (under details) and the private key (download)
 
 This is your Account ID at the top right of the account information (2nd line)
 
-### Generate secret via script
-
-See https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple
-
-1) Install jwt
-2) Create the script client_secret.rb
-3) `ruby ​​client_secret.rb`
-
-"This JWT expires in 6 months, which is the maximum lifetime Apple will allow."
-
 ## Differences to other providers
 
 The secret is generated from a signed JWT token. Instead of a secret you have to provide your team id, key id and key file.
@@ -70,7 +60,5 @@ The secret is generated from a signed JWT token. Instead of a secret you have to
 
 To generate the token, additional libraries are required:   
 `composer require firebase/php-jwt`
-
-User information is **only** sent by Apple in the POST request as response to the **first** `authenticate()` call as a JSON Objekt in `$_POST['user']`. Make sure you save this information, there is no way to get it delivered a second time.
 
 The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined). If a scope is defined, Apple **always** sends the `code` value as a **POST** request. Facebook and Google return the code as a query parameter.

--- a/APPLE.md
+++ b/APPLE.md
@@ -2,7 +2,7 @@
 
 ## Dependencies
  * `composer require firebase/php-jwt`
- * `composer require codercat/jwk-to-pem` (for optional token signature validation only)
+ * `composer require codercat/jwk-to-pem`
 
 ## Online documentation
 
@@ -24,20 +24,20 @@ Sign in to https://developer.apple.com/account/resources
 
 #### App ID
 
-Create the primary ID for "Sign in".
+Create the primary ID for "Sign in" service.
 
 #### Service ID
 
 Create a service ID of the type *Sign in with Apple* and assign it to the app ID, then fill in your domains.
 
-(Apple *Service ID* = OAuth2 *Client ID*)
+The Apple Service ID is **your OAuth2 Client ID**.
 
 ### Key ID and private key
 
 Create a new key for your Sign-In Service.
-This gets you a key ID (under details) and the private key (download)
+This gets you a **key ID** (under details) and the **private key** (download)
 
-#### Attention:
+#### Hints:
 
 * Don't forget to fill in the key name (there will be no error message if you forget).
 * Downloading the privacy key is only possible once.
@@ -46,10 +46,10 @@ This gets you a key ID (under details) and the private key (download)
 
 This is your Account ID at the top right of the account information (2nd line)
 
-## Differences to other providers
+## Notes
 
 * The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your *team_id*, *key_id* and *key_file* in your configuration.    
-Altough the secret is generated, you still have to **configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I don't want change things there since I am not involved in the project.
+Altough the secret is generated, you still have to **configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I don't want to change things there.
 
 
 ```
@@ -70,9 +70,8 @@ Altough the secret is generated, you still have to **configure a `secret` parame
 ```
 
 
-* The token returned after authentication is a signed JWT. Validating the signature is optional (default: true) and requires an a additional library and an additional lookup (@todo caching).    
-Validation can be disabled by setting.   `"verifyTokenSignature" => false`.  
-in the Configuration.
+* The token returned after authentication is a signed JWT.  Validating requires an a additional library. It can be disabled by setting   `"verifyTokenSignature" => false` 
+in the configuration.
 
 * The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined).    
 If a scope is defined, Apple **always** sends the `code` value as a **POST** request (Facebook and Google return the code as a query parameter).

--- a/APPLE.md
+++ b/APPLE.md
@@ -48,8 +48,8 @@ This is your Account ID at the top right of the account information (2nd line)
 
 ## Differences to other providers
 
-* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your team id, key id and key file in your configuration.    
-However the secret is generated, **you still have to configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I didn't want change things there since I am not involved in the project.
+* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your *team_id*, *key_id* and *key_file* in your configuration.    
+Altough the secret is generated, you still have to **configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I don't want change things there since I am not involved in the project.
 
 
 ```

--- a/APPLE.md
+++ b/APPLE.md
@@ -55,4 +55,3 @@ See https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-app
 User information is **only** sent by Apple in the POST request as response to the first `authenticate()` call as a JSON Objekt in `$_POST['user']`. Make sure you save this information, there is no way to get it delivered a second time.
 
 Because a scope is defined, Apple always sends the `code` value as a **POST** request. Therefore the `response_mode` is currently hardcoded set to `form_post` (@todo make it configurable). Facebook and Google return the code as a query parameter.
-@todo We could get the code as a query parameter if no scope is used.

--- a/APPLE.md
+++ b/APPLE.md
@@ -52,6 +52,6 @@ See https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-app
 
 `getUserProfile()` is not implemented, since Apple does not provide an API for that.
 
-User information is **only** sent by Apple in the POST request as response to the first `authenticate()` call as a JSON Objekt in `$_POST['user']`. Make sure you save this information, there is no way to get it delivered a second time.
+User information is **only** sent by Apple in the POST request as response to the **first** `authenticate()` call as a JSON Objekt in `$_POST['user']`. Make sure you save this information, there is no way to get it delivered a second time.
 
-Because a scope is defined, Apple always sends the `code` value as a **POST** request. Therefore the `response_mode` is currently hardcoded set to `form_post` (@todo make it configurable). Facebook and Google return the code as a query parameter.
+The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined). If a scope is defined, Apple **always** sends the `code` value as a **POST** request. Facebook and Google return the code as a query parameter.

--- a/APPLE.md
+++ b/APPLE.md
@@ -65,5 +65,9 @@ This is your Account ID at the top right of the account information (2nd line)
 
 * Although the secret is generated, **you have to configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I didn't want change things there since I am not involved in the project.
 
+* The token returned after authentication is a signed JWT object. Validating the signature is optional (default: true) and requires an a additional library and an additional lookup (@todo caching).    
+Validation can be disabled by setting.   `"verifyTokenSignature" => false`.  
+in the Configuration.
+
 * The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined).    
 If a scope is defined, Apple **always** sends the `code` value as a **POST** request (Facebook and Google return the code as a query parameter).

--- a/APPLE.md
+++ b/APPLE.md
@@ -48,7 +48,10 @@ This is your Account ID at the top right of the account information (2nd line)
 
 ## Differences to other providers
 
-* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your team id, key id and key file.
+* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your team id, key id and key file in your configuration.
+
+However the secret is generated, **you still have to configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I didn't want change things there since I am not involved in the project.
+
 
 ```
     "providers" => [
@@ -56,7 +59,7 @@ This is your Account ID at the top right of the account information (2nd line)
             "enabled" => true,
             "keys" => [
                 "id" => MYHYBRIDAUTH_APPLE_ID,
-                "secret" => 'foo',
+                "secret" => 'dont remove this dummy secret',
                 "team_id" => MYHYBRIDAUTH_APPLE_TEAM_ID,
                 "key_id" => MYHYBRIDAUTH_APPLE_KEY_ID,
                 "key_file" => MYHYBRIDAUTH_APPLE_KEY_FULLPATH
@@ -67,7 +70,6 @@ This is your Account ID at the top right of the account information (2nd line)
     ]
 ```
 
-* Although the secret is generated, **you have to configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I didn't want change things there since I am not involved in the project.
 
 * The token returned after authentication is a signed JWT. Validating the signature is optional (default: true) and requires an a additional library and an additional lookup (@todo caching).    
 Validation can be disabled by setting.   `"verifyTokenSignature" => false`.  

--- a/APPLE.md
+++ b/APPLE.md
@@ -50,7 +50,26 @@ See https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-app
 
 ## Differences to other providers
 
-`getUserProfile()` is not implemented, since Apple does not provide an API for that.
+The secret is generated from a signed JWT token. Instead of a secret you have to provide your team id, key id and key file.
+
+```
+    "providers" => [
+        "Apple" => [
+            "enabled" => true,
+            "keys" => [
+                "id" => MYHYBRIDAUTH_APPLE_ID,
+                "secret" => 'foo',
+                "team_id" => MYHYBRIDAUTH_APPLE_TEAM_ID,
+                "key_id" => MYHYBRIDAUTH_APPLE_KEY_ID,
+                "key_file" => MYHYBRIDAUTH_APPLE_KEY_FULLPATH
+                ],
+            "scope" => "name email"
+        ]
+    ]
+```
+
+To generate the token, additional libraries are required:   
+`composer require firebase/php-jwt`
 
 User information is **only** sent by Apple in the POST request as response to the **first** `authenticate()` call as a JSON Objekt in `$_POST['user']`. Make sure you save this information, there is no way to get it delivered a second time.
 

--- a/APPLE.md
+++ b/APPLE.md
@@ -66,9 +66,13 @@ This is your Account ID at the top right of the account information (2nd line)
     ]
 ```
 
-
 * The token returned after authentication is a signed JWT.  Validating requires an a additional library. It can be disabled by setting   `"verifyTokenSignature" => false` 
 in the configuration.
 
 * The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined).    
 If a scope is defined, Apple **always** sends the `code` value as a **POST** request (Facebook and Google return the code as a query parameter).
+
+### Reasons for authentication failures
+* Have the right id (= Service ID, usually in reverse domain name notation e.g. "org.foo.bar"), team id, key id and the full path to your private key file configured.
+* Make sure you have your domain(s) configured correctly in your Service ID.
+* Your server must have the time set correctly (use ntpdate), otherwise signature validation might fail

--- a/APPLE.md
+++ b/APPLE.md
@@ -1,0 +1,58 @@
+# Howto: Sign in with Apple
+
+## Online documentation
+
+https://developer.apple.com/sign-in-with-apple/get-started/
+https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple
+https://sarunw.com/posts/sign-in-with-apple-2/
+
+## Enable email delivery
+
+Click on "More ..." and add domains and email addresses (requires SPF and DKIM, probably also an Apple ID in .well-known)
+
+## Keys & IDs
+
+### Identifiers
+
+#### App ID
+
+Create the primary ID for "Sign in".
+
+#### Service ID
+
+Create a service ID of the type *Sign in with Apple* and assign it to the app ID, then fill in your domains.
+
+(Apple *Service ID* = OAuth2 *Client ID*)
+
+### Key ID and private key
+
+Create a new key for your Sign-In Service.
+This gets you a key ID (under details) and the private key (download)
+
+#### Attention:
+
+* Don't forget to fill in the key name (there will be no error message if you forget).
+* Downloading the privacy key is only possible once.
+
+### Team ID
+
+This is your Account ID at the top right of the account information (2nd line)
+
+### Generate secret via script
+
+See https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple
+
+1) Install jwt
+2) Create the script client_secret.rb
+3) `ruby ​​client_secret.rb`
+
+"This JWT expires in 6 months, which is the maximum lifetime Apple will allow."
+
+## Differences to other providers
+
+`getUserProfile()` is not implemented, since Apple does not provide an API for that.
+
+User information is **only** sent by Apple in the POST request as response to the first `authenticate()` call as a JSON Objekt in `$_POST['user']`. Make sure you save this information, there is no way to get it delivered a second time.
+
+Different to Facebook and Google, Apple sends the code value as a **POST** request.
+

--- a/APPLE.md
+++ b/APPLE.md
@@ -18,7 +18,7 @@ Click on "More ..." and add domains and email addresses (requires SPF and DKIM, 
 
 ## Keys & IDs
 
-Sign in to Sign in to https://developer.apple.com/account/resources
+Sign in to https://developer.apple.com/account/resources
 
 ### Identifiers
 

--- a/APPLE.md
+++ b/APPLE.md
@@ -48,9 +48,7 @@ This is your Account ID at the top right of the account information (2nd line)
 
 ## Notes
 
-* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your *team_id*, *key_id* and *key_file* in your configuration.    
-Altough the secret is generated, you still have to **configure a `secret` parameter** in your provider configuration (any non-empty string) because secrets are compulsory in HybridAuth for all OAuth2 Providers, and I don't want to change things there.
-
+* The secret is generated from a signed [JWT (JSON Web Token)](https://jwt.io). Instead of a secret you have to provide your *team_id*, *key_id* and *key_file* in your configuration. You don't need to generate a secret yourself.
 
 ```
     "providers" => [
@@ -58,7 +56,6 @@ Altough the secret is generated, you still have to **configure a `secret` parame
             "enabled" => true,
             "keys" => [
                 "id" => MYHYBRIDAUTH_APPLE_ID,
-                "secret" => 'dont remove this dummy secret',
                 "team_id" => MYHYBRIDAUTH_APPLE_TEAM_ID,
                 "key_id" => MYHYBRIDAUTH_APPLE_KEY_ID,
                 "key_file" => MYHYBRIDAUTH_APPLE_KEY_FULLPATH

--- a/APPLE.md
+++ b/APPLE.md
@@ -60,5 +60,6 @@ The secret is generated from a signed JWT token. Instead of a secret you have to
 
 To generate the token, additional libraries are required:   
 `composer require firebase/php-jwt`
+`composer require codercat/jwk-to-pem`
 
 The current default value for `response_mode` is `form_post` (you can overrule it with `query` or `fragment` if you don't have a scope defined). If a scope is defined, Apple **always** sends the `code` value as a **POST** request. Facebook and Google return the code as a query parameter.

--- a/APPLE.md
+++ b/APPLE.md
@@ -1,6 +1,6 @@
 # Howto: Sign in with Apple
 
-### Dependencies
+## Dependencies
  * `composer require firebase/php-jwt`
  * `composer require codercat/jwk-to-pem` (for optional token signature validation only)
 

--- a/APPLE.md
+++ b/APPLE.md
@@ -1,5 +1,9 @@
 # Howto: Sign in with Apple
 
+### Dependencies
+ * `composer require firebase/php-jwt`
+ * `composer require codercat/jwk-to-pem` (for optional token signature validation only)
+
 ## Online documentation
 
 https://developer.apple.com/sign-in-with-apple/get-started/    
@@ -53,7 +57,8 @@ This is your Account ID at the top right of the account information (2nd line)
                 "key_id" => MYHYBRIDAUTH_APPLE_KEY_ID,
                 "key_file" => MYHYBRIDAUTH_APPLE_KEY_FULLPATH
                 ],
-            "scope" => "name email"
+            "scope" => "name email",
+            "verifyTokenSignature" => true
         ]
     ]
 ```

--- a/APPLE.md
+++ b/APPLE.md
@@ -2,8 +2,8 @@
 
 ## Online documentation
 
-https://developer.apple.com/sign-in-with-apple/get-started/
-https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple
+https://developer.apple.com/sign-in-with-apple/get-started/    
+https://developer.okta.com/blog/2019/06/04/what-the-heck-is-sign-in-with-apple    
 https://sarunw.com/posts/sign-in-with-apple-2/
 
 ## Enable email delivery

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "firebase/php-jwt": "*",
-        "codercat/jwk-to-pem": "*"
+        "phpseclib/phpseclib": "~2.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "hybridauth/hybridauth",
     "description": "PHP Social Authentication Library",
-    "keywords": ["oauth", "openid", "authentication", "authorization", "social", "api", "google", "facebook", "twitter"],
+    "keywords": ["oauth", "openid", "authentication", "authorization", "social", "api", "google", "facebook", "twitter", "apple"],
     "homepage": "https://hybridauth.github.io",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         "gitter": "https://gitter.im/hybridauth/hybridauth"
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "firebase/php-jwt": "*",
+        "codercat/jwk-to-pem": "*"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -449,7 +449,11 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             $this->storeData('authorization_state', $this->AuthorizeUrlParameters['state']);
         }
 
-        return $this->authorizeUrl . '?' . http_build_query($this->AuthorizeUrlParameters, '', '&', $this->AuthorizeUrlParametersEncType);
+        return $this->authorizeUrl . '?' . http_build_query(
+            $this->AuthorizeUrlParameters,
+            '',
+            '&',
+            $this->AuthorizeUrlParametersEncType);
     }
 
     /**

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -126,7 +126,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     /**
     * Authorization Url Parameters
     *
-    * @var string
+    * @var array
     */
     protected $AuthorizeUrlParameters = [];
 

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -449,11 +449,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             $this->storeData('authorization_state', $this->AuthorizeUrlParameters['state']);
         }
 
-        return $this->authorizeUrl . '?' . http_build_query(
-            $this->AuthorizeUrlParameters,
-            '',
-            '&',
-            $this->AuthorizeUrlParametersEncType);
+        $queryParams = http_build_query($this->AuthorizeUrlParameters, '', '&', $this->AuthorizeUrlParametersEncType);
+        return $this->authorizeUrl . '?' . $queryParams;
     }
 
     /**

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -130,6 +130,15 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     */
     protected $AuthorizeUrlParameters = [];
 
+
+    /**
+     * Authorization Url Parameter encoding type
+     * @see https://www.php.net/manual/de/function.http-build-query.php
+     *
+     * @var string
+     */
+    protected $AuthorizeUrlParametersEncType = PHP_QUERY_RFC1738;
+
     /**
     * Authorization Request State
     *
@@ -440,7 +449,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             $this->storeData('authorization_state', $this->AuthorizeUrlParameters['state']);
         }
 
-        return $this->authorizeUrl . '?' . http_build_query($this->AuthorizeUrlParameters, '', '&');
+        return $this->authorizeUrl . '?' . http_build_query($this->AuthorizeUrlParameters, '', '&', $this->AuthorizeUrlParametersEncType);
     }
 
     /**

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -126,7 +126,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     /**
     * Authorization Url Parameters
     *
-    * @var boolean
+    * @var string
     */
     protected $AuthorizeUrlParameters = [];
 

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -29,7 +29,7 @@ use \Firebase\JWT\JWK;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'id' => '', 'secret' => '' ],
+ *       'keys'     => [ 'id' => '', 'team_id' => '', 'key_id' => '', 'key_file' => '' ],
  *       'scope'    => 'name email',
  *
  *        // Apple's custom auth url params
@@ -104,6 +104,15 @@ class Apple extends OAuth2
 
     /**
      * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->config->filter('keys')->set('secret', $this->getSecret());
+        return parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
      *
      * include id_token $tokenNames
      */
@@ -136,15 +145,6 @@ class Apple extends OAuth2
     public function isConnected()
     {
         return (bool)$this->getStoredData('access_token') && !$this->hasAccessTokenExpired();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function exchangeCodeForAccessToken($code)
-    {
-        $this->tokenExchangeParameters['client_secret'] = $this->getSecret();
-        return parent::exchangeCodeForAccessToken($code);
     }
 
     /**

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -196,15 +196,15 @@ class Apple extends OAuth2
             }
         }
 
-        $token = new Data\Collection($payload);
+        $data = new Data\Collection($payload);
 
-        if (!$token->exists('sub')) {
+        if (!$data->exists('sub')) {
             throw new UnexpectedValueException('Missing token payload.');
         }
 
         $userProfile = new User\Profile();
-        $userProfile->identifier = $token->get('sub');
-        $userProfile->email = $token->get('email');
+        $userProfile->identifier = $data->get('sub');
+        $userProfile->email = $data->get('email');
 
         if (!empty($_REQUEST['user'])) {
             $objUser = json_decode($_REQUEST['user']);

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -48,7 +48,11 @@ use \Firebase\JWT\JWK;
  *       echo $e->getMessage() ;
  *   }
  *
- * requires require firebase/php-jwt: composer require firebase/php-jwt
+ * Requires:
+ *
+ * composer require codercat/jwk-to-pem
+ * composer require firebase/php-jwt
+
  *
  * @see https://github.com/sputnik73/hybridauth-sign-in-with-apple
  * @see https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -1,0 +1,88 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2017 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Provider;
+
+use Hybridauth\Exception\InvalidArgumentException;
+use Hybridauth\Exception\UnexpectedApiResponseException;
+use Hybridauth\Adapter\OAuth2;
+use Hybridauth\Data;
+use Hybridauth\User;
+
+/**
+ * Apple OAuth2 provider adapter.
+ *
+ * Example:
+ *
+ *   $config = [
+ *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys'     => [ 'id' => '', 'secret' => '' ],
+ *       'scope'    => 'name email'
+ *   ];
+ *
+ *   $adapter = new Hybridauth\Provider\Apple( $config );
+ *
+ *   try {
+ *       $adapter->authenticate();
+ *
+ *       $tokens = $adapter->getAccessToken();
+ *       $response = $adapter->setUserStatus("Hybridauth test message..");
+ *   }
+ *   catch( Exception $e ){
+ *       echo $e->getMessage() ;
+ *   }
+ *
+ * @see https://github.com/sputnik73/hybridauth-sign-in-with-apple
+ * @see https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api
+ */
+class Apple extends OAuth2
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $scope = 'name email';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiBaseUrl = null; // No API available
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $authorizeUrl = 'https://appleid.apple.com/auth/authorize';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $accessTokenUrl = 'https://appleid.apple.com/auth/token';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api';
+
+    /**
+     * {@inheritdoc}
+     * The Sign in with Apple servers require percent encoding (or URL encoding)
+     * for its query parameters. If you are using the Sign in with Apple REST API,
+     * you must provide values with encoded spaces (`%20`) instead of plus (`+`) signs.
+     */
+    protected $AuthorizeUrlParametersEncType = PHP_QUERY_RFC3986;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        $this->AuthorizeUrlParameters += [
+            'response_mode' => 'form_post'
+        ];
+    }
+}

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -82,7 +82,7 @@ class Apple extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $apiDocumentation = 'https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api';
+    protected $apiDocumentation = 'https://developer.apple.com/documentation/sign_in_with_apple';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -107,7 +107,9 @@ class Apple extends OAuth2
      */
     protected function configure()
     {
-        $this->config->filter('keys')->set('secret', $this->getSecret());
+        $keys = $this->config->get('keys');
+        $keys['secret'] = $this->getSecret();
+        $this->config->set('keys', $keys);
         return parent::configure();
     }
 

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -98,9 +98,8 @@ class Apple extends OAuth2
     protected function initialize()
     {
         parent::initialize();
+        $this->AuthorizeUrlParameters['response_mode'] = 'form_post';
 
-        $this->AuthorizeUrlParameters += [
-            'response_mode' => 'form_post'
         ];
     }
 

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -2,7 +2,7 @@
 /*!
 * Hybridauth
 * https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
-*  (c) 2017 Hybridauth authors | https://hybridauth.github.io/license.html
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
 */
 
 namespace Hybridauth\Provider;
@@ -11,6 +11,7 @@ use Hybridauth\Exception\InvalidArgumentException;
 use Hybridauth\Exception\UnexpectedApiResponseException;
 use Hybridauth\Exception\InvalidApplicationCredentialsException;
 use Hybridauth\Exception\UnexpectedValueException;
+
 use Hybridauth\Adapter\OAuth2;
 use Hybridauth\Data;
 use Hybridauth\User;
@@ -52,7 +53,6 @@ use \Firebase\JWT\JWK;
  *
  * composer require codercat/jwk-to-pem
  * composer require firebase/php-jwt
-
  *
  * @see https://github.com/sputnik73/hybridauth-sign-in-with-apple
  * @see https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -222,12 +222,12 @@ class Apple extends OAuth2
         if (!empty($_REQUEST['user'])) {
             $objUser = json_decode($_REQUEST['user']);
             $user = new Data\Collection($objUser);
-
-            $name = $user->get('name');
-            $userProfile->firstName = $name->firstName;
-            $userProfile->lastName = $name->lastName;
-            $userProfile->displayName = join(' ', array($userProfile->firstName,
-                $userProfile->lastName));
+            if (!$user->isEmpty()) {
+                $name = $user->get('name');
+                $userProfile->firstName = $name->firstName;
+                $userProfile->lastName = $name->lastName;
+                $userProfile->displayName = join(' ', [ $userProfile->firstName, $userProfile->lastName ]);
+            }
         }
 
         return $userProfile;

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -244,7 +244,7 @@ class Apple extends OAuth2
         }
 
         // Your Services ID, e.g. com.aaronparecki.services
-        if (!$client_id = $this->clientId) {
+        if (!$client_id = $this->config->filter('keys')->get('id') ?: $this->config->filter('keys')->get('key')) {
             throw new InvalidApplicationCredentialsException(
                 'Your client id is required generate the JWS token.'
             );

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -172,7 +172,6 @@ class Apple extends OAuth2
             // JWT splits the string to 3 components 1) first is header 2) is payload 3) is signature
             $payload = explode('.', $id_token)[1];
             $payload = json_decode(base64_decode($payload));
-
         } else {
             // validate the token signature and get the payload
             $publicKeys = $this->apiRequest('keys');

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -34,8 +34,7 @@ use \Firebase\JWT\JWK;
  *
  *        // Apple's custom auth url params
  *       'authorize_url_parameters' => [
- *              'response_mode' => 'form_post', // query, fragment, form_post. form_post is always used if scope is defined.
- *              // etc.
+ *              'response_mode' => 'form_post'
  *       ]
  *   ];
  *
@@ -164,7 +163,8 @@ class Apple extends OAuth2
     {
         $id_token = $this->getStoredData('id_token');
 
-        $verifyTokenSignature = ($this->config->exists('verifyTokenSignature')) ? $this->config->get('verifyTokenSignature') : true;
+        $verifyTokenSignature =
+            ($this->config->exists('verifyTokenSignature')) ? $this->config->get('verifyTokenSignature') : true;
 
         if (!$verifyTokenSignature) {
             // payload extraction by https://github.com/omidborjian

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -134,7 +134,7 @@ class Apple extends OAuth2
      */
     public function isConnected()
     {
-        return (bool) $this->getStoredData('access_token') && !$this->hasAccessTokenExpired();
+        return (bool)$this->getStoredData('access_token') && !$this->hasAccessTokenExpired();
     }
 
     /**
@@ -178,7 +178,7 @@ class Apple extends OAuth2
             \Firebase\JWT\JWT::$leeway = 60;
             $jwkConverter = new JWKConverter();
 
-            foreach($publicKeys->keys as $publicKey) {
+            foreach ($publicKeys->keys as $publicKey) {
                 try {
                     $pem = $jwkConverter->toPEM((array)$publicKey);
                     $payload = JWT::decode($id_token, $pem, ['RS256']);

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -142,6 +142,7 @@ class Apple extends OAuth2
             // validate the token signature and get the payload
             $publicKeys = $this->apiRequest('keys');
 
+            \Firebase\JWT\JWT::$leeway = 60;
             $jwkConverter = new JWKConverter();
 
             foreach($publicKeys->keys as $publicKey) {

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -17,7 +17,7 @@ use Hybridauth\User;
 
 use CoderCat\JWKToPEM\JWKConverter;
 use \Firebase\JWT\JWT;
-
+use \Firebase\JWT\JWK;
 
 /**
  * Apple OAuth2 provider adapter.

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -109,7 +109,6 @@ class Apple extends OAuth2
      */
     public function isConnected()
     {
-        return false;
         return (bool) $this->getStoredData('access_token') && !$this->hasAccessTokenExpired();
     }
 

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -205,6 +205,7 @@ class Apple extends OAuth2
         $userProfile = new User\Profile();
         $userProfile->identifier = $data->get('sub');
         $userProfile->email = $data->get('email');
+        $this->storeData('expires_at', $data->get('exp'));
 
         if (!empty($_REQUEST['user'])) {
             $objUser = json_decode($_REQUEST['user']);

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -21,7 +21,13 @@ use Hybridauth\User;
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
  *       'keys'     => [ 'id' => '', 'secret' => '' ],
- *       'scope'    => 'name email'
+ *       'scope'    => 'name email',
+ *
+ *        // Apple's custom auth url params
+ *       'authorize_url_parameters' => [
+ *              'response_mode' => 'form_post', // query, fragment, form_post. form_post is always used if scope is defined.
+ *              // etc.
+ *       ]
  *   ];
  *
  *   $adapter = new Hybridauth\Provider\Apple( $config );

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -107,6 +107,15 @@ class Apple extends OAuth2
     /**
      * {@inheritdoc}
      */
+    public function isConnected()
+    {
+        return false;
+        return (bool) $this->getStoredData('access_token') && !$this->hasAccessTokenExpired();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function exchangeCodeForAccessToken($code)
     {
         $this->tokenExchangeParameters['client_secret'] = $this->getSecret();

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -67,7 +67,7 @@ class Apple extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $apiBaseUrl = null; // No API available
+    protected $apiBaseUrl = 'https://appleid.apple.com/auth/';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -99,8 +99,34 @@ class Apple extends OAuth2
     {
         parent::initialize();
         $this->AuthorizeUrlParameters['response_mode'] = 'form_post';
+    }
 
+    /**
+     * {@inheritdoc}
+     *
+     * include id_token $tokenNames
+     */
+    public function getAccessToken()
+    {
+        $tokenNames = [
+            'access_token',
+            'id_token',
+            'access_token_secret',
+            'token_type',
+            'refresh_token',
+            'expires_in',
+            'expires_at',
         ];
+
+        $tokens = [];
+
+        foreach ($tokenNames as $name) {
+            if ($this->getStoredData($name)) {
+                $tokens[$name] = $this->getStoredData($name);
+            }
+        }
+
+        return $tokens;
     }
 
     /**


### PR DESCRIPTION
The main difference of this version is that users don’t need care about secret generation, and `getUserProfile()` returns all information Apple provides. 

Additionally it handles token expiration (refresh token is not available in the Apple API). A leeway makes JWT validation more reliable.

The provider was discussed in [issue #1095 ](https://github.com/hybridauth/hybridauth/issues/1095)