### PR TITLE
Pass locale to Facebook API

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -102,7 +102,8 @@ class Facebook extends OAuth2
             'hometown',
             'birthday',
         ];
-        $response = $this->apiRequest('me', 'GET', [ 'fields' => implode(',', $fields), 'locale' => 'en_US' ]);
+        $locale = $this->config->get('locale') ?: 'en_US'; // Note that en_US is needed for gender fields to match convention
+        $response = $this->apiRequest('me', 'GET', [ 'fields' => implode(',', $fields), 'locale' => $locale ]);
 
         $data = new Data\Collection($response);
 

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -106,7 +106,7 @@ class Facebook extends OAuth2
         // Note that en_US is needed for gender fields to match convention.
         $locale = $this->config->get('locale') ?: 'en_US';
         $response = $this->apiRequest('me', 'GET', [
-            'fields' => implode(',', $fields), 
+            'fields' => implode(',', $fields),
             'locale' => $locale,
         ]);
 

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -102,8 +102,13 @@ class Facebook extends OAuth2
             'hometown',
             'birthday',
         ];
-        $locale = $this->config->get('locale') ?: 'en_US'; // Note that en_US is needed for gender fields to match convention
-        $response = $this->apiRequest('me', 'GET', [ 'fields' => implode(',', $fields), 'locale' => $locale ]);
+
+        // Note that en_US is needed for gender fields to match convention.
+        $locale = $this->config->get('locale') ?: 'en_US';
+        $response = $this->apiRequest('me', 'GET', [
+            'fields' => implode(',', $fields), 
+            'locale' => $locale,
+        ]);
 
         $data = new Data\Collection($response);
 

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -102,7 +102,7 @@ class Facebook extends OAuth2
             'hometown',
             'birthday',
         ];
-        $response = $this->apiRequest('me?fields=' . implode(',', $fields));
+        $response = $this->apiRequest('me', 'GET', [ 'fields' => implode(',', $fields), 'locale' => 'en_US' ]);
 
         $data = new Data\Collection($response);
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1097 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

To get consistent gender options in English you need to tell the API your locale (as per https://stackoverflow.com/questions/35118373/facebook-graph-api-gender).
I couldn't test this as user_gender permission needs app approval, which I don't have.
But I think it'll work and it doesn't break anything.