### PR TITLE
Fixed Yahoo as it now needs to use OpenID Connect on top of OAuth2, n…

### DIFF
--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -62,6 +62,8 @@ class Yahoo extends OAuth2
         $this->tokenExchangeHeaders = [
             'Authorization' => 'Basic ' . base64_encode($this->clientId .  ':' . $this->clientSecret)
         ];
+
+        $this->tokenRefreshHeaders = $this->tokenExchangeHeaders;
     }
 
     /**


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1192, Fixes #1165
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

Fixed the Yahoo provider as it now needs to use OpenID Connect on top of OAuth2, not their old social directory. Was broken since June as per https://developer.yahoo.com/oauth/social-directory-eol/
