### PR TITLE
Improved code comments documenting Twitter provider

### DIFF
--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -14,13 +14,15 @@ use Hybridauth\User;
 
 /**
  * Twitter provider adapter.
+ * Uses OAuth1 not OAuth2 because many Twitter endpoints are built around OAuth1.
  *
  * Example:
  *
  *   $config = [
  *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
  *       'keys'      => [ 'key' => '', 'secret' => '' ], // OAuth1 uses 'key' not 'id'
- *       'authorize' => true
+ *       'authorize' => true // Needed to perform actions on behalf of users (see below link)
+ *         // https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
  *   ];
  *
  *   $adapter = new Hybridauth\Provider\Twitter( $config );


### PR DESCRIPTION
This just adds comments to the Twitter provider's code to clarify why it is OAuth1 and what 'authorize' is for.
It wasn't obvious without reading Twitter's API documentation.