### PR TITLE
Fix code inconsistencies across providers

### DIFF
--- a/src/Provider/AOLOpenID.php
+++ b/src/Provider/AOLOpenID.php
@@ -18,4 +18,9 @@ class AOLOpenID extends OpenID
     * {@inheritdoc}
     */
     protected $openidIdentifier = 'http://openid.aol.com/';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = ''; // Not available
 }

--- a/src/Provider/Amazon.php
+++ b/src/Provider/Amazon.php
@@ -20,7 +20,7 @@ class Amazon extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public $scope = 'profile';
+    protected $scope = 'profile';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -43,6 +43,7 @@ use \Firebase\JWT\JWK;
  *   try {
  *       $adapter->authenticate();
  *
+ *       $userProfile = $adapter->getUserProfile();
  *       $tokens = $adapter->getAccessToken();
  *       $response = $adapter->setUserStatus("Hybridauth test message..");
  *   }

--- a/src/Provider/Authentiq.php
+++ b/src/Provider/Authentiq.php
@@ -20,7 +20,7 @@ class Authentiq extends OAuth2
     /**
     * {@inheritdoc}
     */
-    public $scope = 'aq:name email~rs aq:push openid';
+    protected $scope = 'aq:name email~rs aq:push openid';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/BitBucket.php
+++ b/src/Provider/BitBucket.php
@@ -24,7 +24,7 @@ class BitBucket extends OAuth2
     /**
     * {@inheritdoc}
     */
-    public $scope = 'email';
+    protected $scope = 'email';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/Blizzard.php
+++ b/src/Provider/Blizzard.php
@@ -20,7 +20,7 @@ class Blizzard extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public $scope = '';
+    protected $scope = '';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/DeviantArt.php
+++ b/src/Provider/DeviantArt.php
@@ -14,33 +14,13 @@ use Hybridauth\User;
 
 /**
  * DeviantArt OAuth2 provider adapter.
- *
- * Example:
- *
- *   $config = [
- *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'id' => '', 'secret' => '' ],
- *       'scope'    => 'user',
- *   ];
- *
- *   $adapter = new Hybridauth\Provider\DeviantArt( $config );
- *
- *   try {
- *       $adapter->authenticate();
- *
- *       $userProfile = $adapter->getUserProfile();
- *       $tokens = $adapter->getAccessToken();
- *   }
- *   catch( Exception $e ){
- *       echo $e->getMessage() ;
- *   }
  */
 class DeviantArt extends OAuth2
 {
     /**
      * {@inheritdoc}
      */
-    public $scope = 'user';
+    protected $scope = 'user';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -17,11 +17,10 @@ use Hybridauth\User;
  */
 class Discord extends OAuth2
 {
-
     /**
      * {@inheritdoc}
      */
-    public $scope = 'identify email';
+    protected $scope = 'identify email';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -2,7 +2,7 @@
 /*!
 * Hybridauth
 * https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
-*  (c) 2019 Hybridauth authors | https://hybridauth.github.io/license.html
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
 */
 
 namespace Hybridauth\Provider;
@@ -20,7 +20,7 @@ class Dropbox extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public $scope = 'account_info.read';
+    protected $scope = 'account_info.read';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -17,11 +17,10 @@ use Hybridauth\User;
  */
 class GitHub extends OAuth2
 {
-
     /**
      * {@inheritdoc}
      */
-    public $scope = 'user:email';
+    protected $scope = 'user:email';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/GitLab.php
+++ b/src/Provider/GitLab.php
@@ -20,7 +20,7 @@ class GitLab extends OAuth2
     /**
     * {@inheritdoc}
     */
-    public $scope = 'api';
+    protected $scope = 'api';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -50,6 +50,7 @@ class Google extends OAuth2
     /**
     * {@inheritdoc}
     */
+    // phpcs:ignore
     protected $scope = 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email';
 
     /**

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -50,7 +50,7 @@ class Google extends OAuth2
     /**
     * {@inheritdoc}
     */
-    public $scope = 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email';
+    protected $scope = 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -20,7 +20,7 @@ class LinkedIn extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public $scope = 'r_liteprofile r_emailaddress w_member_social';
+    protected $scope = 'r_liteprofile r_emailaddress w_member_social';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Mailru.php
+++ b/src/Provider/Mailru.php
@@ -13,27 +13,7 @@ use Hybridauth\Data\Collection;
 use Hybridauth\User\Profile;
 
 /**
- * Mailru provider adapter.
- *
- * Example:
- *
- *   $config = [
- *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'      => ['id' => '', 'secret' => ''],
- *   ];
- *
- *   $adapter = new Hybridauth\Provider\Mailru($config);
- *
- *   try {
- *       if (!$adapter->isConnected()) {
- *           $adapter->authenticate();
- *       }
- *
- *       $userProfile = $adapter->getUserProfile();
- *   }
- *   catch(\Exception $e) {
- *       print $e->getMessage() ;
- *   }
+ * Mailru OAuth2 provider adapter.
  */
 class Mailru extends OAuth2
 {
@@ -52,6 +32,10 @@ class Mailru extends OAuth2
      */
     protected $accessTokenUrl = 'https://connect.mail.ru/oauth/token';
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = ''; // Not available
 
     /**
      * {@inheritdoc}

--- a/src/Provider/MicrosoftGraph.php
+++ b/src/Provider/MicrosoftGraph.php
@@ -13,7 +13,7 @@ use Hybridauth\Exception\UnexpectedApiResponseException;
 use Hybridauth\User;
 
 /**
- * Microsoft Graph provider adapter.
+ * Microsoft Graph OAuth2 provider adapter.
  *
  * Create an "Azure Active Directory" resource at https://portal.azure.com/
  * (not from the Visual Studio site).
@@ -47,7 +47,7 @@ class MicrosoftGraph extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public $scope = 'openid user.read contacts.read';
+    protected $scope = 'openid user.read contacts.read';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Odnoklassniki.php
+++ b/src/Provider/Odnoklassniki.php
@@ -14,26 +14,6 @@ use Hybridauth\User;
 
 /**
  * Odnoklassniki OAuth2 provider adapter.
- *
- * Example:
- *
- *   $config = [
- *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'      => ['id' => '', 'key' => '', 'secret' => ''],
- *   ];
-
- *   $adapter = new Hybridauth\Provider\Odnoklassniki($config);
- *
- *   try {
- *       if (!$adapter->isConnected()) {
- *           $adapter->authenticate();
- *       }
- *
- *       $userProfile = $adapter->getUserProfile();
- *   }
- *   catch(\Exception $e) {
- *       print $e->getMessage() ;
- *   }
  */
 class Odnoklassniki extends OAuth2
 {
@@ -51,6 +31,11 @@ class Odnoklassniki extends OAuth2
     * {@inheritdoc}
     */
     protected $accessTokenUrl = 'https://api.ok.ru/oauth/token.do';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://apiok.ru/en/ext/oauth/';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/Patreon.php
+++ b/src/Provider/Patreon.php
@@ -17,11 +17,10 @@ use Hybridauth\Data\Collection;
  */
 class Patreon extends OAuth2
 {
-
     /**
      * {@inheritdoc}
      */
-    public $scope = 'identity identity[email]';
+    protected $scope = 'identity identity[email]';
 
     /**
      * {@inheritdoc}
@@ -37,6 +36,11 @@ class Patreon extends OAuth2
      * {@inheritdoc}
      */
     protected $accessTokenUrl = 'https://www.patreon.com/api/oauth2/token';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://docs.patreon.com/#oauth';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Paypal.php
+++ b/src/Provider/Paypal.php
@@ -14,34 +14,13 @@ use Hybridauth\User;
 
 /**
  * Paypal OAuth2 provider adapter.
- *
- * Example:
- *
- *   $config = [
- *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'id' => '', 'secret' => '' ],
- *       'scope'    => 'openid profile email',
- *   ];
- *
- *   $adapter = new Hybridauth\Provider\Paypal( $config );
- *
- *   try {
- *       $adapter->authenticate();
- *
- *       $userProfile = $adapter->getUserProfile();
- *       $tokens = $adapter->getAccessToken();
- *       $profile = $adapter->getUserProfile();
- *   }
- *   catch( Exception $e ){
- *       echo $e->getMessage() ;
- *   }
  */
 class Paypal extends OAuth2
 {
     /**
     * {@inheritdoc}
     */
-    public $scope = 'openid profile email address';
+    protected $scope = 'openid profile email address';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/PaypalOpenID.php
+++ b/src/Provider/PaypalOpenID.php
@@ -21,6 +21,11 @@ class PaypalOpenID extends OpenID
     protected $openidIdentifier = 'https://www.sandbox.paypal.com/webapps/auth/server';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://developer.paypal.com/docs/connect-with-paypal/';
+
+    /**
     * {@inheritdoc}
     */
     public function authenticateBegin()

--- a/src/Provider/QQ.php
+++ b/src/Provider/QQ.php
@@ -12,7 +12,6 @@ use Hybridauth\User\Profile;
  */
 class QQ extends OAuth2
 {
-
     /**
      * {@inheritdoc}
      */
@@ -53,6 +52,11 @@ class QQ extends OAuth2
      * {@inheritdoc}
      */
     protected $tokenRefreshMethod = 'GET';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = ''; // Not available
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Slack.php
+++ b/src/Provider/Slack.php
@@ -17,11 +17,10 @@ use Hybridauth\User;
  */
 class Slack extends OAuth2
 {
-
     /**
      * {@inheritdoc}
      */
-    public $scope = 'identity.basic identity.email identity.avatar';
+    protected $scope = 'identity.basic identity.email identity.avatar';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Spotify.php
+++ b/src/Provider/Spotify.php
@@ -17,11 +17,10 @@ use Hybridauth\User;
  */
 class Spotify extends OAuth2
 {
-
     /**
      * {@inheritdoc}
      */
-    public $scope = 'user-read-email';
+    protected $scope = 'user-read-email';
 
     /**
      * {@inheritdoc}
@@ -37,6 +36,11 @@ class Spotify extends OAuth2
      * {@inheritdoc}
      */
     protected $accessTokenUrl = 'https://accounts.spotify.com/api/token';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://developer.spotify.com/documentation/general/guides/authorization-guide/';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/StackExchange.php
+++ b/src/Provider/StackExchange.php
@@ -26,9 +26,15 @@ use Hybridauth\User;
  *
  *   $adapter = new Hybridauth\Provider\StackExchange( $config );
  *
- *   $adapter->authenticate();
+ *   try {
+ *       $adapter->authenticate();
  *
- *   $userProfile = $adapter->getUserProfile();
+ *       $userProfile = $adapter->getUserProfile();
+ *       $tokens = $adapter->getAccessToken();
+ *   }
+ *   catch( \Exception $e ){
+ *       echo $e->getMessage() ;
+ *   }
  */
 class StackExchange extends OAuth2
 {

--- a/src/Provider/StackExchangeOpenID.php
+++ b/src/Provider/StackExchangeOpenID.php
@@ -20,6 +20,11 @@ class StackExchangeOpenID extends OpenID
     protected $openidIdentifier = 'https://openid.stackexchange.com/';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://openid.stackexchange.com/';
+
+    /**
     * {@inheritdoc}
     */
     public function authenticateFinish()

--- a/src/Provider/Steam.php
+++ b/src/Provider/Steam.php
@@ -24,9 +24,14 @@ use Hybridauth\User;
  *
  *   $adapter = new Hybridauth\Provider\Steam( $config );
  *
- *   $adapter->authenticate();
-
- *   $userProfile = $adapter->getUserProfile();
+ *   try {
+ *       $adapter->authenticate();
+ *
+ *       $userProfile = $adapter->getUserProfile();
+ *   }
+ *   catch( \Exception $e ){
+ *       echo $e->getMessage() ;
+ *   }
  */
 class Steam extends OpenID
 {
@@ -34,6 +39,11 @@ class Steam extends OpenID
     * {@inheritdoc}
     */
     protected $openidIdentifier = 'http://steamcommunity.com/openid';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://steamcommunity.com/dev';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/Strava.php
+++ b/src/Provider/Strava.php
@@ -20,7 +20,7 @@ class Strava extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public $scope = 'profile:read_all';
+    protected $scope = 'profile:read_all';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Telegram.php
+++ b/src/Provider/Telegram.php
@@ -34,12 +34,16 @@ use Hybridauth\Exception\UnexpectedApiResponseException;
  */
 class Telegram extends AbstractAdapter implements AdapterInterface
 {
-
     protected $botId = '';
 
     protected $botSecret = '';
 
     protected $callbackUrl = '';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://core.telegram.org/bots';
 
     /**
      * {@inheritdoc}

--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -13,7 +13,7 @@ use Hybridauth\Data;
 use Hybridauth\User;
 
 /**
- * Twitter provider adapter.
+ * Twitter OAuth1 provider adapter.
  * Uses OAuth1 not OAuth2 because many Twitter endpoints are built around OAuth1.
  *
  * Example:

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -15,7 +15,7 @@ use Hybridauth\Data;
 use Hybridauth\User;
 
 /**
- * Vkontakte provider adapter.
+ * Vkontakte OAuth2 provider adapter.
  *
  * Example:
  *
@@ -42,7 +42,6 @@ use Hybridauth\User;
  */
 class Vkontakte extends OAuth2
 {
-
     const API_VERSION = '5.95';
 
     const URL = 'https://vk.com/';
@@ -66,6 +65,11 @@ class Vkontakte extends OAuth2
      * {@inheritdoc}
      */
     protected $scope = 'email,offline';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = ''; // Not available
 
     /**
      * {@inheritdoc}

--- a/src/Provider/WeChat.php
+++ b/src/Provider/WeChat.php
@@ -17,7 +17,6 @@ use Hybridauth\User;
  */
 class WeChat extends OAuth2
 {
-
     /**
      * {@inheritdoc}
      */
@@ -58,6 +57,11 @@ class WeChat extends OAuth2
      * {@inheritdoc}
      */
     protected $tokenRefreshMethod = 'GET';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = ''; // Not available
 
     /**
     * {@inheritdoc}

--- a/src/Provider/WeChatChina.php
+++ b/src/Provider/WeChatChina.php
@@ -12,7 +12,6 @@ namespace Hybridauth\Provider;
  */
 class WeChatChina extends WeChat
 {
-
     /**
      * {@inheritdoc}
      */

--- a/src/Provider/WindowsLive.php
+++ b/src/Provider/WindowsLive.php
@@ -20,7 +20,7 @@ class WindowsLive extends OAuth2
     /**
     * {@inheritdoc}
     */
-    public $scope = 'wl.basic wl.contacts_emails wl.emails wl.signin wl.share wl.birthday';
+    protected $scope = 'wl.basic wl.contacts_emails wl.emails wl.signin wl.share wl.birthday';
 
     /**
     * {@inheritdoc}

--- a/src/Provider/YahooOpenID.php
+++ b/src/Provider/YahooOpenID.php
@@ -20,6 +20,11 @@ class YahooOpenID extends OpenID
     protected $openidIdentifier = 'https://open.login.yahooapis.com/openid20/www.yahoo.com/xrds';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = ''; // Not available
+
+    /**
     * {@inheritdoc}
     */
     public function authenticateFinish()

--- a/src/Provider/Yandex.php
+++ b/src/Provider/Yandex.php
@@ -14,27 +14,7 @@ use Hybridauth\Data\Collection;
 use Hybridauth\User\Profile;
 
 /**
- * Yandex provider adapter.
- *
- * Example:
- *
- *   $config = [
- *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'      => ['id' => '', 'secret' => ''],
- *   ];
- *
- *   $adapter = new Hybridauth\Provider\Yandex($config);
- *
- *   try {
- *       if (!$adapter->isConnected()) {
- *           $adapter->authenticate();
- *       }
- *
- *       $userProfile = $adapter->getUserProfile();
- *   }
- *   catch(\Exception $e) {
- *       print $e->getMessage() ;
- *   }
+ * Yandex OAuth2 provider adapter.
  */
 class Yandex extends OAuth2
 {
@@ -54,13 +34,17 @@ class Yandex extends OAuth2
     protected $accessTokenUrl = 'https://oauth.yandex.ru/token';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://yandex.com/dev/oauth/doc/dg/concepts/about-docpage/';
+
+    /**
      * load the user profile from the IDp api client
      *
      * @throws Exception
      */
     public function getUserProfile()
     {
-
         $this->scope = implode(',', []);
 
         $response = $this->apiRequest($this->apiBaseUrl . "?format=json");


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |  No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

When integrating Hybridauth, and working with providers, it was a little confusing that there were discrepancies between the provider files. For example, if one provides an example, and another doesn't, it suggests that example might show something special - which is only sometimes true.

This makes providers consistent...

1) Fixing that many make $scope public for no reason, overriding the scope of the parent class (might even be some kind of error in future PHP versions?)
2) Fix inconsistent space after opening braces sometimes (encourage consistent coding standards to be followed in future)
3) Only includes examples when those examples have something unique to show (avoid wasting readers time)
4) Always provide an API documentation link, or a note if one is not available (avoids people working on a provider Googling)
5) Fix last year copyright date in the new Dropbox provider (my bad)
6) Consistent header line comment above each provider class ("<Human name> <tech> provider adapter."
7) Make examples 100% consistent with each other apart from where there is an actual implementation difference (so readers don't think differences between providers exist when they don't)
