### PR TITLE
Document where the config settings on Vkontakte come from

### DIFF
--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -21,7 +21,10 @@ use Hybridauth\User;
  *
  *   $config = [
  *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'      => ['id' => '', 'secret' => ''],
+ *       'keys'      => [
+ *           'id' => '', // App ID
+ *           'secret' => '' // Secure key
+ *       ],
  *   ];
  *
  *   $adapter = new Hybridauth\Provider\Vkontakte($config);


### PR DESCRIPTION
Vkontakte uses non-standard terminology for the OAuth settings - so comment the mappings in the provider code file.