### PR TITLE
Fix incorrect exceptions being thrown by a couple of providers

### DIFF
--- a/src/Provider/Authentiq.php
+++ b/src/Provider/Authentiq.php
@@ -81,7 +81,7 @@ class Authentiq extends OAuth2
         $data = new Data\Collection($response);
 
         if (!$data->exists('sub')) {
-            throw new UnexpectedValueException('Provider API returned an unexpected response.');
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();

--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -76,7 +76,7 @@ class Yahoo extends OAuth2
         $data = new Data\Collection($response);
 
         if (!$data->exists('sub')) {
-            throw new UnexpectedValueException('Provider API returned an unexpected response.');
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

A couple of providers throw UnexpectedValueException instead of UnexpectedApiResponseException. Fixing this should not create a compat issue because UnexpectedApiResponseException is a subclass of UnexpectedValueException.