### PR TITLE
Fix various bad error messages and inconsistencies in exceptions

### DIFF
--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -278,7 +278,7 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
 
         if ($oauth_problem) {
             throw new InvalidOauthTokenException(
-                'Provider returned an invalid oauth_token. oauth_problem: ' . htmlentities($oauth_problem)
+                'Provider returned an error. oauth_problem: ' . htmlentities($oauth_problem)
             );
         }
 
@@ -397,7 +397,7 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
 
         if (! $collection->exists('oauth_token')) {
             throw new InvalidOauthTokenException(
-                'Provider returned an invalid access_token: ' . htmlentities($response)
+                'Provider returned no oauth_token: ' . htmlentities($response)
             );
         }
 
@@ -495,7 +495,7 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
 
         if (! $collection->exists('oauth_token')) {
             throw new InvalidAccessTokenException(
-                'Provider returned an invalid access_token: ' . htmlentities($response)
+                'Provider returned no access_token: ' . htmlentities($response)
             );
         }
 

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -532,7 +532,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
 
         if (! $collection->exists('access_token')) {
             throw new InvalidAccessTokenException(
-                'Provider returned an invalid access_token: ' . htmlentities($response)
+                'Provider returned no access_token: ' . htmlentities($response)
             );
         }
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | Probably not
| Minor: New Feature?      | No

Exception messages are not correct. Mainly it complains about "invalid <some kind of token>" for situations where there is actually no token passed. Change these to accurate messages.

In one case (the second line change of OAuth1.php it says access_token when it should say oauth_token. This is assuming the initial token is consistently called the oauth_token and exchanged for an access_token. It also makes it consistent with the specific exception used.