### PR TITLE
Refactor refresh token handling to fix some messy code and bugs

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -126,6 +126,11 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    abstract public function isConnected();
+
+    /**
+     * {@inheritdoc}
+     */
     public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         throw new NotImplementedException('Provider does not support this feature.');
@@ -178,11 +183,6 @@ abstract class AbstractAdapter implements AdapterInterface
     {
         throw new NotImplementedException('Provider does not support this feature.');
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public abstract function isConnected();
 
     /**
      * {@inheritdoc}

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -182,6 +182,11 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    public abstract function isConnected();
+
+    /**
+     * {@inheritdoc}
+     */
     public function disconnect()
     {
         $this->clearStoredData();

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -181,16 +181,6 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * {@inheritdoc}
-     *
-     * Checking access_token only works for oauth1 and oauth2, openid will overwrite this method.
-     */
-    public function isConnected()
-    {
-        return (bool) $this->getStoredData('access_token');
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function disconnect()
     {

--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -231,8 +231,6 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
 
     /**
      * {@inheritdoc}
-     *
-     * Checking access_token only works for oauth1 and oauth2, openid will overwrite this method.
      */
     public function isConnected()
     {

--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -230,6 +230,16 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * Checking access_token only works for oauth1 and oauth2, openid will overwrite this method.
+     */
+    public function isConnected()
+    {
+        return (bool)$this->getStoredData('access_token');
+    }
+
+    /**
     * Initiate the authorization protocol
     *
     * 1. Obtaining an Unauthorized Request Token

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -333,7 +333,10 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
      */
     public function isConnected()
     {
-        return (bool)$this->getStoredData('access_token') && (!$this->hasAccessTokenExpired() || $this->isRefreshTokenAvailable());
+        if ((bool)$this->getStoredData('access_token')) {
+            return (!$this->hasAccessTokenExpired() || $this->isRefreshTokenAvailable());
+        }
+        return false;
     }
 
     /**

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -328,8 +328,6 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
 
     /**
      * {@inheritdoc}
-     *
-     * Checking access_token only works for oauth1 and oauth2, openid will overwrite this method.
      */
     public function isConnected()
     {

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -144,14 +144,6 @@ class Apple extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public function isConnected()
-    {
-        return (bool)$this->getStoredData('access_token') && !$this->hasAccessTokenExpired();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function validateAccessTokenExchange($response)
     {
         $collection = parent::validateAccessTokenExchange($response);

--- a/src/Provider/Authentiq.php
+++ b/src/Provider/Authentiq.php
@@ -64,15 +64,6 @@ class Authentiq extends OAuth2
 
     /**
     * {@inheritdoc}
-    *
-    * Disable functionality as Authentiq Provider doesn't support this yet
-    */
-    public function refreshAccessToken($parameters = [])
-    {
-    }
-
-    /**
-    * {@inheritdoc}
     */
     public function getUserProfile()
     {

--- a/src/Provider/DeviantArt.php
+++ b/src/Provider/DeviantArt.php
@@ -69,10 +69,12 @@ class DeviantArt extends OAuth2
     {
         parent::initialize();
 
-        $this->tokenRefreshParameters += [
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret,
-        ];
+        if (is_array($this->tokenRefreshParameters)) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ];
+        }
     }
 
     /**

--- a/src/Provider/DeviantArt.php
+++ b/src/Provider/DeviantArt.php
@@ -69,7 +69,7 @@ class DeviantArt extends OAuth2
     {
         parent::initialize();
 
-        if (is_array($this->tokenRefreshParameters)) {
+        if ($this->isRefreshTokenAvailable()) {
             $this->tokenRefreshParameters += [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -50,7 +50,7 @@ class Discord extends OAuth2
     {
         parent::initialize();
 
-        if (is_array($this->tokenRefreshParameters)) {
+        if ($this->isRefreshTokenAvailable()) {
             $this->tokenRefreshParameters += [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,

--- a/src/Provider/Discord.php
+++ b/src/Provider/Discord.php
@@ -50,10 +50,12 @@ class Discord extends OAuth2
     {
         parent::initialize();
 
-        $this->tokenRefreshParameters += [
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret,
-        ];
+        if (is_array($this->tokenRefreshParameters)) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ];
+        }
     }
 
     /**

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -83,7 +83,7 @@ class Google extends OAuth2
             'access_type' => 'offline'
         ];
 
-        if (is_array($this->tokenRefreshParameters)) {
+        if ($this->isRefreshTokenAvailable()) {
             $this->tokenRefreshParameters += [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -83,10 +83,12 @@ class Google extends OAuth2
             'access_type' => 'offline'
         ];
 
-        $this->tokenRefreshParameters += [
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret
-        ];
+        if (is_array($this->tokenRefreshParameters)) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret
+            ];
+        }
     }
 
     /**

--- a/src/Provider/Odnoklassniki.php
+++ b/src/Provider/Odnoklassniki.php
@@ -59,7 +59,7 @@ class Odnoklassniki extends OAuth2
     {
         parent::initialize();
 
-        if (is_array($this->tokenRefreshParameters)) {
+        if ($this->isRefreshTokenAvailable()) {
             $this->tokenRefreshParameters += [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret

--- a/src/Provider/Odnoklassniki.php
+++ b/src/Provider/Odnoklassniki.php
@@ -59,10 +59,12 @@ class Odnoklassniki extends OAuth2
     {
         parent::initialize();
 
-        $this->tokenRefreshParameters += [
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret
-        ];
+        if (is_array($this->tokenRefreshParameters)) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret
+            ];
+        }
     }
 
     /**

--- a/src/Provider/Patreon.php
+++ b/src/Provider/Patreon.php
@@ -45,7 +45,7 @@ class Patreon extends OAuth2
     {
         parent::initialize();
 
-        if (is_array($this->tokenRefreshParameters)) {
+        if ($this->isRefreshTokenAvailable()) {
             $this->tokenRefreshParameters += [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,

--- a/src/Provider/Patreon.php
+++ b/src/Provider/Patreon.php
@@ -45,10 +45,12 @@ class Patreon extends OAuth2
     {
         parent::initialize();
 
-        $this->tokenRefreshParameters += [
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret,
-        ];
+        if (is_array($this->tokenRefreshParameters)) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ];
+        }
     }
 
     /**

--- a/src/Provider/QQ.php
+++ b/src/Provider/QQ.php
@@ -61,12 +61,12 @@ class QQ extends OAuth2
     {
         parent::initialize();
 
-        $this->tokenRefreshParameters = [
-            'grant_type'    => 'refresh_token',
-            'client_id'     => $this->clientId,
-            'client_secret' => $this->clientSecret,
-            'refresh_token' => $this->getStoredData('refresh_token'),
-        ];
+        if (is_array($this->tokenRefreshParameters)) {
+            $this->tokenRefreshParameters = [
+                'client_id'     => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ];
+        }
 
         $this->apiRequestParameters = [
             'access_token' => $this->getStoredData('access_token')

--- a/src/Provider/QQ.php
+++ b/src/Provider/QQ.php
@@ -61,8 +61,8 @@ class QQ extends OAuth2
     {
         parent::initialize();
 
-        if (is_array($this->tokenRefreshParameters)) {
-            $this->tokenRefreshParameters = [
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
                 'client_id'     => $this->clientId,
                 'client_secret' => $this->clientSecret,
             ];

--- a/src/Provider/Telegram.php
+++ b/src/Provider/Telegram.php
@@ -82,9 +82,17 @@ class Telegram extends AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
+    public function isConnected()
+    {
+        return !empty($this->getStoredData('auth_data'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
-        $data = new Collection($this->parseAuthData());
+        $data = new Collection($this->getStoredData('auth_data'));
 
         if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
@@ -164,6 +172,9 @@ HTML
             sprintf('%s::authenticateFinish(), callback url:', get_class($this)),
             [Util::getCurrentUrl(true)]
         );
+
+        $this->storeData('auth_data', $this->parseAuthData());
+
         $this->initialize();
     }
 

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -97,7 +97,7 @@ class Vkontakte extends OAuth2
      */
     public function hasAccessTokenExpired()
     {
-        // As we using offline scope, $expired will be false.
+        // If we are using offline scope, $expired will be false.
         $expired = $this->getStoredData('expires_in')
             ? $this->getStoredData('expires_at') <= time()
             : false;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1218 
| Patch: Bug Fix?          | Arguably yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | Debatable

The refresh token handling code in Hybridauth has some issues, which this patch fixes.

1) At a basic level, OAuth2 is assuming every OAuth implementation supports refresh tokens, and it tries refreshing expired tokens even when it has no refresh token.
2) Some providers then override this with null-op functionality, which is inconsistent. For example, Google provider didn't override it but my testing shows it does not have refresh tokens.
3) isConnected is implemented in AbstractAdapter with hard-baked assumption that then has to be overridden away for OpenID. Messy.
4) For OAuth2 isConnected should return false if token is expired and refresh is not available
5) Telegram isConnected is also a mess. It has its own adapter API (i.e. not derived from OAuth) yet is inheriting that dodgy isConnected from AbstractAdapter. It needs its data handling rewriting so that it can store the connection info as other adapters do.
6) hasAccessTokenExpired is overriden for VK, which is good, but it has a slightly misleading code comment. Fix that.

