### PR TITLE
StackExchange fix and clarification

### DIFF
--- a/src/Provider/StackExchange.php
+++ b/src/Provider/StackExchange.php
@@ -20,7 +20,7 @@ use Hybridauth\User;
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
  *       'keys'     => [ 'id' => '', 'secret' => '' ],
- *       'site'     => 'stackoverflow'
+ *       'site'     => 'stackoverflow' // required parameter to call getUserProfile()
  *       'api_key'  => '...' // that thing to receive a higher request quota.
  *   ];
  *
@@ -76,7 +76,7 @@ class StackExchange extends OAuth2
     {
         $site = $this->config->get('site');
 
-        $response = $this->apiRequest('me?site=' . $site);
+        $response = $this->apiRequest('me?site=' . $site, 'GET', [ 'access_token' => $this->getStoredData('access_token') ]);
 
         if (! $response || !isset($response->items) || !isset($response->items[0])) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');

--- a/src/Provider/StackExchange.php
+++ b/src/Provider/StackExchange.php
@@ -76,7 +76,7 @@ class StackExchange extends OAuth2
     {
         $site = $this->config->get('site');
 
-        $response = $this->apiRequest('me?site=' . $site, 'GET', [ 'access_token' => $this->getStoredData('access_token') ]);
+        $response = $this->apiRequest('me', 'GET', [ 'site' => $site, 'access_token' => $this->getStoredData('access_token') ]);
 
         if (! $response || !isset($response->items) || !isset($response->items[0])) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');

--- a/src/Provider/StackExchange.php
+++ b/src/Provider/StackExchange.php
@@ -76,7 +76,10 @@ class StackExchange extends OAuth2
     {
         $site = $this->config->get('site');
 
-        $response = $this->apiRequest('me', 'GET', [ 'site' => $site, 'access_token' => $this->getStoredData('access_token') ]);
+        $response = $this->apiRequest('me', 'GET', [
+            'site' => $site,
+            'access_token' => $this->getStoredData('access_token'),
+        ]);
 
         if (! $response || !isset($response->items) || !isset($response->items[0])) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');

--- a/src/Provider/StackExchange.php
+++ b/src/Provider/StackExchange.php
@@ -86,7 +86,7 @@ class StackExchange extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier  = strval($data->get('user_id'));
         $userProfile->displayName = $data->get('display_name');
         $userProfile->photoURL    = $data->get('profile_image');
         $userProfile->profileURL  = $data->get('link');


### PR DESCRIPTION
This fixes a couple of things I found testing the StackExchange provider...

First, it needs clearly documenting the 'site' parameter is needed.

Second, weirdly you need to explicitly pass the token to get the profile, even though the Bearer token header is passed.