### PR TITLE
Fix PSR-2 compliance

### DIFF
--- a/examples/example_01.php
+++ b/examples/example_01.php
@@ -10,7 +10,7 @@
  *
  * Normally this step is not required as Hybridauth will attempt to start the session for you, however
  * in some cases it might be better to call session_start() at top of script to avoid cookie-based sessions
- * issues. 
+ * issues.
  *
  * See: http://php.net/manual/en/function.session-start.php#refsect1-function.session-start-notes
  *      http://stackoverflow.com/a/8028987
@@ -57,7 +57,7 @@ include 'vendor/autoload.php';
 $config = [
     'callback' => 'https://path/to/hybridauth/examples/example_01.php', // or Hybridauth\HttpClient\Util::getCurrentUrl()
 
-    'keys' => [ 'id' => 'your-app-id', 'secret' => 'your-app-secret' ], // Your Github application credentials
+    'keys' => ['id' => 'your-app-id', 'secret' => 'your-app-secret'], // Your Github application credentials
 
     /* optional : set scope
         'scope' => 'user:email', */
@@ -68,17 +68,17 @@ $config = [
         'debug_file' => __FILE__ . '.log', */
 
     /* optional : customize Curl settings
-        // for more information on curl, refer to: http://www.php.net/manual/fr/function.curl-setopt.php  
+        // for more information on curl, refer to: http://www.php.net/manual/fr/function.curl-setopt.php
         'curl_options' => [
             // setting custom certificates
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_CAINFO         => '/path/to/your/certificate.crt',
+            CURLOPT_CAINFO => '/path/to/your/certificate.crt',
 
             // set a valid proxy ip address
             CURLOPT_PROXY => '*.*.*.*:*',
 
             // set a custom user agent
-            CURLOPT_USERAGENT      => ''
+            CURLOPT_USERAGENT => ''
         ] */
 ];
 
@@ -106,14 +106,14 @@ $github->authenticate();
 /**
  * Step 5: Retrieve Users Profiles
  *
- * Calling getUserProfile returns an instance of class Hybridauth\User\Profile which contain the 
+ * Calling getUserProfile returns an instance of class Hybridauth\User\Profile which contain the
  * connected user's profile in simple and standardized structure across all the social APIs supported
  * by Hybridauth.
  */
 
 $userProfile = $github->getUserProfile();
 
-echo 'Hi '.$userProfile->displayName;
+echo 'Hi ' . $userProfile->displayName;
 
 /**
  * Bonus: Access GitHub API
@@ -164,9 +164,8 @@ try {
  *
  * The full list of curl errors that may happen can be found at http://curl.haxx.se/libcurl/c/libcurl-errors.html
  */
-
 catch (Hybridauth\Exception\HttpClientFailureException $e) {
-    echo 'Curl text error message : '.$github->getHttpClient()->getResponseClientError();
+    echo 'Curl text error message : ' . $github->getHttpClient()->getResponseClientError();
 }
 
 /**
@@ -176,15 +175,13 @@ catch (Hybridauth\Exception\HttpClientFailureException $e) {
  *     - Wrong URI or a mal-formatted http request.
  *     - Protected resource without providing a valid access token.
  */
-
 catch (Hybridauth\Exception\HttpRequestFailedException $e) {
-    echo 'Raw API Response: '.$github->getHttpClient()->getResponseBody();
+    echo 'Raw API Response: ' . $github->getHttpClient()->getResponseBody();
 }
 
 /**
  * Base PHP's exception that catches everything [else]
  */
-
 catch (\Exception $e) {
-    echo 'Oops! We ran into an unknown issue: '.$e->getMessage();
+    echo 'Oops! We ran into an unknown issue: ' . $e->getMessage();
 }

--- a/examples/example_02.php
+++ b/examples/example_02.php
@@ -1,6 +1,6 @@
 <?php
 /*!
-* Details how to use users in a similar fashion to Hybridauth 2. Note that while Hybridauth 3 provides 
+* Details how to use users in a similar fashion to Hybridauth 2. Note that while Hybridauth 3 provides
 * a similar interface to Hybridauth 2, both versions are not fully compatible with each other.
 */
 
@@ -13,24 +13,24 @@ $config = [
     'callback' => HttpClient\Util::getCurrentUrl(),
 
     'providers' => [
-        'GitHub' => [ 
+        'GitHub' => [
             'enabled' => true,
-            'keys'    => [ 'id' => '', 'secret' => '' ], 
+            'keys' => ['id' => '', 'secret' => ''],
         ],
 
-        'Google' => [ 
+        'Google' => [
             'enabled' => true,
-            'keys'    => [ 'id' => '', 'secret' => '' ],
+            'keys' => ['id' => '', 'secret' => ''],
         ],
 
-        'Facebook' => [ 
+        'Facebook' => [
             'enabled' => true,
-            'keys'    => [ 'id' => '', 'secret' => '' ],
+            'keys' => ['id' => '', 'secret' => ''],
         ],
 
-        'Twitter' => [ 
+        'Twitter' => [
             'enabled' => true,
-            'keys'    => [ 'key' => '', 'secret' => '' ],
+            'keys' => ['key' => '', 'secret' => ''],
         ]
     ],
 
@@ -40,24 +40,24 @@ $config = [
         'debug_file' => __FILE__ . '.log', */
 
     /* optional : customize Curl settings
-        // for more information on curl, refer to: http://www.php.net/manual/fr/function.curl-setopt.php  
+        // for more information on curl, refer to: http://www.php.net/manual/fr/function.curl-setopt.php
         'curl_options' => [
             // setting custom certificates
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_CAINFO         => '/path/to/your/certificate.crt',
+            CURLOPT_CAINFO => '/path/to/your/certificate.crt',
 
             // set a valid proxy ip address
             CURLOPT_PROXY => '*.*.*.*:*',
 
             // set a custom user agent
-            CURLOPT_USERAGENT      => ''
+            CURLOPT_USERAGENT => ''
         ] */
 ];
 
-try {    
-    $hybridauth = new Hybridauth( $config );
+try {
+    $hybridauth = new Hybridauth($config);
 
-    $adapter = $hybridauth->authenticate( 'GitHub' );
+    $adapter = $hybridauth->authenticate('GitHub');
 
     // $adapter = $hybridauth->authenticate( 'Google' );
     // $adapter = $hybridauth->authenticate( 'Facebook' );
@@ -70,7 +70,6 @@ try {
     // print_r( $userProfile );
 
     $adapter->disconnect();
-}
-catch (\Exception $e) {
+} catch (\Exception $e) {
     echo $e->getMessage();
 }

--- a/examples/example_03.php
+++ b/examples/example_03.php
@@ -6,19 +6,19 @@
 include 'vendor/autoload.php';
 
 $config = [
-    'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
+    'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
 
-    'keys' => [ 'id' => 'your-facebook-app-id', 'secret' => 'your-facebook-app-secret' ],
+    'keys' => ['id' => 'your-facebook-app-id', 'secret' => 'your-facebook-app-secret'],
 
     'endpoints' => [
-        'api_base_url'     => 'https://graph.facebook.com/v2.8/',
-        'authorize_url'    => 'https://www.facebook.com/dialog/oauth',
+        'api_base_url' => 'https://graph.facebook.com/v2.8/',
+        'authorize_url' => 'https://www.facebook.com/dialog/oauth',
         'access_token_url' => 'https://graph.facebook.com/oauth/access_token',
     ]
 ];
 
 try {
-    $adapter = new Hybridauth\Provider\Facebook( $config );
+    $adapter = new Hybridauth\Provider\Facebook($config);
 
     $adapter->setAccessToken(['access_token' => 'user-facebook-access-token']);
 
@@ -27,7 +27,6 @@ try {
     // print_r( $userProfile );
 
     $adapter->disconnect();
-}
-catch( Exception $e ){
+} catch (Exception $e) {
     echo $e->getMessage();
 }

--- a/examples/example_04.php
+++ b/examples/example_04.php
@@ -6,7 +6,7 @@
 include 'vendor/autoload.php';
 
 $config = [
-    'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
+    'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
 
     'openid_identifier' => 'https://open.login.yahooapis.com/openid20/www.yahoo.com/xrds',
     // 'openid_identifier' => 'https://openid.stackexchange.com/',
@@ -15,7 +15,7 @@ $config = [
 ];
 
 try {
-    $adapter = new Hybridauth\Provider\OpenID( $config );
+    $adapter = new Hybridauth\Provider\OpenID($config);
 
     $adapter->authenticate();
 
@@ -26,7 +26,6 @@ try {
     // print_r( $userProfile );
 
     $adapter->disconnect();
-}
-catch( Exception $e ){
+} catch (Exception $e) {
     echo $e->getMessage();
 }

--- a/examples/example_05.php
+++ b/examples/example_05.php
@@ -6,13 +6,13 @@
 include 'vendor/autoload.php';
 
 $config = [
-    'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
+    'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
 
-    'keys' => [ 'id' => '', 'secret' => '' ],
+    'keys' => ['id' => '', 'secret' => ''],
 ];
 
 $guzzle = new Hybridauth\HttpClient\Guzzle(null, [
-    // 'verify'  => true, # Set to false to disable SSL certificate verification
+    // 'verify' => true, # Set to false to disable SSL certificate verification
 ]);
 
 try {
@@ -27,7 +27,6 @@ try {
     // print_r( $userProfile );
 
     $adapter->disconnect();
-}
-catch( Exception $e ){
+} catch (Exception $e) {
     echo $e->getMessage();
 }

--- a/examples/example_06/config.php
+++ b/examples/example_06/config.php
@@ -4,32 +4,32 @@
  */
 
 $config = [
-  /**
-   * Set the Authorization callback URL to https://path/to/hybridauth/examples/example_06/callback.php.
-   * Understandably, you need to replace 'path/to/hybridauth' with the real path to this script.
-   */
-  'callback' => 'https://path/to/hybridauth/examples/example_06/callback.php',
-  'providers' => [
-    'Twitter' => [
-      'enabled' => true,
-      'keys' => [
-        'key' => '...',
-        'secret' => '...',
-      ],
+    /**
+     * Set the Authorization callback URL to https://path/to/hybridauth/examples/example_06/callback.php.
+     * Understandably, you need to replace 'path/to/hybridauth' with the real path to this script.
+     */
+    'callback' => 'https://path/to/hybridauth/examples/example_06/callback.php',
+    'providers' => [
+        'Twitter' => [
+            'enabled' => true,
+            'keys' => [
+                'key' => '...',
+                'secret' => '...',
+            ],
+        ],
+        'LinkedIn' => [
+            'enabled' => true,
+            'keys' => [
+                'id' => '...',
+                'secret' => '...',
+            ],
+        ],
+        'Facebook' => [
+            'enabled' => true,
+            'keys' => [
+                'id' => '...',
+                'secret' => '...',
+            ],
+        ],
     ],
-    'LinkedIn' => [
-      'enabled' => true,
-      'keys' => [
-        'id' => '...',
-        'secret' => '...',
-      ],
-    ],
-    'Facebook' => [
-      'enabled' => true,
-      'keys' => [
-        'id' => '...',
-        'secret' => '...',
-      ],
-    ],
-  ],
 ];

--- a/examples/example_07/callback.php
+++ b/examples/example_07/callback.php
@@ -47,7 +47,7 @@ try {
     // Handle invalid provider errors
     //
     if ($error) {
-        error_log('Hybridauth Error: Provider '. json_encode($error) .' not found or not enabled in $config');
+        error_log('Hybridauth Error: Provider ' . json_encode($error) . ' not found or not enabled in $config');
         // Close the pop-up window
         echo "
             <script>
@@ -74,12 +74,12 @@ try {
         // add your custom AUTH functions (if any) here
         // ...
         $data = [
-            'token'         => $accessToken,
-            'identifier'    => $userProfile->identifier,
-            'email'         => $userProfile->email,
-            'first_name'    => $userProfile->firstName,
-            'last_name'     => $userProfile->lastName,
-            'photoURL'      => strtok($userProfile->photoURL,'?'),
+            'token' => $accessToken,
+            'identifier' => $userProfile->identifier,
+            'email' => $userProfile->email,
+            'first_name' => $userProfile->firstName,
+            'last_name' => $userProfile->lastName,
+            'photoURL' => strtok($userProfile->photoURL, '?'),
         ];
         // ...
 
@@ -94,6 +94,6 @@ try {
     }
 
 } catch (Exception $e) {
-    error_log( $e->getMessage());
+    error_log($e->getMessage());
     echo $e->getMessage();
 }

--- a/examples/example_07/config.php
+++ b/examples/example_07/config.php
@@ -12,16 +12,16 @@ $config = [
         'Google' => [
             'enabled' => true,
             'keys' => [
-                'id'     => '...',
+                'id' => '...',
                 'secret' => '...',
             ],
             'scope' => 'email',
         ],
 
-        // 'Yahoo'     => ['enabled' => true, 'keys' => [ 'key'  => '...', 'secret' => '...']],
-        // 'Facebook'  => ['enabled' => true, 'keys' => [ 'id'   => '...', 'secret' => '...']],
-        // 'Twitter'   => ['enabled' => true, 'keys' => [ 'key'  => '...', 'secret' => '...']],
-        // 'Instagram' => ['enabled' => true, 'keys' => [ 'id'   => '...', 'secret' => '...']],
+        // 'Yahoo' => ['enabled' => true, 'keys' => ['key' => '...', 'secret' => '...']],
+        // 'Facebook' => ['enabled' => true, 'keys' => ['id' => '...', 'secret' => '...']],
+        // 'Twitter' => ['enabled' => true, 'keys' => ['key' => '...', 'secret' => '...']],
+        // 'Instagram' => ['enabled' => true, 'keys' => ['id' => '...', 'secret' => '...']],
 
     ],
 ];

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -78,23 +78,23 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Whether to validate API status codes of http responses
      *
-     * @var boolean
+     * @var bool
      */
     protected $validateApiResponseHttpCode = true;
 
     /**
      * Common adapters constructor.
      *
-     * @param array               $config
+     * @param array $config
      * @param HttpClientInterface $httpClient
-     * @param StorageInterface    $storage
-     * @param LoggerInterface     $logger
+     * @param StorageInterface $storage
+     * @param LoggerInterface $logger
      */
     public function __construct(
         $config = [],
         HttpClientInterface $httpClient = null,
-        StorageInterface    $storage = null,
-        LoggerInterface     $logger = null
+        StorageInterface $storage = null,
+        LoggerInterface $logger = null
     ) {
         $this->providerId = (new \ReflectionClass($this))->getShortName();
 
@@ -114,13 +114,13 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Load adapter's configuration
-    */
+     * Load adapter's configuration
+     */
     abstract protected function configure();
 
     /**
-    * Adapter initializer
-    */
+     * Adapter initializer
+     */
     abstract protected function initialize();
 
     /**
@@ -210,7 +210,7 @@ abstract class AbstractAdapter implements AdapterInterface
 
         foreach ($tokenNames as $name) {
             if ($this->getStoredData($name)) {
-                $tokens[ $name ] = $this->getStoredData($name);
+                $tokens[$name] = $this->getStoredData($name);
             }
         }
 
@@ -292,15 +292,15 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Set Adapter's API callback url
-    *
-    * @param string $callback
-    *
-    * @throws InvalidArgumentException
-    */
+     * Set Adapter's API callback url
+     *
+     * @param string $callback
+     *
+     * @throws InvalidArgumentException
+     */
     protected function setCallback($callback)
     {
-        if (! filter_var($callback, FILTER_VALIDATE_URL)) {
+        if (!filter_var($callback, FILTER_VALIDATE_URL)) {
             throw new InvalidArgumentException('A valid callback url is required.');
         }
 
@@ -343,12 +343,12 @@ abstract class AbstractAdapter implements AdapterInterface
 
         if ($this->httpClient->getResponseClientError()) {
             throw new HttpClientFailureException(
-                $error.'HTTP client error: '.$this->httpClient->getResponseClientError().'.'
+                $error . 'HTTP client error: ' . $this->httpClient->getResponseClientError() . '.'
             );
         }
 
         // if validateApiResponseHttpCode is set to false, we by pass verification of http status code
-        if (! $this->validateApiResponseHttpCode) {
+        if (!$this->validateApiResponseHttpCode) {
             return;
         }
 
@@ -356,8 +356,8 @@ abstract class AbstractAdapter implements AdapterInterface
 
         if ($status < 200 || $status > 299) {
             throw new HttpRequestFailedException(
-                $error . 'HTTP error '.$this->httpClient->getResponseHttpCode().
-                '. Raw Provider API response: '.$this->httpClient->getResponseBody().'.'
+                $error . 'HTTP error ' . $this->httpClient->getResponseHttpCode() .
+                '. Raw Provider API response: ' . $this->httpClient->getResponseBody() . '.'
             );
         }
     }

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -19,14 +19,14 @@ interface AdapterInterface
     /**
      * Initiate the appropriate protocol and process/automate the authentication or authorization flow.
      *
-     * @return boolean|null
+     * @return bool|null
      */
     public function authenticate();
 
     /**
      * Returns TRUE if the user is connected
      *
-     * @return boolean
+     * @return bool
      */
     public function isConnected();
 

--- a/src/Adapter/DataStoreTrait.php
+++ b/src/Adapter/DataStoreTrait.php
@@ -26,7 +26,7 @@ trait DataStoreTrait
      * can be also used by providers to store any other useful data (i.g., user_id, auth_nonce, etc.)
      *
      * @param string $name
-     * @param mixed  $value
+     * @param mixed $value
      */
     protected function storeData($name, $value = null)
     {
@@ -35,7 +35,7 @@ trait DataStoreTrait
             $this->deleteStoredData($name);
         }
 
-        $this->getStorage()->set($this->providerId.'.'.$name, $value);
+        $this->getStorage()->set($this->providerId . '.' . $name, $value);
     }
 
     /**
@@ -51,7 +51,7 @@ trait DataStoreTrait
      */
     protected function getStoredData($name)
     {
-        return $this->getStorage()->get($this->providerId.'.'.$name);
+        return $this->getStorage()->get($this->providerId . '.' . $name);
     }
 
     /**
@@ -61,7 +61,7 @@ trait DataStoreTrait
      */
     protected function deleteStoredData($name)
     {
-        $this->getStorage()->delete($this->providerId.'.'.$name);
+        $this->getStorage()->delete($this->providerId . '.' . $name);
     }
 
     /**
@@ -69,6 +69,6 @@ trait DataStoreTrait
      */
     protected function clearStoredData()
     {
-        $this->getStorage()->deleteMatch($this->providerId.'.');
+        $this->getStorage()->deleteMatch($this->providerId . '.');
     }
 }

--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -28,129 +28,129 @@ use Hybridauth\Thirdparty\OAuth\OAuthUtil;
 abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
 {
     /**
-    * Base URL to provider API
-    *
-    * This var will be used to build urls when sending signed requests
-    *
-    * @var string
-    */
+     * Base URL to provider API
+     *
+     * This var will be used to build urls when sending signed requests
+     *
+     * @var string
+     */
     protected $apiBaseUrl = '';
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     protected $authorizeUrl = '';
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     protected $requestTokenUrl = '';
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     protected $accessTokenUrl = '';
 
     /**
-    * IPD API Documentation
-    *
-    * OPTIONAL.
-    *
-    * @var string
-    */
+     * IPD API Documentation
+     *
+     * OPTIONAL.
+     *
+     * @var string
+     */
     protected $apiDocumentation = '';
 
     /**
-    * OAuth Version
-    *
-    *  '1.0' OAuth Core 1.0
-    * '1.0a' OAuth Core 1.0 Revision A
-    *
-    * @var string
-    */
+     * OAuth Version
+     *
+     *  '1.0' OAuth Core 1.0
+     * '1.0a' OAuth Core 1.0 Revision A
+     *
+     * @var string
+     */
     protected $oauth1Version = '1.0a';
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     protected $consumerKey = null;
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     protected $consumerSecret = null;
 
     /**
-    * @var object
-    */
+     * @var object
+     */
     protected $OAuthConsumer = null;
 
     /**
-    * @var object
-    */
+     * @var object
+     */
     protected $sha1Method = null;
 
     /**
-    * @var object
-    */
+     * @var object
+     */
     protected $consumerToken = null;
 
     /**
-    * Authorization Url Parameters
-    *
-    * @var boolean
-    */
+     * Authorization Url Parameters
+     *
+     * @var bool
+     */
     protected $AuthorizeUrlParameters = [];
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     protected $requestTokenMethod = 'POST';
 
     /**
-    * @var array
-    */
+     * @var array
+     */
     protected $requestTokenParameters = [];
 
     /**
-    * @var array
-    */
+     * @var array
+     */
     protected $requestTokenHeaders = [];
 
     /**
-    * @var string
-    */
+     * @var string
+     */
     protected $tokenExchangeMethod = 'POST';
 
     /**
-    * @var array
-    */
+     * @var array
+     */
     protected $tokenExchangeParameters = [];
 
     /**
-    * @var array
-    */
+     * @var array
+     */
     protected $tokenExchangeHeaders = [];
 
     /**
-    * @var array
-    */
+     * @var array
+     */
     protected $apiRequestParameters = [];
 
     /**
-    * @var array
-    */
+     * @var array
+     */
     protected $apiRequestHeaders = [];
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function configure()
     {
-        $this->consumerKey    = $this->config->filter('keys')->get('id') ?: $this->config->filter('keys')->get('key');
+        $this->consumerKey = $this->config->filter('keys')->get('id') ?: $this->config->filter('keys')->get('key');
         $this->consumerSecret = $this->config->filter('keys')->get('secret');
 
-        if (! $this->consumerKey || !$this->consumerSecret) {
+        if (!$this->consumerKey || !$this->consumerSecret) {
             throw new InvalidApplicationCredentialsException(
                 'Your application id is required in order to connect to ' . $this->providerId
             );
@@ -165,23 +165,23 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         /**
-        * Set up OAuth Signature and Consumer
-        *
-        * OAuth Core: All Token requests and Protected Resources requests MUST be signed
-        * by the Consumer and verified by the Service Provider.
-        *
-        * The protocol defines three signature methods: HMAC-SHA1, RSA-SHA1, and PLAINTEXT..
-        *
-        * The Consumer declares a signature method in the oauth_signature_method parameter..
-        *
-        * http://oauth.net/core/1.0a/#signing_process
-        */
-        $this->sha1Method  = new OAuthSignatureMethodHMACSHA1();
+         * Set up OAuth Signature and Consumer
+         *
+         * OAuth Core: All Token requests and Protected Resources requests MUST be signed
+         * by the Consumer and verified by the Service Provider.
+         *
+         * The protocol defines three signature methods: HMAC-SHA1, RSA-SHA1, and PLAINTEXT..
+         *
+         * The Consumer declares a signature method in the oauth_signature_method parameter..
+         *
+         * http://oauth.net/core/1.0a/#signing_process
+         */
+        $this->sha1Method = new OAuthSignatureMethodHMACSHA1();
 
         $this->OAuthConsumer = new OAuthConsumer(
             $this->consumerKey,
@@ -204,8 +204,8 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function authenticate()
     {
         $this->logger->info(sprintf('%s::authenticate()', get_class($this)));
@@ -243,12 +243,12 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Initiate the authorization protocol
-    *
-    * 1. Obtaining an Unauthorized Request Token
-    * 2. Build Authorization URL for Authorization Request and redirect the user-agent to the
-    *    Authorization Server.
-    */
+     * Initiate the authorization protocol
+     *
+     * 1. Obtaining an Unauthorized Request Token
+     * 2. Build Authorization URL for Authorization Request and redirect the user-agent to the
+     *    Authorization Server.
+     */
     protected function authenticateBegin()
     {
         $response = $this->requestAuthToken();
@@ -278,9 +278,9 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
             [HttpClient\Util::getCurrentUrl(true)]
         );
 
-        $denied         = filter_input(INPUT_GET, 'denied');
-        $oauth_problem  = filter_input(INPUT_GET, 'oauth_problem');
-        $oauth_token    = filter_input(INPUT_GET, 'oauth_token');
+        $denied = filter_input(INPUT_GET, 'denied');
+        $oauth_problem = filter_input(INPUT_GET, 'oauth_problem');
+        $oauth_token = filter_input(INPUT_GET, 'oauth_token');
         $oauth_verifier = filter_input(INPUT_GET, 'oauth_verifier');
 
         if ($denied) {
@@ -295,7 +295,7 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
             );
         }
 
-        if (! $oauth_token) {
+        if (!$oauth_token) {
             throw new InvalidOauthTokenException(
                 'Expecting a non-null oauth_token to continue the authorization flow.'
             );
@@ -309,20 +309,20 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Build Authorization URL for Authorization Request
-    *
-    * @param array $parameters
-    *
-    * @return string
-    */
+     * Build Authorization URL for Authorization Request
+     *
+     * @param array $parameters
+     *
+     * @return string
+     */
     protected function getAuthorizeUrl($parameters = [])
     {
         $this->AuthorizeUrlParameters = !empty($parameters)
-                    ? $parameters
-                    : array_replace(
-                        (array) $this->AuthorizeUrlParameters,
-                        (array) $this->config->get('authorize_url_parameters')
-                    );
+            ? $parameters
+            : array_replace(
+                (array)$this->AuthorizeUrlParameters,
+                (array)$this->config->get('authorize_url_parameters')
+            );
 
         $this->AuthorizeUrlParameters['oauth_token'] = $this->getStoredData('request_token');
 
@@ -330,27 +330,27 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Unauthorized Request Token
-    *
-    * OAuth Core: The Consumer obtains an unauthorized Request Token by asking the Service Provider
-    * to issue a Token. The Request Token's sole purpose is to receive User approval and can only
-    * be used to obtain an Access Token.
-    *
-    * http://oauth.net/core/1.0/#auth_step1
-    * 6.1.1. Consumer Obtains a Request Token
-    *
-    * @return string Raw Provider API response
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    */
+     * Unauthorized Request Token
+     *
+     * OAuth Core: The Consumer obtains an unauthorized Request Token by asking the Service Provider
+     * to issue a Token. The Request Token's sole purpose is to receive User approval and can only
+     * be used to obtain an Access Token.
+     *
+     * http://oauth.net/core/1.0/#auth_step1
+     * 6.1.1. Consumer Obtains a Request Token
+     *
+     * @return string Raw Provider API response
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     */
     protected function requestAuthToken()
     {
         /**
-        * OAuth Core 1.0 Revision A: oauth_callback: An absolute URL to which the Service Provider will redirect
-        * the User back when the Obtaining User Authorization step is completed.
-        *
-        * http://oauth.net/core/1.0a/#auth_step1
-        */
+         * OAuth Core 1.0 Revision A: oauth_callback: An absolute URL to which the Service Provider will redirect
+         * the User back when the Obtaining User Authorization step is completed.
+         *
+         * http://oauth.net/core/1.0a/#auth_step1
+         */
         if ('1.0a' == $this->oauth1Version) {
             $this->requestTokenParameters['oauth_callback'] = $this->callback;
         }
@@ -366,49 +366,49 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Validate Unauthorized Request Token Response
-    *
-    * OAuth Core: The Service Provider verifies the signature and Consumer Key. If successful,
-    * it generates a Request Token and Token Secret and returns them to the Consumer in the HTTP
-    * response body.
-    *
-    * http://oauth.net/core/1.0/#auth_step1
-    * 6.1.2. Service Provider Issues an Unauthorized Request Token
-    *
-    * @param string $response
-    *
-    * @return \Hybridauth\Data\Collection
-    * @throws InvalidOauthTokenException
-    */
+     * Validate Unauthorized Request Token Response
+     *
+     * OAuth Core: The Service Provider verifies the signature and Consumer Key. If successful,
+     * it generates a Request Token and Token Secret and returns them to the Consumer in the HTTP
+     * response body.
+     *
+     * http://oauth.net/core/1.0/#auth_step1
+     * 6.1.2. Service Provider Issues an Unauthorized Request Token
+     *
+     * @param string $response
+     *
+     * @return \Hybridauth\Data\Collection
+     * @throws InvalidOauthTokenException
+     */
     protected function validateAuthTokenRequest($response)
     {
         /**
-        * The response contains the following parameters:
-        *
-        *    - oauth_token               The Request Token.
-        *    - oauth_token_secret        The Token Secret.
-        *    - oauth_callback_confirmed  MUST be present and set to true.
-        *
-        * http://oauth.net/core/1.0/#auth_step1
-        * 6.1.2. Service Provider Issues an Unauthorized Request Token
-        *
-        * Example of a successful response:
-        *
-        *  HTTP/1.1 200 OK
-        *  Content-Type: text/html; charset=utf-8
-        *  Cache-Control: no-store
-        *  Pragma: no-cache
-        *
-        *  oauth_token=80359084-clg1DEtxQF3wstTcyUdHF3wsdHM&oauth_token_secret=OIF07hPmJB:P
-        *  6qiHTi1znz6qiH3tTcyUdHnz6qiH3tTcyUdH3xW3wsDvV08e&example_parameter=example_value
-        *
-        * OAuthUtil::parse_parameters will attempt to decode the raw response into an array.
-        */
+         * The response contains the following parameters:
+         *
+         *    - oauth_token               The Request Token.
+         *    - oauth_token_secret        The Token Secret.
+         *    - oauth_callback_confirmed  MUST be present and set to true.
+         *
+         * http://oauth.net/core/1.0/#auth_step1
+         * 6.1.2. Service Provider Issues an Unauthorized Request Token
+         *
+         * Example of a successful response:
+         *
+         *  HTTP/1.1 200 OK
+         *  Content-Type: text/html; charset=utf-8
+         *  Cache-Control: no-store
+         *  Pragma: no-cache
+         *
+         *  oauth_token=80359084-clg1DEtxQF3wstTcyUdHF3wsdHM&oauth_token_secret=OIF07hPmJB:P
+         *  6qiHTi1znz6qiH3tTcyUdHnz6qiH3tTcyUdH3xW3wsDvV08e&example_parameter=example_value
+         *
+         * OAuthUtil::parse_parameters will attempt to decode the raw response into an array.
+         */
         $tokens = OAuthUtil::parse_parameters($response);
 
         $collection = new Data\Collection($tokens);
 
-        if (! $collection->exists('oauth_token')) {
+        if (!$collection->exists('oauth_token')) {
             throw new InvalidOauthTokenException(
                 'Provider returned no oauth_token: ' . htmlentities($response)
             );
@@ -426,30 +426,30 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Requests an Access Token
-    *
-    * OAuth Core: The Request Token and Token Secret MUST be exchanged for an Access Token and Token Secret.
-    *
-    * http://oauth.net/core/1.0a/#auth_step3
-    * 6.3.1. Consumer Requests an Access Token
-    *
-    * @param string $oauth_token
-    * @param string $oauth_verifier
-    *
-    * @return string Raw Provider API response
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    */
+     * Requests an Access Token
+     *
+     * OAuth Core: The Request Token and Token Secret MUST be exchanged for an Access Token and Token Secret.
+     *
+     * http://oauth.net/core/1.0a/#auth_step3
+     * 6.3.1. Consumer Requests an Access Token
+     *
+     * @param string $oauth_token
+     * @param string $oauth_verifier
+     *
+     * @return string Raw Provider API response
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     */
     protected function exchangeAuthTokenForAccessToken($oauth_token, $oauth_verifier = '')
     {
         $this->tokenExchangeParameters['oauth_token'] = $oauth_token;
 
         /**
-        * OAuth Core 1.0 Revision A: oauth_verifier: The verification code received from the Service Provider
-        * in the "Service Provider Directs the User Back to the Consumer" step.
-        *
-        * http://oauth.net/core/1.0a/#auth_step3
-        */
+         * OAuth Core 1.0 Revision A: oauth_verifier: The verification code received from the Service Provider
+         * in the "Service Provider Directs the User Back to the Consumer" step.
+         *
+         * http://oauth.net/core/1.0a/#auth_step3
+         */
         if ('1.0a' == $this->oauth1Version) {
             $this->tokenExchangeParameters['oauth_verifier'] = $oauth_verifier;
         }
@@ -465,48 +465,48 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Validate Access Token Response
-    *
-    * OAuth Core: If successful, the Service Provider generates an Access Token and Token Secret and returns
-    * them in the HTTP response body.
-    *
-    * The Access Token and Token Secret are stored by the Consumer and used when signing Protected Resources requests.
-    *
-    * http://oauth.net/core/1.0a/#auth_step3
-    * 6.3.2. Service Provider Grants an Access Token
-    *
-    * @param string $response
-    *
-    * @return \Hybridauth\Data\Collection
-    * @throws InvalidAccessTokenException
-    */
+     * Validate Access Token Response
+     *
+     * OAuth Core: If successful, the Service Provider generates an Access Token and Token Secret and returns
+     * them in the HTTP response body.
+     *
+     * The Access Token and Token Secret are stored by the Consumer and used when signing Protected Resources requests.
+     *
+     * http://oauth.net/core/1.0a/#auth_step3
+     * 6.3.2. Service Provider Grants an Access Token
+     *
+     * @param string $response
+     *
+     * @return \Hybridauth\Data\Collection
+     * @throws InvalidAccessTokenException
+     */
     protected function validateAccessTokenExchange($response)
     {
         /**
-        * The response contains the following parameters:
-        *
-        *    - oauth_token         The Access Token.
-        *    - oauth_token_secret  The Token Secret.
-        *
-        * http://oauth.net/core/1.0/#auth_step3
-        * 6.3.2. Service Provider Grants an Access Token
-        *
-        * Example of a successful response:
-        *
-        *  HTTP/1.1 200 OK
-        *  Content-Type: text/html; charset=utf-8
-        *  Cache-Control: no-store
-        *  Pragma: no-cache
-        *
-        *  oauth_token=sHeLU7Far428zj8PzlWR75&oauth_token_secret=fXb30rzoG&oauth_callback_confirmed=true
-        *
-        * OAuthUtil::parse_parameters will attempt to decode the raw response into an array.
-        */
+         * The response contains the following parameters:
+         *
+         *    - oauth_token         The Access Token.
+         *    - oauth_token_secret  The Token Secret.
+         *
+         * http://oauth.net/core/1.0/#auth_step3
+         * 6.3.2. Service Provider Grants an Access Token
+         *
+         * Example of a successful response:
+         *
+         *  HTTP/1.1 200 OK
+         *  Content-Type: text/html; charset=utf-8
+         *  Cache-Control: no-store
+         *  Pragma: no-cache
+         *
+         *  oauth_token=sHeLU7Far428zj8PzlWR75&oauth_token_secret=fXb30rzoG&oauth_callback_confirmed=true
+         *
+         * OAuthUtil::parse_parameters will attempt to decode the raw response into an array.
+         */
         $tokens = OAuthUtil::parse_parameters($response);
 
         $collection = new Data\Collection($tokens);
 
-        if (! $collection->exists('oauth_token')) {
+        if (!$collection->exists('oauth_token')) {
             throw new InvalidAccessTokenException(
                 'Provider returned no access_token: ' . htmlentities($response)
             );
@@ -527,21 +527,21 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Send a signed request to provider API
-    *
-    * Note: Since the specifics of error responses is beyond the scope of RFC6749 and OAuth specifications,
-    * Hybridauth will consider any HTTP status code that is different than '200 OK' as an ERROR.
-    *
-    * @param string $url
-    * @param string $method
-    * @param array $parameters
-    * @param array $headers
-    * @param bool $multipart
-    *
-    * @return mixed
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    */
+     * Send a signed request to provider API
+     *
+     * Note: Since the specifics of error responses is beyond the scope of RFC6749 and OAuth specifications,
+     * Hybridauth will consider any HTTP status code that is different than '200 OK' as an ERROR.
+     *
+     * @param string $url
+     * @param string $method
+     * @param array $parameters
+     * @param array $headers
+     * @param bool $multipart
+     *
+     * @return mixed
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     */
     public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         if (strrpos($url, 'http://') !== 0 && strrpos($url, 'https://') !== 0) {
@@ -560,20 +560,20 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Setup and Send a Signed Oauth Request
-    *
-    * This method uses OAuth Library.
-    *
-    * @param string $uri
-    * @param string $method
-    * @param array $parameters
-    * @param array $headers
-    * @param bool $multipart
-    *
-    * @return string Raw Provider API response
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    */
+     * Setup and Send a Signed Oauth Request
+     *
+     * This method uses OAuth Library.
+     *
+     * @param string $uri
+     * @param string $method
+     * @param array $parameters
+     * @param array $headers
+     * @param bool $multipart
+     *
+     * @return string Raw Provider API response
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     */
     protected function oauthRequest($uri, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         $signing_parameters = $parameters;
@@ -595,8 +595,8 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
             $this->consumerToken
         );
 
-        $uri        = $request->get_normalized_http_url();
-        $headers    = array_replace($request->to_header(), (array) $headers);
+        $uri = $request->get_normalized_http_url();
+        $headers = array_replace($request->to_header(), (array)$headers);
 
         $response = $this->httpClient->request(
             $uri,

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -25,110 +25,110 @@ use Hybridauth\HttpClient;
 abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
 {
     /**
-    * Client Identifier
-    *
-    * RFC6749: client_id REQUIRED. The client identifier issued to the client during
-    * the registration process described by Section 2.2.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-2.2
-    *
-    * @var string
-    */
-    protected $clientId = '' ;
+     * Client Identifier
+     *
+     * RFC6749: client_id REQUIRED. The client identifier issued to the client during
+     * the registration process described by Section 2.2.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-2.2
+     *
+     * @var string
+     */
+    protected $clientId = '';
 
     /**
-    * Client Secret
-    *
-    * RFC6749: client_secret REQUIRED. The client secret. The client MAY omit the
-    * parameter if the client secret is an empty string.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-2.2
-    *
-    * @var string
-    */
-    protected $clientSecret = '' ;
+     * Client Secret
+     *
+     * RFC6749: client_secret REQUIRED. The client secret. The client MAY omit the
+     * parameter if the client secret is an empty string.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-2.2
+     *
+     * @var string
+     */
+    protected $clientSecret = '';
 
     /**
-    * Access Token Scope
-    *
-    * RFC6749: The authorization and token endpoints allow the client to specify the
-    * scope of the access request using the "scope" request parameter.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-3.3
-    *
-    * @var string
-    */
+     * Access Token Scope
+     *
+     * RFC6749: The authorization and token endpoints allow the client to specify the
+     * scope of the access request using the "scope" request parameter.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-3.3
+     *
+     * @var string
+     */
     protected $scope = '';
 
     /**
-    * Base URL to provider API
-    *
-    * This var will be used to build urls when sending signed requests
-    *
-    * @var string
-    */
+     * Base URL to provider API
+     *
+     * This var will be used to build urls when sending signed requests
+     *
+     * @var string
+     */
     protected $apiBaseUrl = '';
 
     /**
-    * Authorization Endpoint
-    *
-    * RFC6749: The authorization endpoint is used to interact with the resource
-    * owner and obtain an authorization grant.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-3.1
-    *
-    * @var string
-    */
+     * Authorization Endpoint
+     *
+     * RFC6749: The authorization endpoint is used to interact with the resource
+     * owner and obtain an authorization grant.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-3.1
+     *
+     * @var string
+     */
     protected $authorizeUrl = '';
 
     /**
-    * Access Token Endpoint
-    *
-    * RFC6749: The token endpoint is used by the client to obtain an access token by
-    * presenting its authorization grant or refresh token.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-3.2
-    *
-    * @var string
-    */
+     * Access Token Endpoint
+     *
+     * RFC6749: The token endpoint is used by the client to obtain an access token by
+     * presenting its authorization grant or refresh token.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-3.2
+     *
+     * @var string
+     */
     protected $accessTokenUrl = '';
 
     /**
-    * TokenInfo endpoint
-    *
-    * Access token validation. OPTIONAL.
-    *
-    * @var string
-    */
+     * TokenInfo endpoint
+     *
+     * Access token validation. OPTIONAL.
+     *
+     * @var string
+     */
     protected $accessTokenInfoUrl = '';
 
     /**
-    * IPD API Documentation
-    *
-    * OPTIONAL.
-    *
-    * @var string
-    */
+     * IPD API Documentation
+     *
+     * OPTIONAL.
+     *
+     * @var string
+     */
     protected $apiDocumentation = '';
 
     /**
-    * Redirection Endpoint or Callback
-    *
-    * RFC6749: After completing its interaction with the resource owner, the
-    * authorization server directs the resource owner's user-agent back to
-    * the client.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-3.1.2
-    *
-    * @var string
-    */
+     * Redirection Endpoint or Callback
+     *
+     * RFC6749: After completing its interaction with the resource owner, the
+     * authorization server directs the resource owner's user-agent back to
+     * the client.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-3.1.2
+     *
+     * @var string
+     */
     protected $callback = '';
 
     /**
-    * Authorization Url Parameters
-    *
-    * @var array
-    */
+     * Authorization Url Parameters
+     *
+     * @var array
+     */
     protected $AuthorizeUrlParameters = [];
 
 
@@ -141,115 +141,115 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     protected $AuthorizeUrlParametersEncType = PHP_QUERY_RFC1738;
 
     /**
-    * Authorization Request State
-    *
-    * @var boolean
-    */
+     * Authorization Request State
+     *
+     * @var bool
+     */
     protected $supportRequestState = true;
 
     /**
-    * Access Token name
-    *
-    * While most providers will use 'access_token' as name for the Access Token attribute, other do not.
-    * On the latter case, this should be set by sub classes.
-    *
-    * @var string
-    */
+     * Access Token name
+     *
+     * While most providers will use 'access_token' as name for the Access Token attribute, other do not.
+     * On the latter case, this should be set by sub classes.
+     *
+     * @var string
+     */
     protected $accessTokenName = 'access_token';
 
     /**
-    * Authorization Request HTTP method.
-    *
-    * @see exchangeCodeForAccessToken()
-    *
-    * @var string
-    */
+     * Authorization Request HTTP method.
+     *
+     * @see exchangeCodeForAccessToken()
+     *
+     * @var string
+     */
     protected $tokenExchangeMethod = 'POST';
 
     /**
-    * Authorization Request URL parameters.
-    *
-    * Sub classes may change add any additional parameter when necessary.
-    *
-    * @see exchangeCodeForAccessToken()
-    *
-    * @var array
-    */
+     * Authorization Request URL parameters.
+     *
+     * Sub classes may change add any additional parameter when necessary.
+     *
+     * @see exchangeCodeForAccessToken()
+     *
+     * @var array
+     */
     protected $tokenExchangeParameters = [];
 
     /**
-    * Authorization Request HTTP headers.
-    *
-    * Sub classes may add any additional header when necessary.
-    *
-    * @see exchangeCodeForAccessToken()
-    *
-    * @var array
-    */
+     * Authorization Request HTTP headers.
+     *
+     * Sub classes may add any additional header when necessary.
+     *
+     * @see exchangeCodeForAccessToken()
+     *
+     * @var array
+     */
     protected $tokenExchangeHeaders = [];
 
     /**
-    * Refresh Token Request HTTP method.
-    *
-    * @see refreshAccessToken()
-    *
-    * @var string
-    */
+     * Refresh Token Request HTTP method.
+     *
+     * @see refreshAccessToken()
+     *
+     * @var string
+     */
     protected $tokenRefreshMethod = 'POST';
 
     /**
-    * Refresh Token Request URL parameters.
-    *
-    * Sub classes may change add any additional parameter when necessary.
-    *
-    * @see refreshAccessToken()
-    *
-    * @var array|null
-    */
+     * Refresh Token Request URL parameters.
+     *
+     * Sub classes may change add any additional parameter when necessary.
+     *
+     * @see refreshAccessToken()
+     *
+     * @var array|null
+     */
     protected $tokenRefreshParameters = null;
 
     /**
-    * Refresh Token Request HTTP headers.
-    *
-    * Sub classes may add any additional header when necessary.
-    *
-    * @see refreshAccessToken()
-    *
-    * @var array
-    */
+     * Refresh Token Request HTTP headers.
+     *
+     * Sub classes may add any additional header when necessary.
+     *
+     * @see refreshAccessToken()
+     *
+     * @var array
+     */
     protected $tokenRefreshHeaders = [];
 
     /**
-    * Authorization Request URL parameters.
-    *
-    * Sub classes may change add any additional parameter when necessary.
-    *
-    * @see apiRequest()
-    *
-    * @var array
-    */
+     * Authorization Request URL parameters.
+     *
+     * Sub classes may change add any additional parameter when necessary.
+     *
+     * @see apiRequest()
+     *
+     * @var array
+     */
     protected $apiRequestParameters = [];
 
     /**
-    * Authorization Request HTTP headers.
-    *
-    * Sub classes may add any additional header when necessary.
-    *
-    * @see apiRequest()
-    *
-    * @var array
-    */
+     * Authorization Request HTTP headers.
+     *
+     * Sub classes may add any additional header when necessary.
+     *
+     * @see apiRequest()
+     *
+     * @var array
+     */
     protected $apiRequestHeaders = [];
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function configure()
     {
-        $this->clientId     = $this->config->filter('keys')->get('id') ?: $this->config->filter('keys')->get('key');
+        $this->clientId = $this->config->filter('keys')->get('id') ?: $this->config->filter('keys')->get('key');
         $this->clientSecret = $this->config->filter('keys')->get('secret');
 
-        if (! $this->clientId || !$this->clientSecret) {
+        if (!$this->clientId || !$this->clientSecret) {
             throw new InvalidApplicationCredentialsException(
                 'Your application id is required in order to connect to ' . $this->providerId
             );
@@ -266,28 +266,28 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         $this->AuthorizeUrlParameters = [
             'response_type' => 'code',
-            'client_id'     => $this->clientId,
-            'redirect_uri'  => $this->callback,
-            'scope'         => $this->scope,
+            'client_id' => $this->clientId,
+            'redirect_uri' => $this->callback,
+            'scope' => $this->scope,
         ];
 
         $this->tokenExchangeParameters = [
-            'client_id'     => $this->clientId,
+            'client_id' => $this->clientId,
             'client_secret' => $this->clientSecret,
-            'grant_type'    => 'authorization_code',
-            'redirect_uri'  => $this->callback
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => $this->callback
         ];
 
         $refreshToken = $this->getStoredData('refresh_token');
         if (!empty($refreshToken)) {
             $this->tokenRefreshParameters = [
-                'grant_type'    => 'refresh_token',
+                'grant_type' => 'refresh_token',
                 'refresh_token' => $refreshToken,
             ];
         }
@@ -298,8 +298,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function authenticate()
     {
         $this->logger->info(sprintf('%s::authenticate()', get_class($this)));
@@ -349,22 +349,22 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Authorization Request Error Response
-    *
-    * RFC6749: If the request fails due to a missing, invalid, or mismatching
-    * redirection URI, or if the client identifier is missing or invalid,
-    * the authorization server SHOULD inform the resource owner of the error.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-4.1.2.1
-    *
-    * @throws \Hybridauth\Exception\InvalidAuthorizationCodeException
-    * @throws \Hybridauth\Exception\AuthorizationDeniedException
-    */
+     * Authorization Request Error Response
+     *
+     * RFC6749: If the request fails due to a missing, invalid, or mismatching
+     * redirection URI, or if the client identifier is missing or invalid,
+     * the authorization server SHOULD inform the resource owner of the error.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-4.1.2.1
+     *
+     * @throws \Hybridauth\Exception\InvalidAuthorizationCodeException
+     * @throws \Hybridauth\Exception\AuthorizationDeniedException
+     */
     protected function authenticateCheckError()
     {
         $error = filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
 
-        if (! empty($error)) {
+        if (!empty($error)) {
             $error_description = filter_input(INPUT_GET, 'error_description', FILTER_SANITIZE_SPECIAL_CHARS);
             $error_uri = filter_input(INPUT_GET, 'error_uri', FILTER_SANITIZE_SPECIAL_CHARS);
 
@@ -379,11 +379,11 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Initiate the authorization protocol
-    *
-    * Build Authorization URL for Authorization Request and redirect the user-agent to the
-    * Authorization Server.
-    */
+     * Initiate the authorization protocol
+     *
+     * Build Authorization URL for Authorization Request and redirect the user-agent to the
+     * Authorization Server.
+     */
     protected function authenticateBegin()
     {
         $authUrl = $this->getAuthorizeUrl();
@@ -394,13 +394,13 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Finalize the authorization process
-    *
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    * @throws InvalidAccessTokenException
-    * @throws InvalidAuthorizationStateException
-    */
+     * Finalize the authorization process
+     *
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws InvalidAccessTokenException
+     * @throws InvalidAuthorizationStateException
+     */
     protected function authenticateFinish()
     {
         $this->logger->debug(
@@ -412,31 +412,31 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         $code = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
 
         /**
-        * Authorization Request State
-        *
-        * RFC6749: state : RECOMMENDED. An opaque value used by the client to maintain
-        * state between the request and callback. The authorization server includes
-        * this value when redirecting the user-agent back to the client.
-        *
-        * http://tools.ietf.org/html/rfc6749#section-4.1.1
-        */
+         * Authorization Request State
+         *
+         * RFC6749: state : RECOMMENDED. An opaque value used by the client to maintain
+         * state between the request and callback. The authorization server includes
+         * this value when redirecting the user-agent back to the client.
+         *
+         * http://tools.ietf.org/html/rfc6749#section-4.1.1
+         */
         if ($this->supportRequestState
-            &&  $this->getStoredData('authorization_state') != $state
+            && $this->getStoredData('authorization_state') != $state
         ) {
             throw new InvalidAuthorizationStateException(
-                'The authorization state [state=' . substr(htmlentities($state), 0, 100). '] '
-                    . 'of this page is either invalid or has already been consumed.'
+                'The authorization state [state=' . substr(htmlentities($state), 0, 100) . '] '
+                . 'of this page is either invalid or has already been consumed.'
             );
         }
 
         /**
-        * Authorization Request Code
-        *
-        * RFC6749: If the resource owner grants the access request, the authorization
-        * server issues an authorization code and delivers it to the client:
-        *
-        * http://tools.ietf.org/html/rfc6749#section-4.1.2
-        */
+         * Authorization Request Code
+         *
+         * RFC6749: If the resource owner grants the access request, the authorization
+         * server issues an authorization code and delivers it to the client:
+         *
+         * http://tools.ietf.org/html/rfc6749#section-4.1.2
+         */
         $response = $this->exchangeCodeForAccessToken($code);
 
         $this->validateAccessTokenExchange($response);
@@ -445,32 +445,32 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Build Authorization URL for Authorization Request
-    *
-    * RFC6749: The client constructs the request URI by adding the following
-    * $parameters to the query component of the authorization endpoint URI:
-    *
-    *    - response_type  REQUIRED. Value MUST be set to "code".
-    *    - client_id      REQUIRED.
-    *    - redirect_uri   OPTIONAL.
-    *    - scope          OPTIONAL.
-    *    - state          RECOMMENDED.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-4.1.1
-    *
-    * Sub classes may redefine this method when necessary.
-    *
-    * @param array $parameters
-    *
-    * @return string Authorization URL
-    */
+     * Build Authorization URL for Authorization Request
+     *
+     * RFC6749: The client constructs the request URI by adding the following
+     * $parameters to the query component of the authorization endpoint URI:
+     *
+     *    - response_type  REQUIRED. Value MUST be set to "code".
+     *    - client_id      REQUIRED.
+     *    - redirect_uri   OPTIONAL.
+     *    - scope          OPTIONAL.
+     *    - state          RECOMMENDED.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-4.1.1
+     *
+     * Sub classes may redefine this method when necessary.
+     *
+     * @param array $parameters
+     *
+     * @return string Authorization URL
+     */
     protected function getAuthorizeUrl($parameters = [])
     {
         $this->AuthorizeUrlParameters = !empty($parameters)
             ? $parameters
             : array_replace(
-                (array) $this->AuthorizeUrlParameters,
-                (array) $this->config->get('authorize_url_parameters')
+                (array)$this->AuthorizeUrlParameters,
+                (array)$this->config->get('authorize_url_parameters')
             );
 
         if ($this->supportRequestState) {
@@ -486,27 +486,27 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Access Token Request
-    *
-    * This method will exchange the received $code in loginFinish() with an Access Token.
-    *
-    * RFC6749: The client makes a request to the token endpoint by sending the
-    * following parameters using the "application/x-www-form-urlencoded"
-    * with a character encoding of UTF-8 in the HTTP request entity-body:
-    *
-    *    - grant_type    REQUIRED. Value MUST be set to "authorization_code".
-    *    - code          REQUIRED. The authorization code received from the authorization server.
-    *    - redirect_uri  REQUIRED.
-    *    - client_id     REQUIRED.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-4.1.3
-    *
-    * @param string $code
-    *
-    * @return string Raw Provider API response
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    */
+     * Access Token Request
+     *
+     * This method will exchange the received $code in loginFinish() with an Access Token.
+     *
+     * RFC6749: The client makes a request to the token endpoint by sending the
+     * following parameters using the "application/x-www-form-urlencoded"
+     * with a character encoding of UTF-8 in the HTTP request entity-body:
+     *
+     *    - grant_type    REQUIRED. Value MUST be set to "authorization_code".
+     *    - code          REQUIRED. The authorization code received from the authorization server.
+     *    - redirect_uri  REQUIRED.
+     *    - client_id     REQUIRED.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-4.1.3
+     *
+     * @param string $code
+     *
+     * @return string Raw Provider API response
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     */
     protected function exchangeCodeForAccessToken($code)
     {
         $this->tokenExchangeParameters['code'] = $code;
@@ -524,45 +524,45 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Validate Access Token Response
-    *
-    * RFC6749: If the access token request is valid and authorized, the
-    * authorization server issues an access token and optional refresh token.
-    * If the request client authentication failed or is invalid, the authorization
-    * server returns an error response as described in Section 5.2.
-    *
-    * Example of a successful response:
-    *
-    *  HTTP/1.1 200 OK
-    *  Content-Type: application/json;charset=UTF-8
-    *  Cache-Control: no-store
-    *  Pragma: no-cache
-    *
-    *  {
-    *      "access_token":"2YotnFZFEjr1zCsicMWpAA",
-    *      "token_type":"example",
-    *      "expires_in":3600,
-    *      "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
-    *      "example_parameter":"example_value"
-    *  }
-    *
-    * http://tools.ietf.org/html/rfc6749#section-4.1.4
-    *
-    * This method uses Data_Parser to attempt to decodes the raw $response (usually JSON)
-    * into a data collection.
-    *
-    * @param string $response
-    *
-    * @return \Hybridauth\Data\Collection
-    * @throws InvalidAccessTokenException
-    */
+     * Validate Access Token Response
+     *
+     * RFC6749: If the access token request is valid and authorized, the
+     * authorization server issues an access token and optional refresh token.
+     * If the request client authentication failed or is invalid, the authorization
+     * server returns an error response as described in Section 5.2.
+     *
+     * Example of a successful response:
+     *
+     *  HTTP/1.1 200 OK
+     *  Content-Type: application/json;charset=UTF-8
+     *  Cache-Control: no-store
+     *  Pragma: no-cache
+     *
+     *  {
+     *      "access_token":"2YotnFZFEjr1zCsicMWpAA",
+     *      "token_type":"example",
+     *      "expires_in":3600,
+     *      "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
+     *      "example_parameter":"example_value"
+     *  }
+     *
+     * http://tools.ietf.org/html/rfc6749#section-4.1.4
+     *
+     * This method uses Data_Parser to attempt to decodes the raw $response (usually JSON)
+     * into a data collection.
+     *
+     * @param string $response
+     *
+     * @return \Hybridauth\Data\Collection
+     * @throws InvalidAccessTokenException
+     */
     protected function validateAccessTokenExchange($response)
     {
         $data = (new Data\Parser())->parse($response);
 
         $collection = new Data\Collection($data);
 
-        if (! $collection->exists('access_token')) {
+        if (!$collection->exists('access_token')) {
             throw new InvalidAccessTokenException(
                 'Provider returned no access_token: ' . htmlentities($response)
             );
@@ -577,7 +577,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
 
         // calculate when the access token expire
         if ($collection->exists('expires_in')) {
-            $expires_at = time() + (int) $collection->get('expires_in');
+            $expires_at = time() + (int)$collection->get('expires_in');
 
             $this->storeData('expires_in', $collection->get('expires_in'));
             $this->storeData('expires_at', $expires_at);
@@ -591,28 +591,28 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Refreshing an Access Token
-    *
-    * RFC6749: If the authorization server issued a refresh token to the
-    * client, the client makes a refresh request to the token endpoint by
-    * adding the following parameters ... in the HTTP request entity-body:
-    *
-    *    - grant_type     REQUIRED. Value MUST be set to "refresh_token".
-    *    - refresh_token  REQUIRED. The refresh token issued to the client.
-    *    - scope          OPTIONAL.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-6
-    *
-    * This method is similar to exchangeCodeForAccessToken(). The only
-    * difference is here we exchange refresh_token for a new access_token.
-    *
-    * @param array $parameters
-    *
-    * @return string|null Raw Provider API response, or null if we cannot refresh
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    * @throws InvalidAccessTokenException
-    */
+     * Refreshing an Access Token
+     *
+     * RFC6749: If the authorization server issued a refresh token to the
+     * client, the client makes a refresh request to the token endpoint by
+     * adding the following parameters ... in the HTTP request entity-body:
+     *
+     *    - grant_type     REQUIRED. Value MUST be set to "refresh_token".
+     *    - refresh_token  REQUIRED. The refresh token issued to the client.
+     *    - scope          OPTIONAL.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-6
+     *
+     * This method is similar to exchangeCodeForAccessToken(). The only
+     * difference is here we exchange refresh_token for a new access_token.
+     *
+     * @param array $parameters
+     *
+     * @return string|null Raw Provider API response, or null if we cannot refresh
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws InvalidAccessTokenException
+     */
     public function refreshAccessToken($parameters = [])
     {
         $this->tokenRefreshParameters = !empty($parameters)
@@ -638,11 +638,11 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Check whether access token has expired
-    *
-    * @param int|null $time
-    * @return bool|null
-    */
+     * Check whether access token has expired
+     *
+     * @param int|null $time
+     * @return bool|null
+     */
     public function hasAccessTokenExpired($time = null)
     {
         if ($time === null) {
@@ -658,55 +658,55 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Validate Refresh Access Token Request
-    *
-    * RFC6749: If valid and authorized, the authorization server issues an
-    * access token as described in Section 5.1.  If the request failed
-    * verification or is invalid, the authorization server returns an error
-    * response as described in Section 5.2.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-6
-    * http://tools.ietf.org/html/rfc6749#section-5.1
-    * http://tools.ietf.org/html/rfc6749#section-5.2
-    *
-    * This method simply use validateAccessTokenExchange(), however sub
-    * classes may redefine it when necessary.
-    *
-    * @param $response
-    *
-    * @return \Hybridauth\Data\Collection
-    * @throws InvalidAccessTokenException
-    */
+     * Validate Refresh Access Token Request
+     *
+     * RFC6749: If valid and authorized, the authorization server issues an
+     * access token as described in Section 5.1.  If the request failed
+     * verification or is invalid, the authorization server returns an error
+     * response as described in Section 5.2.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-6
+     * http://tools.ietf.org/html/rfc6749#section-5.1
+     * http://tools.ietf.org/html/rfc6749#section-5.2
+     *
+     * This method simply use validateAccessTokenExchange(), however sub
+     * classes may redefine it when necessary.
+     *
+     * @param $response
+     *
+     * @return \Hybridauth\Data\Collection
+     * @throws InvalidAccessTokenException
+     */
     protected function validateRefreshAccessToken($response)
     {
         return $this->validateAccessTokenExchange($response);
     }
 
     /**
-    * Send a signed request to provider API
-    *
-    * RFC6749: Accessing Protected Resources: The client accesses protected
-    * resources by presenting the access token to the resource server. The
-    * resource server MUST validate the access token and ensure that it has
-    * not expired and that its scope covers the requested resource.
-    *
-    * Note: Since the specifics of error responses is beyond the scope of
-    * RFC6749 and OAuth specifications, Hybridauth will consider any HTTP
-    * status code that is different than '200 OK' as an ERROR.
-    *
-    * http://tools.ietf.org/html/rfc6749#section-7
-    *
-    * @param string $url
-    * @param string $method
-    * @param array $parameters
-    * @param array $headers
-    * @param bool $multipart
-    *
-    * @return mixed
-    * @throws \Hybridauth\Exception\HttpClientFailureException
-    * @throws \Hybridauth\Exception\HttpRequestFailedException
-    * @throws InvalidAccessTokenException
-    */
+     * Send a signed request to provider API
+     *
+     * RFC6749: Accessing Protected Resources: The client accesses protected
+     * resources by presenting the access token to the resource server. The
+     * resource server MUST validate the access token and ensure that it has
+     * not expired and that its scope covers the requested resource.
+     *
+     * Note: Since the specifics of error responses is beyond the scope of
+     * RFC6749 and OAuth specifications, Hybridauth will consider any HTTP
+     * status code that is different than '200 OK' as an ERROR.
+     *
+     * http://tools.ietf.org/html/rfc6749#section-7
+     *
+     * @param string $url
+     * @param string $method
+     * @param array $parameters
+     * @param array $headers
+     * @param bool $multipart
+     *
+     * @return mixed
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws InvalidAccessTokenException
+     */
     public function apiRequest($url, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
         // refresh tokens if needed
@@ -718,8 +718,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             $url = rtrim($this->apiBaseUrl, '/') . '/' . ltrim($url, '/');
         }
 
-        $parameters = array_replace($this->apiRequestParameters, (array) $parameters);
-        $headers = array_replace($this->apiRequestHeaders, (array) $headers);
+        $parameters = array_replace($this->apiRequestParameters, (array)$parameters);
+        $headers = array_replace($this->apiRequestHeaders, (array)$headers);
 
         $response = $this->httpClient->request(
             $url,

--- a/src/Adapter/OpenID.php
+++ b/src/Adapter/OpenID.php
@@ -25,22 +25,22 @@ use Hybridauth\Thirdparty\OpenID\LightOpenID;
 abstract class OpenID extends AbstractAdapter implements AdapterInterface
 {
     /**
-    * LightOpenID instance
-    *
-    * @var object
-    */
+     * LightOpenID instance
+     *
+     * @var object
+     */
     protected $openIdClient = null;
 
     /**
-    * Openid provider identifier
-    *
-    * @var string
-    */
+     * Openid provider identifier
+     *
+     * @var string
+     */
     protected $openidIdentifier = '';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function configure()
     {
         if ($this->config->exists('openid_identifier')) {
@@ -56,12 +56,12 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         $hostPort = parse_url($this->callback, PHP_URL_PORT);
-        $hostUrl  = parse_url($this->callback, PHP_URL_HOST);
+        $hostUrl = parse_url($this->callback, PHP_URL_HOST);
 
         if ($hostPort) {
             $hostUrl .= ':' . $hostPort;
@@ -72,8 +72,8 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function authenticate()
     {
         $this->logger->info(sprintf('%s::authenticate()', get_class($this)));
@@ -92,16 +92,16 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function isConnected()
     {
-        return (bool) $this->storage->get($this->providerId . '.user');
+        return (bool)$this->storage->get($this->providerId . '.user');
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function disconnect()
     {
         $this->storage->delete($this->providerId . '.user');
@@ -110,31 +110,31 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Initiate the authorization protocol
-    *
-    * Include and instantiate LightOpenID
-    */
+     * Initiate the authorization protocol
+     *
+     * Include and instantiate LightOpenID
+     */
     protected function authenticateBegin()
     {
-        $this->openIdClient->identity  = $this->openidIdentifier;
+        $this->openIdClient->identity = $this->openidIdentifier;
         $this->openIdClient->returnUrl = $this->callback;
-        $this->openIdClient->required  = [
-            'namePerson/first'       ,
-            'namePerson/last'        ,
-            'namePerson/friendly'    ,
-            'namePerson'             ,
-            'contact/email'          ,
-            'birthDate'              ,
-            'birthDate/birthDay'     ,
-            'birthDate/birthMonth'   ,
-            'birthDate/birthYear'    ,
-            'person/gender'          ,
-            'pref/language'          ,
+        $this->openIdClient->required = [
+            'namePerson/first',
+            'namePerson/last',
+            'namePerson/friendly',
+            'namePerson',
+            'contact/email',
+            'birthDate',
+            'birthDate/birthDay',
+            'birthDate/birthMonth',
+            'birthDate/birthYear',
+            'person/gender',
+            'pref/language',
             'contact/postalCode/home',
-            'contact/city/home'      ,
-            'contact/country/home'   ,
+            'contact/city/home',
+            'contact/country/home',
 
-            'media/image/default'    ,
+            'media/image/default',
         ];
 
         $authUrl = $this->openIdClient->authUrl();
@@ -145,11 +145,11 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Finalize the authorization process.
-    *
-    * @throws AuthorizationDeniedException
-    * @throws UnexpectedApiResponseException
-    */
+     * Finalize the authorization process.
+     *
+     * @throws AuthorizationDeniedException
+     * @throws UnexpectedApiResponseException
+     */
     protected function authenticateFinish()
     {
         $this->logger->debug(
@@ -161,13 +161,13 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
             throw new AuthorizationDeniedException('User has cancelled the authentication.');
         }
 
-        if (! $this->openIdClient->validate()) {
+        if (!$this->openIdClient->validate()) {
             throw new UnexpectedApiResponseException('Invalid response received.');
         }
 
         $openidAttributes = $this->openIdClient->getAttributes();
 
-        if (! $this->openIdClient->identity) {
+        if (!$this->openIdClient->identity) {
             throw new UnexpectedApiResponseException('Provider returned an unexpected response.');
         }
 
@@ -178,31 +178,31 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Fetch user profile from received openid attributes
-    *
-    * @param array $openidAttributes
-    *
-    * @return User\Profile
-    */
+     * Fetch user profile from received openid attributes
+     *
+     * @param array $openidAttributes
+     *
+     * @return User\Profile
+     */
     protected function fetchUserProfile($openidAttributes)
     {
         $data = new Data\Collection($openidAttributes);
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $this->openIdClient->identity;
+        $userProfile->identifier = $this->openIdClient->identity;
 
-        $userProfile->firstName   = $data->get('namePerson/first');
-        $userProfile->lastName    = $data->get('namePerson/last');
-        $userProfile->email       = $data->get('contact/email');
-        $userProfile->language    = $data->get('pref/language');
-        $userProfile->country     = $data->get('contact/country/home');
-        $userProfile->zip         = $data->get('contact/postalCode/home');
-        $userProfile->gender      = $data->get('person/gender');
-        $userProfile->photoURL    = $data->get('media/image/default');
-        $userProfile->birthDay    = $data->get('birthDate/birthDay');
-        $userProfile->birthMonth  = $data->get('birthDate/birthMonth');
-        $userProfile->birthYear   = $data->get('birthDate/birthDate');
+        $userProfile->firstName = $data->get('namePerson/first');
+        $userProfile->lastName = $data->get('namePerson/last');
+        $userProfile->email = $data->get('contact/email');
+        $userProfile->language = $data->get('pref/language');
+        $userProfile->country = $data->get('contact/country/home');
+        $userProfile->zip = $data->get('contact/postalCode/home');
+        $userProfile->gender = $data->get('person/gender');
+        $userProfile->photoURL = $data->get('media/image/default');
+        $userProfile->birthDay = $data->get('birthDate/birthDay');
+        $userProfile->birthMonth = $data->get('birthDate/birthMonth');
+        $userProfile->birthYear = $data->get('birthDate/birthDate');
 
         $userProfile = $this->fetchUserGender($userProfile, $data->get('person/gender'));
 
@@ -212,36 +212,36 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * Extract users display names
-    *
-    * @param User\Profile $userProfile
-    * @param Data\Collection $data
-    *
-    * @return User\Profile
-    */
+     * Extract users display names
+     *
+     * @param User\Profile $userProfile
+     * @param Data\Collection $data
+     *
+     * @return User\Profile
+     */
     protected function fetchUserDisplayName(User\Profile $userProfile, Data\Collection $data)
     {
         $userProfile->displayName = $data->get('namePerson');
 
         $userProfile->displayName = $userProfile->displayName
-                                        ? $userProfile->displayName
-                                        : $data->get('namePerson/friendly');
+            ? $userProfile->displayName
+            : $data->get('namePerson/friendly');
 
         $userProfile->displayName = $userProfile->displayName
-                                        ? $userProfile->displayName
-                                        : trim($userProfile->firstName . ' ' . $userProfile->lastName);
+            ? $userProfile->displayName
+            : trim($userProfile->firstName . ' ' . $userProfile->lastName);
 
         return $userProfile;
     }
 
     /**
-    * Extract users gender
-    *
-    * @param User\Profile $userProfile
-    * @param string $gender
-    *
-    * @return User\Profile
-    */
+     * Extract users gender
+     *
+     * @param User\Profile $userProfile
+     * @param string $gender
+     *
+     * @return User\Profile
+     */
     protected function fetchUserGender(User\Profile $userProfile, $gender)
     {
         $gender = strtolower($gender);
@@ -260,13 +260,13 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
     }
 
     /**
-    * OpenID only provide the user profile one. This method will attempt to retrieve the profile from storage.
-    */
+     * OpenID only provide the user profile one. This method will attempt to retrieve the profile from storage.
+     */
     public function getUserProfile()
     {
         $userProfile = $this->storage->get($this->providerId . '.user');
 
-        if (! is_object($userProfile)) {
+        if (!is_object($userProfile)) {
             throw new UnexpectedApiResponseException('Provider returned an unexpected response.');
         }
 

--- a/src/Data/Collection.php
+++ b/src/Data/Collection.php
@@ -13,15 +13,15 @@ namespace Hybridauth\Data;
 final class Collection
 {
     /**
-    * Data collection
-    *
-    * @var mixed
-    */
+     * Data collection
+     *
+     * @var mixed
+     */
     protected $collection = null;
 
     /**
-    * @param mixed $data
-    */
+     * @param mixed $data
+     */
     public function __construct($data = null)
     {
         $this->collection = new \stdClass();
@@ -30,26 +30,26 @@ final class Collection
             $this->collection = $data;
         }
 
-        $this->collection = (object) $data;
+        $this->collection = (object)$data;
     }
 
     /**
-    * Retrieves the whole collection as array
-    *
-    * @return mixed
-    */
+     * Retrieves the whole collection as array
+     *
+     * @return mixed
+     */
     public function toArray()
     {
-        return (array) $this->collection;
+        return (array)$this->collection;
     }
 
     /**
-    * Retrieves an item
-    *
-    * @param $property
-    *
-    * @return mixed
-    */
+     * Retrieves an item
+     *
+     * @param $property
+     *
+     * @return mixed
+     */
     public function get($property)
     {
         if ($this->exists($property)) {
@@ -60,11 +60,11 @@ final class Collection
     }
 
     /**
-    * Add or update an item
-    *
-    * @param $property
-    * @param mixed $value
-    */
+     * Add or update an item
+     *
+     * @param $property
+     * @param mixed $value
+     */
     public function set($property, $value)
     {
         if ($property) {
@@ -73,18 +73,18 @@ final class Collection
     }
 
     /**
-    * .. until I come with a better name..
-    *
-    * @param $property
-    *
-    * @return Collection
-    */
+     * .. until I come with a better name..
+     *
+     * @param $property
+     *
+     * @return Collection
+     */
     public function filter($property)
     {
         if ($this->exists($property)) {
             $data = $this->get($property);
 
-            if (! is_a($data, 'Collection')) {
+            if (!is_a($data, 'Collection')) {
                 $data = new Collection($data);
             }
 
@@ -95,42 +95,42 @@ final class Collection
     }
 
     /**
-    * Checks whether an item within the collection
-    *
-    * @param $property
-    *
-    * @return bool
-    */
+     * Checks whether an item within the collection
+     *
+     * @param $property
+     *
+     * @return bool
+     */
     public function exists($property)
     {
         return property_exists($this->collection, $property);
     }
 
     /**
-    * Finds whether the collection is empty
-    *
-    * @return bool
-    */
+     * Finds whether the collection is empty
+     *
+     * @return bool
+     */
     public function isEmpty()
     {
-        return ! (bool) $this->count();
+        return !(bool)$this->count();
     }
 
     /**
-    * Count all items in collection
-    *
-    * @return int
-    */
+     * Count all items in collection
+     *
+     * @return int
+     */
     public function count()
     {
         return count($this->properties());
     }
 
     /**
-    * Returns all items properties names
-    *
-    * @return array
-    */
+     * Returns all items properties names
+     *
+     * @return array
+     */
     public function properties()
     {
         $properties = [];
@@ -143,10 +143,10 @@ final class Collection
     }
 
     /**
-    * Returns all items values
-    *
-    * @return array
-    */
+     * Returns all items values
+     *
+     * @return array
+     */
     public function values()
     {
         $values = [];

--- a/src/Data/Parser.php
+++ b/src/Data/Parser.php
@@ -16,23 +16,23 @@ namespace Hybridauth\Data;
 final class Parser
 {
     /**
-    * Decodes a string into an object.
-    *
-    * This method will first attempt to parse data as a JSON string (since most providers use this format)
-    * then XML and parse_str.
-    *
-    * @param string $raw
-    *
-    * @return mixed
-    */
+     * Decodes a string into an object.
+     *
+     * This method will first attempt to parse data as a JSON string (since most providers use this format)
+     * then XML and parse_str.
+     *
+     * @param string $raw
+     *
+     * @return mixed
+     */
     public function parse($raw = null)
     {
         $data = $this->parseJson($raw);
 
-        if (! $data) {
+        if (!$data) {
             $data = $this->parseXml($raw);
-            
-            if (! $data) {
+
+            if (!$data) {
                 $data = $this->parseQueryString($raw);
             }
         }
@@ -41,12 +41,12 @@ final class Parser
     }
 
     /**
-    * Decodes a JSON string
-    *
-    * @param $result
-    *
-    * @return mixed
-    */
+     * Decodes a JSON string
+     *
+     * @param $result
+     *
+     * @return mixed
+     */
     public function parseJson($result)
     {
         return json_decode($result);
@@ -65,31 +65,31 @@ final class Parser
 
         $result = preg_replace('/([<<\/])([a-z0-9-]+):/i', '$1', $result);
         $xml = simplexml_load_string($result);
-        
+
         libxml_use_internal_errors(false);
-        
-        if (! $xml) {
+
+        if (!$xml) {
             return [];
         }
 
-        $arr = json_decode(json_encode((array) $xml), true);
+        $arr = json_decode(json_encode((array)$xml), true);
         $arr = array($xml->getName() => $arr);
 
         return $arr;
     }
 
     /**
-    * Parses a string into variables
-    *
-    * @param $result
-    *
-    * @return \StdClass
-    */
+     * Parses a string into variables
+     *
+     * @param $result
+     *
+     * @return \StdClass
+     */
     public function parseQueryString($result)
     {
         parse_str($result, $output);
 
-        if (! is_array($output)) {
+        if (!is_array($output)) {
             return $result;
         }
 
@@ -114,6 +114,6 @@ final class Parser
     {
         $birthday = date_parse($birthday);
 
-        return [ $birthday['year'], $birthday['month'], $birthday['day'] ];
+        return [$birthday['year'], $birthday['month'], $birthday['day']];
     }
 }

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -13,20 +13,20 @@ namespace Hybridauth\Exception;
 class Exception extends \Exception implements ExceptionInterface
 {
     /**
-    * Shamelessly Borrowed from Slimframework
-    *
-    * @param $object
-    */
+     * Shamelessly Borrowed from Slimframework
+     *
+     * @param $object
+     */
     public function debug($object)
     {
-        $title   = 'Hybridauth Exception';
-        $code    = $this->getCode();
+        $title = 'Hybridauth Exception';
+        $code = $this->getCode();
         $message = $this->getMessage();
-        $file    = $this->getFile();
-        $line    = $this->getLine();
-        $trace   = $this->getTraceAsString();
+        $file = $this->getFile();
+        $line = $this->getLine();
+        $trace = $this->getTraceAsString();
 
-        $html  = sprintf('<h1>%s</h1>', $title);
+        $html = sprintf('<h1>%s</h1>', $title);
         $html .= '<p>Hybridauth has encountered the following error:</p>';
         $html .= '<h2>Details</h2>';
 

--- a/src/HttpClient/Curl.php
+++ b/src/HttpClient/Curl.php
@@ -13,98 +13,98 @@ namespace Hybridauth\HttpClient;
 class Curl implements HttpClientInterface
 {
     /**
-    * Default curl options
-    *
-    * These defaults options can be overwritten when sending requests.
-    *
-    * See setCurlOptions()
-    *
-    * @var array
-    */
+     * Default curl options
+     *
+     * These defaults options can be overwritten when sending requests.
+     *
+     * See setCurlOptions()
+     *
+     * @var array
+     */
     protected $curlOptions = [
-        CURLOPT_TIMEOUT        => 30,
+        CURLOPT_TIMEOUT => 30,
         CURLOPT_CONNECTTIMEOUT => 30,
         CURLOPT_SSL_VERIFYPEER => false,
         CURLOPT_SSL_VERIFYHOST => false,
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_FOLLOWLOCATION => true,
-        CURLOPT_MAXREDIRS      => 5,
-        CURLINFO_HEADER_OUT    => true,
-        CURLOPT_ENCODING       => 'identity',
+        CURLOPT_MAXREDIRS => 5,
+        CURLINFO_HEADER_OUT => true,
+        CURLOPT_ENCODING => 'identity',
         // phpcs:ignore
-        CURLOPT_USERAGENT      => 'Hybridauth, PHP Social Authentication Library (https://github.com/hybridauth/hybridauth)',
+        CURLOPT_USERAGENT => 'Hybridauth, PHP Social Authentication Library (https://github.com/hybridauth/hybridauth)',
     ];
 
     /**
-    * Method request() arguments
-    *
-    * This is used for debugging.
-    *
-    * @var array
-    */
+     * Method request() arguments
+     *
+     * This is used for debugging.
+     *
+     * @var array
+     */
     protected $requestArguments = [];
 
     /**
-    * Default request headers
-    *
-    * @var array
-    */
+     * Default request headers
+     *
+     * @var array
+     */
     protected $requestHeader = [
-        'Accept'          => '*/*',
-        'Cache-Control'   => 'max-age=0',
-        'Connection'      => 'keep-alive',
-        'Expect'          => '',
-        'Pragma'          => '',
+        'Accept' => '*/*',
+        'Cache-Control' => 'max-age=0',
+        'Connection' => 'keep-alive',
+        'Expect' => '',
+        'Pragma' => '',
     ];
 
     /**
-    * Raw response returned by server
-    *
-    * @var string
-    */
+     * Raw response returned by server
+     *
+     * @var string
+     */
     protected $responseBody = '';
 
     /**
-    * Headers returned in the response
-    *
-    * @var array
-    */
+     * Headers returned in the response
+     *
+     * @var array
+     */
     protected $responseHeader = [];
 
     /**
-    * Response HTTP status code
-    *
-    * @var integer
-    */
+     * Response HTTP status code
+     *
+     * @var int
+     */
     protected $responseHttpCode = 0;
 
     /**
-    * Last curl error number
-    *
-    * @var mixed
-    */
+     * Last curl error number
+     *
+     * @var mixed
+     */
     protected $responseClientError = null;
 
     /**
-    * Information about the last transfer
-    *
-    * @var mixed
-    */
+     * Information about the last transfer
+     *
+     * @var mixed
+     */
     protected $responseClientInfo = [];
 
     /**
-    * Hybridauth logger instance
-    *
-    * @var object
-    */
+     * Hybridauth logger instance
+     *
+     * @var object
+     */
     protected $logger = null;
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function request($uri, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
-        $this->requestHeader = array_replace($this->requestHeader, (array) $headers);
+        $this->requestHeader = array_replace($this->requestHeader, (array)$headers);
 
         $this->requestArguments = [
             'uri' => $uri,
@@ -145,9 +145,9 @@ class Curl implements HttpClientInterface
                 break;
         }
 
-        $this->curlOptions[CURLOPT_URL]            = $uri;
-        $this->curlOptions[CURLOPT_HTTPHEADER]     = $this->prepareRequestHeaders();
-        $this->curlOptions[CURLOPT_HEADERFUNCTION] = [ $this, 'fetchResponseHeader' ];
+        $this->curlOptions[CURLOPT_URL] = $uri;
+        $this->curlOptions[CURLOPT_HTTPHEADER] = $this->prepareRequestHeaders();
+        $this->curlOptions[CURLOPT_HEADERFUNCTION] = [$this, 'fetchResponseHeader'];
 
         foreach ($this->curlOptions as $opt => $value) {
             curl_setopt($curl, $opt, $value);
@@ -155,10 +155,10 @@ class Curl implements HttpClientInterface
 
         $response = curl_exec($curl);
 
-        $this->responseBody        = $response;
-        $this->responseHttpCode    = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $this->responseBody = $response;
+        $this->responseHttpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $this->responseClientError = curl_error($curl);
-        $this->responseClientInfo  = curl_getinfo($curl);
+        $this->responseClientInfo = curl_getinfo($curl);
 
         if ($this->logger) {
             // phpcs:ignore
@@ -176,8 +176,8 @@ class Curl implements HttpClientInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponse()
     {
         $curlOptions = $this->curlOptions;
@@ -187,126 +187,126 @@ class Curl implements HttpClientInterface
         return [
             'request' => $this->getRequestArguments(),
             'response' => [
-                'code'    => $this->getResponseHttpCode(),
+                'code' => $this->getResponseHttpCode(),
                 'headers' => $this->getResponseHeader(),
-                'body'    => $this->getResponseBody(),
+                'body' => $this->getResponseBody(),
             ],
             'client' => [
                 'error' => $this->getResponseClientError(),
-                'info'  => $this->getResponseClientInfo(),
-                'opts'  => $curlOptions,
+                'info' => $this->getResponseClientInfo(),
+                'opts' => $curlOptions,
             ],
         ];
     }
 
     /**
-    * Reset curl options
-    *
-    * @param array $curlOptions
-    */
+     * Reset curl options
+     *
+     * @param array $curlOptions
+     */
     public function setCurlOptions($curlOptions)
     {
         foreach ($curlOptions as $opt => $value) {
-            $this->curlOptions[ $opt ] = $value;
+            $this->curlOptions[$opt] = $value;
         }
     }
 
     /**
-    * Set logger instance
-    *
-    * @param object $logger
-    */
+     * Set logger instance
+     *
+     * @param object $logger
+     */
     public function setLogger($logger)
     {
         $this->logger = $logger;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseBody()
     {
         return $this->responseBody;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseHeader()
     {
         return $this->responseHeader;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseHttpCode()
     {
         return $this->responseHttpCode;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseClientError()
     {
         return $this->responseClientError;
     }
 
     /**
-    * @return array
-    */
+     * @return array
+     */
     protected function getResponseClientInfo()
     {
         return $this->responseClientInfo;
     }
 
     /**
-    * Returns method request() arguments
-    *
-    * This is used for debugging.
-    *
-    * @return array
-    */
+     * Returns method request() arguments
+     *
+     * This is used for debugging.
+     *
+     * @return array
+     */
     protected function getRequestArguments()
     {
         return $this->requestArguments;
     }
 
     /**
-    * Fetch server response headers
-    *
-    * @param mixed  $curl
-    * @param string $header
-    *
-    * @return integer
-    */
+     * Fetch server response headers
+     *
+     * @param mixed $curl
+     * @param string $header
+     *
+     * @return int
+     */
     protected function fetchResponseHeader($curl, $header)
     {
         $pos = strpos($header, ':');
 
-        if (! empty($pos)) {
-            $key   = str_replace('-', '_', strtolower(substr($header, 0, $pos)));
+        if (!empty($pos)) {
+            $key = str_replace('-', '_', strtolower(substr($header, 0, $pos)));
 
             $value = trim(substr($header, $pos + 2));
 
-            $this->responseHeader[ $key ] = $value;
+            $this->responseHeader[$key] = $value;
         }
 
         return strlen($header);
     }
 
     /**
-    * Convert request headers to the expect curl format
-    *
-    * @return array
-    */
+     * Convert request headers to the expect curl format
+     *
+     * @return array
+     */
     protected function prepareRequestHeaders()
     {
         $headers = [];
 
         foreach ($this->requestHeader as $header => $value) {
-            $headers[] = trim($header) .': '. trim($value);
+            $headers[] = trim($header) . ': ' . trim($value);
         }
 
         return $headers;

--- a/src/HttpClient/Guzzle.php
+++ b/src/HttpClient/Guzzle.php
@@ -21,8 +21,8 @@ use GuzzleHttp\Exception\TransferException;
  *
  * <code>
  *  $guzzle = new Hybridauth\HttpClient\Guzzle( new GuzzleHttp\Client(), [
- *      'verify'  => '/path/to/your/certificate.crt',
- *      'headers' => [ 'User-Agent' => '..' ]
+ *      'verify' => '/path/to/your/certificate.crt',
+ *      'headers' => ['User-Agent' => '..']
  *      // 'proxy' => ...
  *  ]);
  *
@@ -34,73 +34,73 @@ use GuzzleHttp\Exception\TransferException;
 class Guzzle implements HttpClientInterface
 {
     /**
-    * Method request() arguments
-    *
-    * This is used for debugging.
-    *
-    * @var array
-    */
+     * Method request() arguments
+     *
+     * This is used for debugging.
+     *
+     * @var array
+     */
     protected $requestArguments = [];
 
     /**
-    * Default request headers
-    *
-    * @var array
-    */
+     * Default request headers
+     *
+     * @var array
+     */
     protected $requestHeader = [];
 
     /**
-    * Raw response returned by server
-    *
-    * @var string
-    */
+     * Raw response returned by server
+     *
+     * @var string
+     */
     protected $responseBody = '';
 
     /**
-    * Headers returned in the response
-    *
-    * @var array
-    */
+     * Headers returned in the response
+     *
+     * @var array
+     */
     protected $responseHeader = [];
 
     /**
-    * Response HTTP status code
-    *
-    * @var integer
-    */
+     * Response HTTP status code
+     *
+     * @var int
+     */
     protected $responseHttpCode = 0;
 
     /**
-    * Last curl error number
-    *
-    * @var mixed
-    */
+     * Last curl error number
+     *
+     * @var mixed
+     */
     protected $responseClientError = null;
 
     /**
-    * Information about the last transfer
-    *
-    * @var mixed
-    */
+     * Information about the last transfer
+     *
+     * @var mixed
+     */
     protected $responseClientInfo = [];
 
     /**
-    * Hybridauth logger instance
-    *
-    * @var object
-    */
+     * Hybridauth logger instance
+     *
+     * @var object
+     */
     protected $logger = null;
 
     /**
-    * GuzzleHttp client
-    *
-    * @var \GuzzleHttp\Client
-    */
+     * GuzzleHttp client
+     *
+     * @var \GuzzleHttp\Client
+     */
     protected $client = null;
 
     /**
      * ..
-     * @param null  $client
+     * @param null $client
      * @param array $config
      */
     public function __construct($client = null, $config = [])
@@ -109,11 +109,11 @@ class Guzzle implements HttpClientInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function request($uri, $method = 'GET', $parameters = [], $headers = [], $multipart = false)
     {
-        $this->requestHeader = array_replace($this->requestHeader, (array) $headers);
+        $this->requestHeader = array_replace($this->requestHeader, (array)$headers);
 
         $this->requestArguments = [
             'uri' => $uri,
@@ -129,8 +129,8 @@ class Guzzle implements HttpClientInterface
                 case 'GET':
                 case 'DELETE':
                     $response = $this->client->request($method, $uri, [
-                      'query' => $parameters,
-                      'headers' => $this->requestHeader,
+                        'query' => $parameters,
+                        'headers' => $this->requestHeader,
                     ]);
                     break;
                 case 'PUT':
@@ -171,9 +171,9 @@ class Guzzle implements HttpClientInterface
         }
 
         if (!$this->responseClientError) {
-            $this->responseBody     = $response->getBody();
+            $this->responseBody = $response->getBody();
             $this->responseHttpCode = $response->getStatusCode();
-            $this->responseHeader   = $response->getHeaders();
+            $this->responseHeader = $response->getHeaders();
         }
 
         if ($this->logger) {
@@ -190,82 +190,82 @@ class Guzzle implements HttpClientInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponse()
     {
         return [
             'request' => $this->getRequestArguments(),
             'response' => [
-                'code'    => $this->getResponseHttpCode(),
+                'code' => $this->getResponseHttpCode(),
                 'headers' => $this->getResponseHeader(),
-                'body'    => $this->getResponseBody(),
+                'body' => $this->getResponseBody(),
             ],
             'client' => [
                 'error' => $this->getResponseClientError(),
-                'info'  => $this->getResponseClientInfo(),
-                'opts'  => null,
+                'info' => $this->getResponseClientInfo(),
+                'opts' => null,
             ],
         ];
     }
 
     /**
-    * Set logger instance
-    *
-    * @param object $logger
-    */
+     * Set logger instance
+     *
+     * @param object $logger
+     */
     public function setLogger($logger)
     {
         $this->logger = $logger;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseBody()
     {
         return $this->responseBody;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseHeader()
     {
         return $this->responseHeader;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseHttpCode()
     {
         return $this->responseHttpCode;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getResponseClientError()
     {
         return $this->responseClientError;
     }
 
     /**
-    * @return array
-    */
+     * @return array
+     */
     protected function getResponseClientInfo()
     {
         return $this->responseClientInfo;
     }
 
     /**
-    * Returns method request() arguments
-    *
-    * This is used for debugging.
-    *
-    * @return array
-    */
+     * Returns method request() arguments
+     *
+     * This is used for debugging.
+     *
+     * @return array
+     */
     protected function getRequestArguments()
     {
         return $this->requestArguments;

--- a/src/HttpClient/HttpClientInterface.php
+++ b/src/HttpClient/HttpClientInterface.php
@@ -13,46 +13,46 @@ namespace Hybridauth\HttpClient;
 interface HttpClientInterface
 {
     /**
-    * Send request to the remote server
-    *
-    * Returns the result (Raw response from the server) on success, FALSE on failure
-    *
-    * @param string $uri
-    * @param string $method
-    * @param array  $parameters
-    * @param array  $headers
-    * @param bool   $multipart
-    *
-    * @return mixed
-    */
+     * Send request to the remote server
+     *
+     * Returns the result (Raw response from the server) on success, FALSE on failure
+     *
+     * @param string $uri
+     * @param string $method
+     * @param array $parameters
+     * @param array $headers
+     * @param bool $multipart
+     *
+     * @return mixed
+     */
     public function request($uri, $method = 'GET', $parameters = [], $headers = [], $multipart = false);
 
     /**
-    * Returns raw response from the server on success, FALSE on failure
-    *
-    * @return mixed
-    */
+     * Returns raw response from the server on success, FALSE on failure
+     *
+     * @return mixed
+     */
     public function getResponseBody();
 
     /**
-    * Retriever the headers returned in the response
-    *
-    * @return array
-    */
+     * Retriever the headers returned in the response
+     *
+     * @return array
+     */
     public function getResponseHeader();
 
     /**
-    * Returns latest request HTTP status code
-    *
-    * @return integer
-    */
+     * Returns latest request HTTP status code
+     *
+     * @return int
+     */
     public function getResponseHttpCode();
 
     /**
-    * Returns latest error encountered by the client
-    * This can be either a code or error message
-    *
-    * @return mixed
-    */
+     * Returns latest error encountered by the client
+     * This can be either a code or error message
+     *
+     * @return mixed
+     */
     public function getResponseClientError();
 }

--- a/src/HttpClient/Util.php
+++ b/src/HttpClient/Util.php
@@ -15,17 +15,17 @@ use Hybridauth\Data;
 class Util
 {
     /**
-    * Redirect handler.
-    *
-    * @var callable|null
-    */
+     * Redirect handler.
+     *
+     * @var callable|null
+     */
     protected static $redirectHandler;
 
     /**
-    * Exit handler.
-    *
-    * @var callable|null
-    */
+     * Exit handler.
+     *
+     * @var callable|null
+     */
     protected static $exitHandler;
 
     /**
@@ -56,32 +56,32 @@ class Util
     }
 
     /**
-    * Redirect handler to which the regular redirect() will yield the action of redirecting users.
-    *
-    * @param callable $callback
-    */
+     * Redirect handler to which the regular redirect() will yield the action of redirecting users.
+     *
+     * @param callable $callback
+     */
     public static function setRedirectHandler($callback)
     {
         self::$redirectHandler = $callback;
     }
 
     /**
-    * Exit handler will be called instead of regular exit() when calling Util::redirect() method.
-    *
-    * @param callable $callback
-    */
+     * Exit handler will be called instead of regular exit() when calling Util::redirect() method.
+     *
+     * @param callable $callback
+     */
     public static function setExitHandler($callback)
     {
         self::$exitHandler = $callback;
     }
 
     /**
-    * Returns the Current URL.
-    *
-    * @param bool $requestUri TRUE to use $_SERVER['REQUEST_URI'], FALSE for $_SERVER['PHP_SELF']
-    *
-    * @return string
-    */
+     * Returns the Current URL.
+     *
+     * @param bool $requestUri TRUE to use $_SERVER['REQUEST_URI'], FALSE for $_SERVER['PHP_SELF']
+     *
+     * @return string
+     */
     public static function getCurrentUrl($requestUri = false)
     {
         $collection = new Data\Collection($_SERVER);
@@ -93,8 +93,8 @@ class Util
             $protocol = 'https://';
         }
 
-        return $protocol.
-               $collection->get('HTTP_HOST').
-               $collection->get($requestUri ? 'REQUEST_URI' : 'PHP_SELF');
+        return $protocol .
+            $collection->get('HTTP_HOST') .
+            $collection->get($requestUri ? 'REQUEST_URI' : 'PHP_SELF');
     }
 }

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -25,41 +25,41 @@ use Hybridauth\HttpClient\HttpClientInterface;
 class Hybridauth
 {
     /**
-    * Hybridauth config.
-    *
-    * @var array
-    */
+     * Hybridauth config.
+     *
+     * @var array
+     */
     protected $config;
 
     /**
-    * Storage.
-    *
-    * @var StorageInterface
-    */
+     * Storage.
+     *
+     * @var StorageInterface
+     */
     protected $storage;
 
     /**
-    * HttpClient.
-    *
-    * @var HttpClientInterface
-    */
+     * HttpClient.
+     *
+     * @var HttpClientInterface
+     */
     protected $httpClient;
 
     /**
-    * Logger.
-    *
-    * @var LoggerInterface
-    */
+     * Logger.
+     *
+     * @var LoggerInterface
+     */
     protected $logger;
 
     /**
-    * @param array|string        $config     Array with configuration or Path to PHP file that will return array
-    * @param HttpClientInterface $httpClient
-    * @param StorageInterface    $storage
-    * @param LoggerInterface     $logger
-    *
-    * @throws InvalidArgumentException
-    */
+     * @param array|string $config Array with configuration or Path to PHP file that will return array
+     * @param HttpClientInterface $httpClient
+     * @param StorageInterface $storage
+     * @param LoggerInterface $logger
+     *
+     * @throws InvalidArgumentException
+     */
     public function __construct(
         $config,
         HttpClientInterface $httpClient = null,
@@ -68,34 +68,34 @@ class Hybridauth
     ) {
         if (is_string($config) && file_exists($config)) {
             $config = include $config;
-        } elseif (! is_array($config)) {
+        } elseif (!is_array($config)) {
             throw new InvalidArgumentException('Hybridauth config does not exist on the given path.');
         }
 
         $this->config = $config + [
-            'debug_mode'   => Logger::NONE,
-            'debug_file'   => '',
-            'curl_options' => null,
-            'providers'    => []
-        ];
+                'debug_mode' => Logger::NONE,
+                'debug_file' => '',
+                'curl_options' => null,
+                'providers' => []
+            ];
         $this->storage = $storage;
         $this->logger = $logger;
         $this->httpClient = $httpClient;
     }
 
     /**
-    * Instantiate the given provider and authentication or authorization protocol.
-    *
-    * If not authenticated yet, the user will be redirected to the provider's site for
-    * authentication/authorisation, otherwise it will simply return an instance of
-    * provider's adapter.
-    *
-    * @param string $name adapter's name (case insensitive)
-    *
-    * @return \Hybridauth\Adapter\AdapterInterface
-    * @throws InvalidArgumentException
-    * @throws UnexpectedValueException
-    */
+     * Instantiate the given provider and authentication or authorization protocol.
+     *
+     * If not authenticated yet, the user will be redirected to the provider's site for
+     * authentication/authorisation, otherwise it will simply return an instance of
+     * provider's adapter.
+     *
+     * @param string $name adapter's name (case insensitive)
+     *
+     * @return \Hybridauth\Adapter\AdapterInterface
+     * @throws InvalidArgumentException
+     * @throws UnexpectedValueException
+     */
     public function authenticate($name)
     {
         $adapter = $this->getAdapter($name);
@@ -106,14 +106,14 @@ class Hybridauth
     }
 
     /**
-    * Returns a new instance of a provider's adapter by name
-    *
-    * @param string $name adapter's name (case insensitive)
-    *
-    * @return \Hybridauth\Adapter\AdapterInterface
-    * @throws InvalidArgumentException
-    * @throws UnexpectedValueException
-    */
+     * Returns a new instance of a provider's adapter by name
+     *
+     * @param string $name adapter's name (case insensitive)
+     *
+     * @return \Hybridauth\Adapter\AdapterInterface
+     * @throws InvalidArgumentException
+     * @throws UnexpectedValueException
+     */
     public function getAdapter($name)
     {
         $config = $this->getProviderConfig($name);
@@ -142,26 +142,26 @@ class Hybridauth
     }
 
     /**
-    * Get provider config by name.
-    *
-    * @param string $name adapter's name (case insensitive)
-    *
-    * @throws UnexpectedValueException
-    * @throws InvalidArgumentException
-    *
-    * @return array
-    */
+     * Get provider config by name.
+     *
+     * @param string $name adapter's name (case insensitive)
+     *
+     * @throws UnexpectedValueException
+     * @throws InvalidArgumentException
+     *
+     * @return array
+     */
     public function getProviderConfig($name)
     {
         $name = strtolower($name);
 
         $providersConfig = array_change_key_case($this->config['providers'], CASE_LOWER);
 
-        if (! isset($providersConfig[$name])) {
+        if (!isset($providersConfig[$name])) {
             throw new InvalidArgumentException('Unknown Provider.');
         }
 
-        if (! $providersConfig[$name]['enabled']) {
+        if (!$providersConfig[$name]['enabled']) {
             throw new UnexpectedValueException('Disabled Provider.');
         }
 
@@ -171,7 +171,7 @@ class Hybridauth
             'debug_file' => $this->config['debug_file'],
         ];
 
-        if (! isset($config['callback']) && isset($this->config['callback'])) {
+        if (!isset($config['callback']) && isset($this->config['callback'])) {
             $config['callback'] = $this->config['callback'];
         }
 
@@ -179,24 +179,24 @@ class Hybridauth
     }
 
     /**
-    * Returns a boolean of whether the user is connected with a provider
-    *
-    * @param string $name adapter's name (case insensitive)
-    *
-    * @return boolean
-    * @throws InvalidArgumentException
-    * @throws UnexpectedValueException
-    */
+     * Returns a boolean of whether the user is connected with a provider
+     *
+     * @param string $name adapter's name (case insensitive)
+     *
+     * @return bool
+     * @throws InvalidArgumentException
+     * @throws UnexpectedValueException
+     */
     public function isConnectedWith($name)
     {
         return $this->getAdapter($name)->isConnected();
     }
 
     /**
-    * Returns a list of enabled adapters names
-    *
-    * @return array
-    */
+     * Returns a list of enabled adapters names
+     *
+     * @return array
+     */
     public function getProviders()
     {
         $providers = [];
@@ -211,19 +211,19 @@ class Hybridauth
     }
 
     /**
-    * Returns a list of currently connected adapters names
-    *
-    * @return array
-    * @throws InvalidArgumentException
-    * @throws UnexpectedValueException
-    */
+     * Returns a list of currently connected adapters names
+     *
+     * @return array
+     * @throws InvalidArgumentException
+     * @throws UnexpectedValueException
+     */
     public function getConnectedProviders()
     {
         $providers = [];
 
         foreach ($this->getProviders() as $name) {
             if ($this->isConnectedWith($name)) {
-                 $providers[] = $name;
+                $providers[] = $name;
             }
         }
 
@@ -231,12 +231,12 @@ class Hybridauth
     }
 
     /**
-    * Returns a list of new instances of currently connected adapters
-    *
-    * @return \Hybridauth\Adapter\AdapterInterface[]
-    * @throws InvalidArgumentException
-    * @throws UnexpectedValueException
-    */
+     * Returns a list of new instances of currently connected adapters
+     *
+     * @return \Hybridauth\Adapter\AdapterInterface[]
+     * @throws InvalidArgumentException
+     * @throws UnexpectedValueException
+     */
     public function getConnectedAdapters()
     {
         $adapters = [];
@@ -253,8 +253,8 @@ class Hybridauth
     }
 
     /**
-    * Disconnect all currently connected adapters at once
-    */
+     * Disconnect all currently connected adapters at once
+     */
     public function disconnectAllAdapters()
     {
         foreach ($this->getProviders() as $name) {

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -15,9 +15,9 @@ use Hybridauth\Exception\InvalidArgumentException;
  */
 class Logger implements LoggerInterface
 {
-    const NONE  = 'none';  // turn logging off
+    const NONE = 'none';  // turn logging off
     const DEBUG = 'debug'; // debug, info and error messages
-    const INFO  = 'info';  // info and error messages
+    const INFO = 'info';  // info and error messages
     const ERROR = 'error'; // only error messages
 
     /**
@@ -38,7 +38,7 @@ class Logger implements LoggerInterface
 
     /**
      * @param bool|string $level One of Logger::NONE, Logger::DEBUG, Logger::INFO, Logger::ERROR
-     * @param string      $file  File where to write messages
+     * @param string $file File where to write messages
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException
@@ -50,7 +50,7 @@ class Logger implements LoggerInterface
         if ($level && $level !== self::NONE) {
             $this->initialize($file);
 
-            $this->level = $level === true ? Logger::DEBUG :  $level;
+            $this->level = $level === true ? Logger::DEBUG : $level;
             $this->file = $file;
         }
     }
@@ -121,7 +121,7 @@ class Logger implements LoggerInterface
         $datetime = $datetime->format(DATE_ATOM);
 
         $content = sprintf('%s -- %s -- %s -- %s', $level, $_SERVER['REMOTE_ADDR'], $datetime, $message);
-        $content .= ($context ? "\n".print_r($context, true) : '');
+        $content .= ($context ? "\n" . print_r($context, true) : '');
         $content .= "\n";
 
         file_put_contents($this->file, $content, FILE_APPEND);

--- a/src/Logger/LoggerInterface.php
+++ b/src/Logger/LoggerInterface.php
@@ -18,7 +18,7 @@ interface LoggerInterface
      * Example: User logs in, SQL logs.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      */
     public function info($message, array $context = array());
 
@@ -26,7 +26,7 @@ interface LoggerInterface
      * Detailed debug information.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      */
     public function debug($message, array $context = array());
 
@@ -35,16 +35,16 @@ interface LoggerInterface
      * be logged and monitored.
      *
      * @param string $message
-     * @param array  $context
+     * @param array $context
      */
     public function error($message, array $context = array());
 
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
+     * @param mixed $level
      * @param string $message
-     * @param array  $context
+     * @param array $context
      */
     public function log($level, $message, array $context = array());
 }

--- a/src/Provider/AOLOpenID.php
+++ b/src/Provider/AOLOpenID.php
@@ -15,8 +15,8 @@ use Hybridauth\Adapter\OpenID;
 class AOLOpenID extends OpenID
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $openidIdentifier = 'http://openid.aol.com/';
 
     /**

--- a/src/Provider/Amazon.php
+++ b/src/Provider/Amazon.php
@@ -57,9 +57,9 @@ class Amazon extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('user_id');
+        $userProfile->identifier = $data->get('user_id');
         $userProfile->displayName = $data->get('name');
-        $userProfile->email       = $data->get('email');
+        $userProfile->email = $data->get('email');
 
         return $userProfile;
     }

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -29,8 +29,8 @@ use \Firebase\JWT\JWK;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'id' => '', 'team_id' => '', 'key_id' => '', 'key_file' => '', 'key_content' => '' ],
- *       'scope'    => 'name email',
+ *       'keys' => ['id' => '', 'team_id' => '', 'key_id' => '', 'key_file' => '', 'key_content' => ''],
+ *       'scope' => 'name email',
  *
  *        // Apple's custom auth url params
  *       'authorize_url_parameters' => [
@@ -47,8 +47,8 @@ use \Firebase\JWT\JWK;
  *       $tokens = $adapter->getAccessToken();
  *       $response = $adapter->setUserStatus("Hybridauth test message..");
  *   }
- *   catch( Exception $e ){
- *       echo $e->getMessage() ;
+ *   catch (Exception $e) {
+ *       echo $e->getMessage();
  *   }
  *
  * Requires:
@@ -176,7 +176,7 @@ class Apple extends OAuth2
             foreach ($publicKeys->keys as $publicKey) {
                 try {
                     $rsa = new RSA();
-                    $jwk = (array) $publicKey;
+                    $jwk = (array)$publicKey;
 
                     $rsa->loadKey(
                         [
@@ -219,7 +219,7 @@ class Apple extends OAuth2
                 $name = $user->get('name');
                 $userProfile->firstName = $name->firstName;
                 $userProfile->lastName = $name->lastName;
-                $userProfile->displayName = join(' ', [ $userProfile->firstName, $userProfile->lastName ]);
+                $userProfile->displayName = join(' ', [$userProfile->firstName, $userProfile->lastName]);
             }
         }
 

--- a/src/Provider/Authentiq.php
+++ b/src/Provider/Authentiq.php
@@ -18,33 +18,33 @@ use Hybridauth\User;
 class Authentiq extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'aq:name email~rs aq:push openid';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://connect.authentiq.io/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://connect.authentiq.io/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://connect.authentiq.io/token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'http://developers.authentiq.io/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -54,17 +54,17 @@ class Authentiq extends OAuth2
         ];
 
         $this->tokenExchangeHeaders = [
-            'Authorization' => 'Basic ' . base64_encode($this->clientId .  ':' . $this->clientSecret)
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret)
         ];
 
         $this->tokenRefreshHeaders = [
-            'Authorization' => 'Basic ' . base64_encode($this->clientId .  ':' . $this->clientSecret)
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret)
         ];
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('userinfo');
@@ -77,34 +77,34 @@ class Authentiq extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('sub');
+        $userProfile->identifier = $data->get('sub');
 
         $userProfile->displayName = $data->get('name');
-        $userProfile->firstName   = $data->get('given_name');
+        $userProfile->firstName = $data->get('given_name');
         // $userProfile->middleName  = $data->get('middle_name'); // not supported
-        $userProfile->lastName    = $data->get('family_name');
+        $userProfile->lastName = $data->get('family_name');
 
         if (!empty($userProfile->displayName)) {
             $userProfile->displayName = join(' ', array($userProfile->firstName,
-                                                        // $userProfile->middleName,
-                                                        $userProfile->lastName));
+                // $userProfile->middleName,
+                $userProfile->lastName));
         }
 
-        $userProfile->email       = $data->get('email');
+        $userProfile->email = $data->get('email');
         $userProfile->emailVerified = $data->get('email_verified') ? $userProfile->email : '';
 
-        $userProfile->phone       = $data->get('phone');
+        $userProfile->phone = $data->get('phone');
         // $userProfile->phoneVerified = $data->get('phone_verified') ? $userProfile->phone : ''; // not supported
 
-        $userProfile->profileURL  = $data->get('profile');
-        $userProfile->webSiteURL  = $data->get('website');
-        $userProfile->photoURL    = $data->get('picture');
-        $userProfile->gender      = $data->get('gender');
-        $userProfile->address     = $data->filter('address')->get('street_address');
-        $userProfile->city        = $data->filter('address')->get('locality');
-        $userProfile->country     = $data->filter('address')->get('country');
-        $userProfile->region      = $data->filter('address')->get('region');
-        $userProfile->zip         = $data->filter('address')->get('postal_code');
+        $userProfile->profileURL = $data->get('profile');
+        $userProfile->webSiteURL = $data->get('website');
+        $userProfile->photoURL = $data->get('picture');
+        $userProfile->gender = $data->get('gender');
+        $userProfile->address = $data->filter('address')->get('street_address');
+        $userProfile->city = $data->filter('address')->get('locality');
+        $userProfile->country = $data->filter('address')->get('country');
+        $userProfile->region = $data->filter('address')->get('region');
+        $userProfile->zip = $data->filter('address')->get('postal_code');
 
         return $userProfile;
     }

--- a/src/Provider/BitBucket.php
+++ b/src/Provider/BitBucket.php
@@ -22,51 +22,51 @@ use Hybridauth\User;
 class BitBucket extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'email';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.bitbucket.org/2.0/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://bitbucket.org/site/oauth2/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://bitbucket.org/site/oauth2/access_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://developer.atlassian.com/bitbucket/concepts/oauth2.html';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('user');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('uuid')) {
+        if (!$data->exists('uuid')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('uuid');
-        $userProfile->profileURL  = 'https://bitbucket.org/' . $data->get('username') . '/';
+        $userProfile->identifier = $data->get('uuid');
+        $userProfile->profileURL = 'https://bitbucket.org/' . $data->get('username') . '/';
         $userProfile->displayName = $data->get('display_name');
-        $userProfile->email       = $data->get('email');
-        $userProfile->webSiteURL  = $data->get('website');
-        $userProfile->region      = $data->get('location');
+        $userProfile->email = $data->get('email');
+        $userProfile->webSiteURL = $data->get('website');
+        $userProfile->region = $data->get('location');
 
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');
 
@@ -95,10 +95,10 @@ class BitBucket extends OAuth2
         $response = $this->apiRequest('user/emails');
 
         foreach ($response->values as $idx => $item) {
-            if (! empty($item->is_primary) && $item->is_primary == true) {
+            if (!empty($item->is_primary) && $item->is_primary == true) {
                 $userProfile->email = $item->email;
 
-                if (! empty($item->is_confirmed) && $item->is_confirmed == true) {
+                if (!empty($item->is_confirmed) && $item->is_confirmed == true) {
                     $userProfile->emailVerified = $userProfile->email;
                 }
 

--- a/src/Provider/Blizzard.php
+++ b/src/Provider/Blizzard.php
@@ -57,7 +57,7 @@ class Blizzard extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier = $data->get('id');
         $userProfile->displayName = $data->get('battletag') ?: $data->get('login');
 
         return $userProfile;

--- a/src/Provider/DeviantArt.php
+++ b/src/Provider/DeviantArt.php
@@ -75,16 +75,16 @@ class DeviantArt extends OAuth2
             $full_name[1] = '';
         }
 
-        $userProfile->identifier  = $data->get('userid');
+        $userProfile->identifier = $data->get('userid');
         $userProfile->displayName = $data->get('username');
-        $userProfile->profileURL  = $data->get('usericon');
-        $userProfile->webSiteURL  = $data->filter('profile')->get('website');
-        $userProfile->firstName   = $full_name[0];
-        $userProfile->lastName    = $full_name[1];
-        $userProfile->profileURL  = $data->filter('profile')->filter('profile_pic')->get('url');
-        $userProfile->gender      = $data->filter('details')->get('sex');
-        $userProfile->age         = $data->filter('details')->get('age');
-        $userProfile->country     = $data->filter('geo')->get('country');
+        $userProfile->profileURL = $data->get('usericon');
+        $userProfile->webSiteURL = $data->filter('profile')->get('website');
+        $userProfile->firstName = $full_name[0];
+        $userProfile->lastName = $full_name[1];
+        $userProfile->profileURL = $data->filter('profile')->filter('profile_pic')->get('url');
+        $userProfile->gender = $data->filter('details')->get('sex');
+        $userProfile->age = $data->filter('details')->get('age');
+        $userProfile->country = $data->filter('geo')->get('country');
 
         return $userProfile;
     }

--- a/src/Provider/Disqus.php
+++ b/src/Provider/Disqus.php
@@ -18,33 +18,33 @@ use Hybridauth\User;
 class Disqus extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'read,email';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://disqus.com/api/3.0/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://disqus.com/api/oauth/2.0/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://disqus.com/api/oauth/2.0/access_token/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://disqus.com/api/docs/auth/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -55,15 +55,15 @@ class Disqus extends OAuth2
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('users/details');
 
         $data = new Data\Collection($response);
 
-        if (! $data->filter('response')->exists('id')) {
+        if (!$data->filter('response')->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
@@ -71,15 +71,15 @@ class Disqus extends OAuth2
 
         $data = $data->filter('response');
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier = $data->get('id');
         $userProfile->displayName = $data->get('name');
         $userProfile->description = $data->get('bio');
-        $userProfile->profileURL  = $data->get('profileUrl');
-        $userProfile->email       = $data->get('email');
-        $userProfile->region      = $data->get('location');
+        $userProfile->profileURL = $data->get('profileUrl');
+        $userProfile->email = $data->get('email');
+        $userProfile->region = $data->get('location');
         $userProfile->description = $data->get('about');
 
-        $userProfile->photoURL    = $data->filter('avatar')->get('permalink');
+        $userProfile->photoURL = $data->filter('avatar')->get('permalink');
 
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');
 

--- a/src/Provider/Dribbble.php
+++ b/src/Provider/Dribbble.php
@@ -18,50 +18,50 @@ use Hybridauth\User;
 class Dribbble extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.dribbble.com/v2/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://dribbble.com/oauth/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://dribbble.com/oauth/token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'http://developer.dribbble.com/v2/oauth/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('user');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('id')) {
+        if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('id');
-        $userProfile->profileURL  = $data->get('html_url');
-        $userProfile->photoURL    = $data->get('avatar_url');
+        $userProfile->identifier = $data->get('id');
+        $userProfile->profileURL = $data->get('html_url');
+        $userProfile->photoURL = $data->get('avatar_url');
         $userProfile->description = $data->get('bio');
-        $userProfile->region      = $data->get('location');
+        $userProfile->region = $data->get('location');
         $userProfile->displayName = $data->get('name');
 
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');
 
-        $userProfile->webSiteURL  = $data->filter('links')->get('web');
+        $userProfile->webSiteURL = $data->filter('links')->get('web');
 
         return $userProfile;
     }

--- a/src/Provider/Dropbox.php
+++ b/src/Provider/Dropbox.php
@@ -57,14 +57,14 @@ class Dropbox extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('account_id');
+        $userProfile->identifier = $data->get('account_id');
         $userProfile->displayName = $data->filter('name')->get('display_name');
-        $userProfile->firstName   = $data->filter('name')->get('given_name');
-        $userProfile->lastName    = $data->filter('name')->get('surname');
-        $userProfile->email       = $data->get('email');
-        $userProfile->photoURL    = $data->get('profile_photo_url');
-        $userProfile->language    = $data->get('locale');
-        $userProfile->country     = $data->get('country');
+        $userProfile->firstName = $data->filter('name')->get('given_name');
+        $userProfile->lastName = $data->filter('name')->get('surname');
+        $userProfile->email = $data->get('email');
+        $userProfile->photoURL = $data->get('profile_photo_url');
+        $userProfile->language = $data->get('locale');
+        $userProfile->country = $data->get('country');
         if ($data->get('email_verified')) {
             $userProfile->emailVerified = $data->get('email');
         }

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -25,9 +25,9 @@ use Hybridauth\User;
  * Example:
  *
  *   $config = [
- *       'callback'                => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'                    => [ 'id' => '', 'secret' => '' ],
- *       'scope'                   => 'email, user_status, user_posts',
+ *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys' => ['id' => '', 'secret' => ''],
+ *       'scope' => 'email, user_status, user_posts',
  *       'exchange_by_expiry_days' => 45, // null for no token exchange
  *   ];
  *
@@ -40,8 +40,8 @@ use Hybridauth\User;
  *       $tokens = $adapter->getAccessToken();
  *       $response = $adapter->setUserStatus("Hybridauth test message..");
  *   }
- *   catch( Exception $e ){
- *       echo $e->getMessage() ;
+ *   catch (Exception $e) {
+ *       echo $e->getMessage();
  *   }
  */
 class Facebook extends OAuth2
@@ -118,9 +118,9 @@ class Facebook extends OAuth2
     public function exchangeAccessToken()
     {
         $exchangeTokenParameters = [
-            'grant_type'        => 'fb_exchange_token',
-            'client_id'         => $this->clientId,
-            'client_secret'     => $this->clientSecret,
+            'grant_type' => 'fb_exchange_token',
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
             'fb_exchange_token' => $this->getStoredData('access_token'),
         ];
 
@@ -339,8 +339,8 @@ class Facebook extends OAuth2
 
         // Refresh proof for API call.
         $parameters = $status + [
-            'appsecret_proof' => hash_hmac('sha256', $page->access_token, $this->clientSecret),
-        ];
+                'appsecret_proof' => hash_hmac('sha256', $page->access_token, $this->clientSecret),
+            ];
 
         $response = $this->apiRequest("{$pageId}/feed", 'POST', $parameters, $headers);
 

--- a/src/Provider/Foursquare.php
+++ b/src/Provider/Foursquare.php
@@ -18,33 +18,33 @@ use Hybridauth\User;
 class Foursquare extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.foursquare.com/v2/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://foursquare.com/oauth2/authenticate';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://foursquare.com/oauth2/access_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenName = 'oauth_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://developer.foursquare.com/overview/auth';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -58,15 +58,15 @@ class Foursquare extends OAuth2
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('users/self');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('response')) {
+        if (!$data->exists('response')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
@@ -74,15 +74,15 @@ class Foursquare extends OAuth2
 
         $data = $data->filter('response')->filter('user');
 
-        $userProfile->identifier    = $data->get('id');
-        $userProfile->firstName     = $data->get('firstName');
-        $userProfile->lastName      = $data->get('lastName');
-        $userProfile->gender        = $data->get('gender');
-        $userProfile->city          = $data->get('homeCity');
-        $userProfile->email         = $data->filter('contact')->get('email');
+        $userProfile->identifier = $data->get('id');
+        $userProfile->firstName = $data->get('firstName');
+        $userProfile->lastName = $data->get('lastName');
+        $userProfile->gender = $data->get('gender');
+        $userProfile->city = $data->get('homeCity');
+        $userProfile->email = $data->filter('contact')->get('email');
         $userProfile->emailVerified = $userProfile->email;
-        $userProfile->profileURL    = 'https://www.foursquare.com/user/' . $userProfile->identifier;
-        $userProfile->displayName   = trim($userProfile->firstName . ' ' . $userProfile->lastName);
+        $userProfile->profileURL = 'https://www.foursquare.com/user/' . $userProfile->identifier;
+        $userProfile->displayName = trim($userProfile->firstName . ' ' . $userProfile->lastName);
 
         if ($data->exists('photo')) {
             $photoSize = $this->config->get('photo_size') ?: '150x150';
@@ -95,15 +95,15 @@ class Foursquare extends OAuth2
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserContacts()
     {
         $response = $this->apiRequest('users/self/friends');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('response')) {
+        if (!$data->exists('response')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 

--- a/src/Provider/GitLab.php
+++ b/src/Provider/GitLab.php
@@ -18,52 +18,52 @@ use Hybridauth\User;
 class GitLab extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'api';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://gitlab.com/api/v3/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://gitlab.com/oauth/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://gitlab.com/oauth/token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://docs.gitlab.com/ee/api/oauth2.html';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('user');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('id')) {
+        if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier = $data->get('id');
         $userProfile->displayName = $data->get('name');
         $userProfile->description = $data->get('bio');
-        $userProfile->photoURL    = $data->get('avatar_url');
-        $userProfile->profileURL  = $data->get('web_url');
-        $userProfile->email       = $data->get('email');
-        $userProfile->webSiteURL  = $data->get('website_url');
+        $userProfile->photoURL = $data->get('avatar_url');
+        $userProfile->profileURL = $data->get('web_url');
+        $userProfile->email = $data->get('email');
+        $userProfile->webSiteURL = $data->get('website_url');
 
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');
 

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -19,15 +19,15 @@ use Hybridauth\User;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'id' => '', 'secret' => '' ],
- *       'scope'    => 'https://www.googleapis.com/auth/userinfo.profile',
+ *       'keys' => ['id' => '', 'secret' => ''],
+ *       'scope' => 'https://www.googleapis.com/auth/userinfo.profile',
  *
  *        // google's custom auth url params
  *       'authorize_url_parameters' => [
  *              'approval_prompt' => 'force', // to pass only when you need to acquire a new refresh token.
- *              'access_type'     => ..,      // is set to 'offline' by default
- *              'hd'              => ..,
- *              'state'           => ..,
+ *              'access_type' => ..,      // is set to 'offline' by default
+ *              'hd' => ..,
+ *              'state' => ..,
  *              // etc.
  *       ]
  *   ];
@@ -41,41 +41,41 @@ use Hybridauth\User;
  *       $tokens = $adapter->getAccessToken();
  *       $contacts = $adapter->getUserContacts(['max-results' => 75]);
  *   }
- *   catch( Exception $e ){
- *       echo $e->getMessage() ;
+ *   catch (Exception $e) {
+ *       echo $e->getMessage();
  *   }
  */
 class Google extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     // phpcs:ignore
     protected $scope = 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://www.googleapis.com/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://accounts.google.com/o/oauth2/auth';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://accounts.google.com/o/oauth2/token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://developers.google.com/identity/protocols/OAuth2';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -93,31 +93,31 @@ class Google extends OAuth2
     }
 
     /**
-    * {@inheritdoc}
-    *
-    * See: https://developers.google.com/identity/protocols/OpenIDConnect#obtainuserinfo
-    */
+     * {@inheritdoc}
+     *
+     * See: https://developers.google.com/identity/protocols/OpenIDConnect#obtainuserinfo
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('oauth2/v3/userinfo');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('sub')) {
+        if (!$data->exists('sub')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('sub');
-        $userProfile->firstName   = $data->get('given_name');
-        $userProfile->lastName    = $data->get('family_name');
+        $userProfile->identifier = $data->get('sub');
+        $userProfile->firstName = $data->get('given_name');
+        $userProfile->lastName = $data->get('family_name');
         $userProfile->displayName = $data->get('name');
-        $userProfile->photoURL    = $data->get('picture');
-        $userProfile->profileURL  = $data->get('profile');
-        $userProfile->gender      = $data->get('gender');
-        $userProfile->language    = $data->get('locale');
-        $userProfile->email       = $data->get('email');
+        $userProfile->photoURL = $data->get('picture');
+        $userProfile->profileURL = $data->get('profile');
+        $userProfile->gender = $data->get('gender');
+        $userProfile->language = $data->get('locale');
+        $userProfile->email = $data->get('email');
 
         $userProfile->emailVerified = $data->get('email_verified') ? $userProfile->email : '';
 
@@ -129,8 +129,8 @@ class Google extends OAuth2
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserContacts($parameters = [])
     {
         $parameters = ['max-results' => 500] + $parameters;
@@ -155,11 +155,11 @@ class Google extends OAuth2
     protected function getGmailContacts($parameters = [])
     {
         $url = 'https://www.google.com/m8/feeds/contacts/default/full?'
-                    . http_build_query(array_replace([ 'alt' => 'json', 'v' => '3.0' ], (array)$parameters));
+            . http_build_query(array_replace(['alt' => 'json', 'v' => '3.0'], (array)$parameters));
 
         $response = $this->apiRequest($url);
 
-        if (! $response) {
+        if (!$response) {
             return [];
         }
 
@@ -170,11 +170,11 @@ class Google extends OAuth2
                 $uc = new User\Contact();
 
                 $uc->email = isset($entry->{'gd$email'}[0]->address)
-                            ? (string) $entry->{'gd$email'}[0]->address
-                            : '';
+                    ? (string)$entry->{'gd$email'}[0]->address
+                    : '';
 
-                $uc->displayName = isset($entry->title->{'$t'}) ? (string) $entry->title->{'$t'} : '';
-                $uc->identifier  = ($uc->email != '') ? $uc->email : '';
+                $uc->displayName = isset($entry->title->{'$t'}) ? (string)$entry->title->{'$t'} : '';
+                $uc->identifier = ($uc->email != '') ? $uc->email : '';
                 $uc->description = '';
 
                 if (property_exists($response, 'website')) {

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -55,8 +55,8 @@ class LinkedIn extends OAuth2
         ];
 
 
-        $response = $this->apiRequest('me', 'GET', [ 'projection' => '(' . implode(',', $fields) . ')' ]);
-        $data     = new Data\Collection($response);
+        $response = $this->apiRequest('me', 'GET', ['projection' => '(' . implode(',', $fields) . ')']);
+        $data = new Data\Collection($response);
 
         if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
@@ -66,14 +66,14 @@ class LinkedIn extends OAuth2
 
         // Handle localized names.
         $userProfile->firstName = $data
-          ->filter('firstName')
-          ->filter('localized')
-          ->get($this->getPreferredLocale($data, 'firstName'));
+            ->filter('firstName')
+            ->filter('localized')
+            ->get($this->getPreferredLocale($data, 'firstName'));
 
         $userProfile->lastName = $data
-          ->filter('lastName')
-          ->filter('localized')
-          ->get($this->getPreferredLocale($data, 'lastName'));
+            ->filter('lastName')
+            ->filter('localized')
+            ->get($this->getPreferredLocale($data, 'lastName'));
 
         $userProfile->identifier = $data->get('id');
         $userProfile->email = $this->getUserEmail();
@@ -168,8 +168,8 @@ class LinkedIn extends OAuth2
 
         $headers = [
             'Content-Type' => 'application/json',
-            'x-li-format'  => 'json',
-            'X-Restli-Protocol-Version'  => '2.0.0',
+            'x-li-format' => 'json',
+            'X-Restli-Protocol-Version' => '2.0.0',
         ];
 
         $response = $this->apiRequest("ugcPosts", 'POST', $status, $headers);

--- a/src/Provider/MicrosoftGraph.php
+++ b/src/Provider/MicrosoftGraph.php
@@ -25,8 +25,8 @@ use Hybridauth\User;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'id' => '', 'secret' => '' ],
- *       'tenant'   => 'user',
+ *       'keys' => ['id' => '', 'secret' => ''],
+ *       'tenant' => 'user',
  *         // ^ May be 'common', 'organizations' or 'consumers' or a specific tenant ID or a domain
  *   ];
  *
@@ -38,8 +38,8 @@ use Hybridauth\User;
  *       $userProfile = $adapter->getUserProfile();
  *       $tokens = $adapter->getAccessToken();
  *   }
- *   catch( Exception $e ){
- *       echo $e->getMessage() ;
+ *   catch (Exception $e) {
+ *       echo $e->getMessage();
  *   }
  */
 class MicrosoftGraph extends OAuth2
@@ -70,8 +70,8 @@ class MicrosoftGraph extends OAuth2
     protected $apiDocumentation = 'https://developer.microsoft.com/en-us/graph/docs/concepts/php';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -79,8 +79,8 @@ class MicrosoftGraph extends OAuth2
         $tenant = $this->config->get('tenant');
         if (!empty($tenant)) {
             $adjustedEndpoints = [
-                'authorize_url' => str_replace('/common/', '/'. $tenant .'/', $this->authorizeUrl),
-                'access_token_url' => str_replace('/common/', '/'. $tenant .'/', $this->accessTokenUrl),
+                'authorize_url' => str_replace('/common/', '/' . $tenant . '/', $this->authorizeUrl),
+                'access_token_url' => str_replace('/common/', '/' . $tenant . '/', $this->accessTokenUrl),
             ];
 
             $this->setApiEndpoints($adjustedEndpoints);
@@ -102,11 +102,11 @@ class MicrosoftGraph extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier    = $data->get('id');
-        $userProfile->displayName   = $data->get('displayName');
-        $userProfile->firstName     = $data->get('givenName');
-        $userProfile->lastName      = $data->get('surname');
-        $userProfile->language      = $data->get('preferredLanguage');
+        $userProfile->identifier = $data->get('id');
+        $userProfile->displayName = $data->get('displayName');
+        $userProfile->firstName = $data->get('givenName');
+        $userProfile->lastName = $data->get('surname');
+        $userProfile->language = $data->get('preferredLanguage');
 
         $userProfile->phone = $data->get('mobilePhone');
         if (empty($userProfile->phone)) {
@@ -132,19 +132,19 @@ class MicrosoftGraph extends OAuth2
      */
     public function getUserContacts()
     {
-        $apiUrl   = 'me/contacts?$top=50';
+        $apiUrl = 'me/contacts?$top=50';
         $contacts = [];
 
         do {
             $response = $this->apiRequest($apiUrl);
-            $data     = new Data\Collection($response);
+            $data = new Data\Collection($response);
             if (!$data->exists('value')) {
                 throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
             }
             foreach ($data->filter('value')->toArray() as $entry) {
                 $entry = new Data\Collection($entry);
-                $userContact              = new User\Contact();
-                $userContact->identifier  = $entry->get('id');
+                $userContact = new User\Contact();
+                $userContact->identifier = $entry->get('id');
                 $userContact->displayName = $entry->get('displayName');
                 if (!empty($entry->get('emailAddresses'))) {
                     $userContact->email = $entry->get('emailAddresses')[0]->address;

--- a/src/Provider/ORCID.php
+++ b/src/Provider/ORCID.php
@@ -18,28 +18,28 @@ use Hybridauth\User;
 class ORCID extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = '/authenticate';
-    
+
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://pub.orcid.org/v2.1/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://orcid.org/oauth/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://orcid.org/oauth/token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://members.orcid.org/api/';
 
     /**
@@ -53,8 +53,8 @@ class ORCID extends OAuth2
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest($this->getStoredData('orcid') . '/record');
@@ -89,8 +89,8 @@ class ORCID extends OAuth2
     {
         $data = new Data\Collection($data->get('orcid-identifier'));
 
-        $profile->identifier  = $data->get('path');
-        $profile->profileURL  = $data->get('uri');
+        $profile->identifier = $data->get('path');
+        $profile->profileURL = $data->get('uri');
 
         return $profile;
     }
@@ -108,7 +108,7 @@ class ORCID extends OAuth2
         $data = new Data\Collection($data->get('person'));
         $data = new Data\Collection($data->get('biography'));
 
-        $profile->description  = $data->get('content');
+        $profile->description = $data->get('content');
 
         return $profile;
     }
@@ -148,7 +148,7 @@ class ORCID extends OAuth2
     {
         $data = new Data\Collection($data->get('person'));
         $data = new Data\Collection($data->get('name'));
-        
+
         if ($data->exists('credit-name')) {
             $profile->displayName = $data->get('credit-name');
         } else {

--- a/src/Provider/Odnoklassniki.php
+++ b/src/Provider/Odnoklassniki.php
@@ -18,18 +18,18 @@ use Hybridauth\User;
 class Odnoklassniki extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.ok.ru/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://connect.ok.ru/oauth/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://api.ok.ru/oauth/token.do';
 
     /**
@@ -38,8 +38,8 @@ class Odnoklassniki extends OAuth2
     protected $apiDocumentation = 'https://apiok.ru/en/ext/oauth/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -53,13 +53,13 @@ class Odnoklassniki extends OAuth2
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $fields = array(
             'uid', 'locale', 'first_name', 'last_name', 'name', 'gender', 'age', 'birthday',
-            'has_email', 'current_status', 'current_status_id', 'current_status_date','online',
+            'has_email', 'current_status', 'current_status_id', 'current_status_date', 'online',
             'photo_id', 'pic_1', 'pic_2', 'pic1024x768', 'location', 'email'
         );
 
@@ -71,38 +71,38 @@ class Odnoklassniki extends OAuth2
         );
 
         $parameters = [
-            'access_token'    => $this->getStoredData('access_token'),
+            'access_token' => $this->getStoredData('access_token'),
             'application_key' => $this->config->get('keys')['key'],
-            'method'          => 'users.getCurrentUser',
-            'fields'          => implode(',', $fields),
-            'sig'             => $sig,
+            'method' => 'users.getCurrentUser',
+            'fields' => implode(',', $fields),
+            'sig' => $sig,
         ];
 
         $response = $this->apiRequest('fb.do', 'GET', $parameters);
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('uid')) {
+        if (!$data->exists('uid')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
 
-        $userProfile->identifier  = $data->get('uid');
-        $userProfile->email       = $data->get('email');
-        $userProfile->firstName   = $data->get('first_name');
-        $userProfile->lastName    = $data->get('last_name');
+        $userProfile->identifier = $data->get('uid');
+        $userProfile->email = $data->get('email');
+        $userProfile->firstName = $data->get('first_name');
+        $userProfile->lastName = $data->get('last_name');
         $userProfile->displayName = $data->get('name');
-        $userProfile->photoURL    = $data->get('pic1024x768');
-        $userProfile->profileURL  = 'http://ok.ru/profile/' . $data->get('uid');
-        
+        $userProfile->photoURL = $data->get('pic1024x768');
+        $userProfile->profileURL = 'http://ok.ru/profile/' . $data->get('uid');
+
         // Handle birthday.
         if ($data->get('birthday')) {
-            $bday                    = explode('-', $data->get('birthday'));
-            $userProfile->birthDay   = (int)$bday[0];
+            $bday = explode('-', $data->get('birthday'));
+            $userProfile->birthDay = (int)$bday[0];
             $userProfile->birthMonth = (int)$bday[1];
-            $userProfile->birthYear  = (int)$bday[2];
+            $userProfile->birthYear = (int)$bday[2];
         }
 
         return $userProfile;

--- a/src/Provider/Paypal.php
+++ b/src/Provider/Paypal.php
@@ -18,33 +18,33 @@ use Hybridauth\User;
 class Paypal extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'openid profile email address';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.paypal.com/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://www.paypal.com/signin/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://api.paypal.com/v1/oauth2/token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://developer.paypal.com/docs/api/overview/#';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -54,20 +54,20 @@ class Paypal extends OAuth2
         ];
 
         $this->tokenExchangeHeaders = [
-            'Authorization' => 'Basic ' . base64_encode($this->clientId .  ':' . $this->clientSecret)
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret)
         ];
 
         $this->tokenRefreshHeaders = [
-            'Authorization' => 'Basic ' . base64_encode($this->clientId .  ':' . $this->clientSecret)
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret)
         ];
     }
 
     /**
-    * {@inheritdoc}
-    *
-    * See: https://developer.paypal.com/docs/api/identity/v1/
-    * See: https://developer.paypal.com/docs/connect-with-paypal/integrate/
-    */
+     * {@inheritdoc}
+     *
+     * See: https://developer.paypal.com/docs/api/identity/v1/
+     * See: https://developer.paypal.com/docs/connect-with-paypal/integrate/
+     */
     public function getUserProfile()
     {
         $headers = [
@@ -81,20 +81,20 @@ class Paypal extends OAuth2
         $response = $this->apiRequest('v1/identity/oauth2/userinfo', 'GET', $parameters, $headers);
         $data = new Data\Collection($response);
 
-        if (! $data->exists('user_id')) {
+        if (!$data->exists('user_id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
-        $userProfile->identifier  = $data->get('user_id');
-        $userProfile->firstName   = $data->get('given_name');
-        $userProfile->lastName    = $data->get('family_name');
+        $userProfile->identifier = $data->get('user_id');
+        $userProfile->firstName = $data->get('given_name');
+        $userProfile->lastName = $data->get('family_name');
         $userProfile->displayName = $data->get('name');
-        $userProfile->address     = $data->filter('address')->get('street_address');
-        $userProfile->city        = $data->filter('address')->get('locality');
-        $userProfile->country     = $data->filter('address')->get('country');
-        $userProfile->region      = $data->filter('address')->get('region');
-        $userProfile->zip         = $data->filter('address')->get('postal_code');
+        $userProfile->address = $data->filter('address')->get('street_address');
+        $userProfile->city = $data->filter('address')->get('locality');
+        $userProfile->country = $data->filter('address')->get('country');
+        $userProfile->region = $data->filter('address')->get('region');
+        $userProfile->zip = $data->filter('address')->get('postal_code');
 
         $emails = $data->filter('emails')->toArray();
         foreach ($emails as $email) {

--- a/src/Provider/PaypalOpenID.php
+++ b/src/Provider/PaypalOpenID.php
@@ -16,8 +16,8 @@ use Hybridauth\HttpClient;
 class PaypalOpenID extends OpenID
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $openidIdentifier = 'https://www.sandbox.paypal.com/webapps/auth/server';
 
     /**
@@ -26,13 +26,13 @@ class PaypalOpenID extends OpenID
     protected $apiDocumentation = 'https://developer.paypal.com/docs/connect-with-paypal/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function authenticateBegin()
     {
-        $this->openIdClient->identity  = $this->openidIdentifier;
+        $this->openIdClient->identity = $this->openidIdentifier;
         $this->openIdClient->returnUrl = $this->callback;
-        $this->openIdClient->required  = [
+        $this->openIdClient->required = [
             'namePerson/prefix',
             'namePerson/first',
             'namePerson/last',

--- a/src/Provider/Pinterest.php
+++ b/src/Provider/Pinterest.php
@@ -53,21 +53,21 @@ class Pinterest extends OAuth2
 
         $data = $data->filter('data');
 
-        if (! $data->exists('id')) {
+        if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier = $data->get('id');
         $userProfile->description = $data->get('bio');
-        $userProfile->photoURL    = $data->get('image');
+        $userProfile->photoURL = $data->get('image');
         $userProfile->displayName = $data->get('username');
         $userProfile->firstName = $data->get('first_name');
         $userProfile->lastName = $data->get('last_name');
         $userProfile->profileURL = "https://pinterest.com/{$data->get('username')}";
-        
-        $userProfile->data = (array) $data->get('counts');
+
+        $userProfile->data = (array)$data->get('counts');
 
         return $userProfile;
     }

--- a/src/Provider/QQ.php
+++ b/src/Provider/QQ.php
@@ -67,7 +67,7 @@ class QQ extends OAuth2
 
         if ($this->isRefreshTokenAvailable()) {
             $this->tokenRefreshParameters += [
-                'client_id'     => $this->clientId,
+                'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
             ];
         }

--- a/src/Provider/Reddit.php
+++ b/src/Provider/Reddit.php
@@ -18,33 +18,33 @@ use Hybridauth\User;
 class Reddit extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'identity';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://oauth.reddit.com/api/v1/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://ssl.reddit.com/api/v1/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://ssl.reddit.com/api/v1/access_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://github.com/reddit/reddit/wiki/OAuth2';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -54,37 +54,37 @@ class Reddit extends OAuth2
         ];
 
         $this->tokenExchangeParameters = [
-            'client_id'    => $this->clientId,
-            'grant_type'   => 'authorization_code',
+            'client_id' => $this->clientId,
+            'grant_type' => 'authorization_code',
             'redirect_uri' => $this->callback
         ];
 
         $this->tokenExchangeHeaders = [
-            'Authorization' => 'Basic ' . base64_encode($this->clientId .  ':' . $this->clientSecret)
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret)
         ];
 
         $this->tokenRefreshHeaders = $this->tokenExchangeHeaders;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('me.json');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('id')) {
+        if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier = $data->get('id');
         $userProfile->displayName = $data->get('name');
-        $userProfile->profileURL  = 'https://www.reddit.com/user/' . $data->get('name') . '/';
-        $userProfile->photoURL    = $data->get('icon_img');
+        $userProfile->profileURL = 'https://www.reddit.com/user/' . $data->get('name') . '/';
+        $userProfile->photoURL = $data->get('icon_img');
 
         return $userProfile;
     }

--- a/src/Provider/StackExchange.php
+++ b/src/Provider/StackExchange.php
@@ -19,9 +19,9 @@ use Hybridauth\User;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'id' => '', 'secret' => '' ],
- *       'site'     => 'stackoverflow' // required parameter to call getUserProfile()
- *       'api_key'  => '...' // that thing to receive a higher request quota.
+ *       'keys' => ['id' => '', 'secret' => ''],
+ *       'site' => 'stackoverflow' // required parameter to call getUserProfile()
+ *       'api_key' => '...' // that thing to receive a higher request quota.
  *   ];
  *
  *   $adapter = new Hybridauth\Provider\StackExchange( $config );
@@ -39,45 +39,45 @@ use Hybridauth\User;
 class StackExchange extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = null;
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.stackexchange.com/2.2/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://stackexchange.com/oauth';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://stackexchange.com/oauth/access_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://api.stackexchange.com/docs/authentication';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
 
         $apiKey = $this->config->get('api_key');
 
-        $this->apiRequestParameters = [ 'key' => $apiKey];
+        $this->apiRequestParameters = ['key' => $apiKey];
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $site = $this->config->get('site');
@@ -87,7 +87,7 @@ class StackExchange extends OAuth2
             'access_token' => $this->getStoredData('access_token'),
         ]);
 
-        if (! $response || !isset($response->items) || !isset($response->items[0])) {
+        if (!$response || !isset($response->items) || !isset($response->items[0])) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
@@ -95,12 +95,12 @@ class StackExchange extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = strval($data->get('user_id'));
+        $userProfile->identifier = strval($data->get('user_id'));
         $userProfile->displayName = $data->get('display_name');
-        $userProfile->photoURL    = $data->get('profile_image');
-        $userProfile->profileURL  = $data->get('link');
-        $userProfile->region      = $data->get('location');
-        $userProfile->age         = $data->get('age');
+        $userProfile->photoURL = $data->get('profile_image');
+        $userProfile->profileURL = $data->get('link');
+        $userProfile->region = $data->get('location');
+        $userProfile->age = $data->get('age');
 
         return $userProfile;
     }

--- a/src/Provider/StackExchangeOpenID.php
+++ b/src/Provider/StackExchangeOpenID.php
@@ -15,8 +15,8 @@ use Hybridauth\Adapter\OpenID;
 class StackExchangeOpenID extends OpenID
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $openidIdentifier = 'https://openid.stackexchange.com/';
 
     /**
@@ -25,15 +25,15 @@ class StackExchangeOpenID extends OpenID
     protected $apiDocumentation = 'https://openid.stackexchange.com/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function authenticateFinish()
     {
         parent::authenticateFinish();
 
         $userProfile = $this->storage->get($this->providerId . '.user');
 
-        $userProfile->identifier    = !empty($userProfile->identifier) ? $userProfile->identifier : $userProfile->email;
+        $userProfile->identifier = !empty($userProfile->identifier) ? $userProfile->identifier : $userProfile->email;
         $userProfile->emailVerified = $userProfile->email;
 
         // re store the user profile

--- a/src/Provider/Steam.php
+++ b/src/Provider/Steam.php
@@ -19,7 +19,7 @@ use Hybridauth\User;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'     => [ 'secret' => 'steam-api-key' ]
+ *       'keys' => ['secret' => 'steam-api-key']
  *   ];
  *
  *   $adapter = new Hybridauth\Provider\Steam( $config );
@@ -36,8 +36,8 @@ use Hybridauth\User;
 class Steam extends OpenID
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $openidIdentifier = 'http://steamcommunity.com/openid';
 
     /**
@@ -46,8 +46,8 @@ class Steam extends OpenID
     protected $apiDocumentation = 'https://steamcommunity.com/dev';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function authenticateFinish()
     {
         parent::authenticateFinish();
@@ -121,7 +121,7 @@ class Steam extends OpenID
      * Fetch user profile on community API
      * @param $steam64
      * @return array
-*/
+     */
     public function getUserProfileLegacyAPI($steam64)
     {
         libxml_use_internal_errors(false);
@@ -142,8 +142,8 @@ class Steam extends OpenID
         $userProfile['description'] = (string)$data->get('summary');
         $userProfile['region'] = (string)$data->get('location');
         $userProfile['profileURL'] = (string)$data->get('customURL')
-          ? 'http://steamcommunity.com/id/' . (string)$data->get('customURL')
-          : 'http://steamcommunity.com/profiles/' . $steam64;
+            ? 'http://steamcommunity.com/id/' . (string)$data->get('customURL')
+            : 'http://steamcommunity.com/profiles/' . $steam64;
 
         return $userProfile;
     }

--- a/src/Provider/SteemConnect.php
+++ b/src/Provider/SteemConnect.php
@@ -51,7 +51,7 @@ class SteemConnect extends OAuth2
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('result')) {
+        if (!$data->exists('result')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
@@ -59,10 +59,10 @@ class SteemConnect extends OAuth2
 
         $data = $data->filter('result');
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier = $data->get('id');
         $userProfile->description = $data->get('about');
-        $userProfile->photoURL    = $data->get('profile_image');
-        $userProfile->webSiteURL  = $data->get('website');
+        $userProfile->photoURL = $data->get('profile_image');
+        $userProfile->webSiteURL = $data->get('website');
         $userProfile->displayName = $data->get('name');
 
         return $userProfile;

--- a/src/Provider/Strava.php
+++ b/src/Provider/Strava.php
@@ -51,13 +51,13 @@ class Strava extends OAuth2
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('id')) {
+        if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('id');
+        $userProfile->identifier = $data->get('id');
         $userProfile->firstName = $data->get('firstname');
         $userProfile->lastName = $data->get('lastname');
         $userProfile->gender = $data->get('sex');

--- a/src/Provider/Telegram.php
+++ b/src/Provider/Telegram.php
@@ -28,8 +28,8 @@ use Hybridauth\Exception\UnexpectedApiResponseException;
  * Example:
  *
  *   $config = [
- *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'      => ['id' => 'your_bot_name', 'secret' => 'your_bot_token'],
+ *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys' => ['id' => 'your_bot_name', 'secret' => 'your_bot_token'],
  *   ];
  *
  *   $adapter = new Hybridauth\Provider\Telegram($config);
@@ -115,11 +115,11 @@ class Telegram extends AbstractAdapter implements AdapterInterface
 
         $userProfile = new Profile();
 
-        $userProfile->identifier    = $data->get('id');
-        $userProfile->firstName     = $data->get('first_name');
-        $userProfile->lastName      = $data->get('last_name');
-        $userProfile->displayName   = $data->get('username');
-        $userProfile->photoURL      = $data->get('photo_url');
+        $userProfile->identifier = $data->get('id');
+        $userProfile->firstName = $data->get('first_name');
+        $userProfile->lastName = $data->get('last_name');
+        $userProfile->displayName = $data->get('username');
+        $userProfile->photoURL = $data->get('photo_url');
         $username = $data->get('username');
         if (!empty($username)) {
             // Only some accounts have usernames.
@@ -205,13 +205,13 @@ HTML
     protected function parseAuthData()
     {
         return [
-            'id'            => filter_input(INPUT_GET, 'id'),
-            'first_name'    => filter_input(INPUT_GET, 'first_name'),
-            'last_name'     => filter_input(INPUT_GET, 'last_name'),
-            'username'      => filter_input(INPUT_GET, 'username'),
-            'photo_url'     => filter_input(INPUT_GET, 'photo_url'),
-            'auth_date'     => filter_input(INPUT_GET, 'auth_date'),
-            'hash'          => filter_input(INPUT_GET, 'hash'),
+            'id' => filter_input(INPUT_GET, 'id'),
+            'first_name' => filter_input(INPUT_GET, 'first_name'),
+            'last_name' => filter_input(INPUT_GET, 'last_name'),
+            'username' => filter_input(INPUT_GET, 'username'),
+            'photo_url' => filter_input(INPUT_GET, 'photo_url'),
+            'auth_date' => filter_input(INPUT_GET, 'auth_date'),
+            'hash' => filter_input(INPUT_GET, 'hash'),
         ];
     }
 }

--- a/src/Provider/Tumblr.php
+++ b/src/Provider/Tumblr.php
@@ -18,40 +18,40 @@ use Hybridauth\User;
 class Tumblr extends OAuth1
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.tumblr.com/v2/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://www.tumblr.com/oauth/authorize';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $requestTokenUrl = 'https://www.tumblr.com/oauth/request_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://www.tumblr.com/oauth/access_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://www.tumblr.com/docs/en/api/v2';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('user/info');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('response')) {
+        if (!$data->exists('response')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
@@ -63,9 +63,9 @@ class Tumblr extends OAuth1
             $blog = new Data\Collection($blog);
 
             if ($blog->get('primary') && $blog->exists('url')) {
-                $userProfile->identifier  = $blog->get('url');
-                $userProfile->profileURL  = $blog->get('url');
-                $userProfile->webSiteURL  = $blog->get('url');
+                $userProfile->identifier = $blog->get('url');
+                $userProfile->profileURL = $blog->get('url');
+                $userProfile->webSiteURL = $blog->get('url');
                 $userProfile->description = strip_tags($blog->get('description'));
 
                 $bloghostname = explode('://', $blog->get('url'));
@@ -82,13 +82,13 @@ class Tumblr extends OAuth1
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function setUserStatus($status)
     {
         $status = is_string($status)
-                    ? [ 'type' => 'text', 'body' => $status ]
-                    : $status;
+            ? ['type' => 'text', 'body' => $status]
+            : $status;
 
         $response = $this->apiRequest('blog/' . $this->getStoredData('primary_blog') . '/post', 'POST', $status);
 

--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -19,8 +19,8 @@ use Hybridauth\User;
  * Example:
  *
  *   $config = [
- *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'      => [ 'key' => '', 'secret' => '' ], // OAuth1 uses 'key' not 'id'
+ *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys' => ['key' => '', 'secret' => ''], // OAuth1 uses 'key' not 'id'
  *       'authorize' => true // Needed to perform actions on behalf of users (see below link)
  *         // https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
  *   ];
@@ -35,8 +35,8 @@ use Hybridauth\User;
  *       $contacts = $adapter->getUserContacts(['screen_name' =>'andypiper']); // get those of @andypiper
  *       $activity = $adapter->getUserActivity('me');
  *   }
- *   catch( Exception $e ){
- *       echo $e->getMessage() ;
+ *   catch (Exception $e) {
+ *       echo $e->getMessage();
  *   }
  */
 class Twitter extends OAuth1
@@ -95,28 +95,28 @@ class Twitter extends OAuth1
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier    = $data->get('id_str');
-        $userProfile->displayName   = $data->get('screen_name');
-        $userProfile->description   = $data->get('description');
-        $userProfile->firstName     = $data->get('name');
-        $userProfile->email         = $data->get('email');
+        $userProfile->identifier = $data->get('id_str');
+        $userProfile->displayName = $data->get('screen_name');
+        $userProfile->description = $data->get('description');
+        $userProfile->firstName = $data->get('name');
+        $userProfile->email = $data->get('email');
         $userProfile->emailVerified = $data->get('email');
-        $userProfile->webSiteURL    = $data->get('url');
-        $userProfile->region        = $data->get('location');
+        $userProfile->webSiteURL = $data->get('url');
+        $userProfile->region = $data->get('location');
 
-        $userProfile->profileURL    = $data->exists('screen_name')
-                                        ? ('http://twitter.com/' . $data->get('screen_name'))
-                                        : '';
+        $userProfile->profileURL = $data->exists('screen_name')
+            ? ('http://twitter.com/' . $data->get('screen_name'))
+            : '';
 
         $photoSize = $this->config->get('photo_size') ?: 'original';
         $photoSize = $photoSize === 'original' ? '' : "_{$photoSize}";
-        $userProfile->photoURL      = $data->exists('profile_image_url_https')
-                                        ? str_replace('_normal', $photoSize, $data->get('profile_image_url_https'))
-                                        : '';
+        $userProfile->photoURL = $data->exists('profile_image_url_https')
+            ? str_replace('_normal', $photoSize, $data->get('profile_image_url_https'))
+            : '';
 
         $userProfile->data = [
-          'followed_by' => $data->get('followers_count'),
-          'follows' => $data->get('friends_count'),
+            'followed_by' => $data->get('followers_count'),
+            'follows' => $data->get('friends_count'),
         ];
 
         return $userProfile;
@@ -127,13 +127,13 @@ class Twitter extends OAuth1
      */
     public function getUserContacts($parameters = [])
     {
-        $parameters = [ 'cursor' => '-1'] + $parameters;
+        $parameters = ['cursor' => '-1'] + $parameters;
 
         $response = $this->apiRequest('friends/ids.json', 'GET', $parameters);
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('ids')) {
+        if (!$data->exists('ids')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
@@ -144,10 +144,10 @@ class Twitter extends OAuth1
         $contacts = [];
 
         // 75 id per time should be okey
-        $contactsIds = array_chunk((array) $data->get('ids'), 75);
+        $contactsIds = array_chunk((array)$data->get('ids'), 75);
 
         foreach ($contactsIds as $chunk) {
-            $parameters = [ 'user_id' => implode(',', $chunk) ];
+            $parameters = ['user_id' => implode(',', $chunk)];
 
             try {
                 $response = $this->apiRequest('users/lookup.json', 'GET', $parameters);
@@ -176,14 +176,14 @@ class Twitter extends OAuth1
 
         $userContact = new User\Contact();
 
-        $userContact->identifier  = $item->get('id_str');
+        $userContact->identifier = $item->get('id_str');
         $userContact->displayName = $item->get('name');
-        $userContact->photoURL    = $item->get('profile_image_url');
+        $userContact->photoURL = $item->get('profile_image_url');
         $userContact->description = $item->get('description');
 
-        $userContact->profileURL  = $item->exists('screen_name')
-                                        ? ('http://twitter.com/' . $item->get('screen_name'))
-                                        : '';
+        $userContact->profileURL = $item->exists('screen_name')
+            ? ('http://twitter.com/' . $item->get('screen_name'))
+            : '';
 
         return $userContact;
     }
@@ -220,8 +220,8 @@ class Twitter extends OAuth1
     public function getUserActivity($stream = 'me')
     {
         $apiUrl = ($stream == 'me')
-                    ? 'statuses/user_timeline.json'
-                    : 'statuses/home_timeline.json';
+            ? 'statuses/user_timeline.json'
+            : 'statuses/home_timeline.json';
 
         $response = $this->apiRequest($apiUrl);
 
@@ -248,17 +248,17 @@ class Twitter extends OAuth1
 
         $userActivity = new User\Activity();
 
-        $userActivity->id   = $item->get('id_str');
+        $userActivity->id = $item->get('id_str');
         $userActivity->date = $item->get('created_at');
         $userActivity->text = $item->get('text');
 
-        $userActivity->user->identifier   = $item->filter('user')->get('id_str');
-        $userActivity->user->displayName  = $item->filter('user')->get('name');
-        $userActivity->user->photoURL     = $item->filter('user')->get('profile_image_url');
+        $userActivity->user->identifier = $item->filter('user')->get('id_str');
+        $userActivity->user->displayName = $item->filter('user')->get('name');
+        $userActivity->user->photoURL = $item->filter('user')->get('profile_image_url');
 
-        $userActivity->user->profileURL   = $item->filter('user')->get('screen_name')
-                                                ? ('http://twitter.com/' . $item->filter('user')->get('screen_name'))
-                                                : '';
+        $userActivity->user->profileURL = $item->filter('user')->get('screen_name')
+            ? ('http://twitter.com/' . $item->filter('user')->get('screen_name'))
+            : '';
 
         return $userActivity;
     }

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -20,8 +20,8 @@ use Hybridauth\User;
  * Example:
  *
  *   $config = [
- *       'callback'  => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys'      => [
+ *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys' => [
  *           'id' => '', // App ID
  *           'secret' => '' // Secure key
  *       ],
@@ -136,19 +136,19 @@ class Vkontakte extends OAuth2
 
         $userProfile = new Profile();
 
-        $userProfile->identifier  = $data->get('id');
-        $userProfile->email       = $this->getStoredData('email');
-        $userProfile->firstName   = $data->get('first_name');
-        $userProfile->lastName    = $data->get('last_name');
+        $userProfile->identifier = $data->get('id');
+        $userProfile->email = $this->getStoredData('email');
+        $userProfile->firstName = $data->get('first_name');
+        $userProfile->lastName = $data->get('last_name');
         $userProfile->displayName = $data->get('screen_name');
-        $userProfile->photoURL    = $data->get('has_photo') === 1 ? $data->get($photoField) : '';
+        $userProfile->photoURL = $data->get('has_photo') === 1 ? $data->get($photoField) : '';
 
         // Handle b-date.
         if ($data->get('bdate')) {
             $bday = explode('.', $data->get('bdate'));
-            $userProfile->birthDay = (int) $bday[0];
-            $userProfile->birthMonth = (int) $bday[1];
-            $userProfile->birthYear = (int) $bday[2];
+            $userProfile->birthDay = (int)$bday[0];
+            $userProfile->birthMonth = (int)$bday[1];
+            $userProfile->birthYear = (int)$bday[2];
         }
 
         $userProfile->data = [
@@ -156,7 +156,7 @@ class Vkontakte extends OAuth2
         ];
 
         $screen_name = static::URL . ($data->get('screen_name') ?: 'id' . $data->get('id'));
-        $userProfile->profileURL  = $screen_name;
+        $userProfile->profileURL = $screen_name;
 
         switch ($data->get('sex')) {
             case 1:

--- a/src/Provider/WeChat.php
+++ b/src/Provider/WeChat.php
@@ -64,8 +64,8 @@ class WeChat extends OAuth2
     protected $apiDocumentation = ''; // Not available
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
@@ -121,13 +121,13 @@ class WeChat extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('openid');
+        $userProfile->identifier = $data->get('openid');
         $userProfile->displayName = $data->get('nickname');
-        $userProfile->photoURL    = $data->get('headimgurl');
-        $userProfile->city        = $data->get('city');
-        $userProfile->region      = $data->get('province');
-        $userProfile->country     = $data->get('country');
-        $userProfile->gender      = ['', 'male', 'female'][(int)$data->get('sex')];
+        $userProfile->photoURL = $data->get('headimgurl');
+        $userProfile->city = $data->get('city');
+        $userProfile->region = $data->get('province');
+        $userProfile->country = $data->get('country');
+        $userProfile->gender = ['', 'male', 'female'][(int)$data->get('sex')];
 
         return $userProfile;
     }

--- a/src/Provider/WindowsLive.php
+++ b/src/Provider/WindowsLive.php
@@ -18,71 +18,71 @@ use Hybridauth\User;
 class WindowsLive extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'wl.basic wl.contacts_emails wl.emails wl.signin wl.share wl.birthday';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://apis.live.net/v5.0/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://login.live.com/oauth20_authorize.srf';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://login.live.com/oauth20_token.srf';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://msdn.microsoft.com/en-us/library/hh243647.aspx';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('me');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('id')) {
+        if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier    = $data->get('id');
-        $userProfile->displayName   = $data->get('name');
-        $userProfile->firstName     = $data->get('first_name');
-        $userProfile->lastName      = $data->get('last_name');
-        $userProfile->gender        = $data->get('gender');
-        $userProfile->profileURL    = $data->get('link');
-        $userProfile->email         = $data->filter('emails')->get('preferred');
+        $userProfile->identifier = $data->get('id');
+        $userProfile->displayName = $data->get('name');
+        $userProfile->firstName = $data->get('first_name');
+        $userProfile->lastName = $data->get('last_name');
+        $userProfile->gender = $data->get('gender');
+        $userProfile->profileURL = $data->get('link');
+        $userProfile->email = $data->filter('emails')->get('preferred');
         $userProfile->emailVerified = $data->filter('emails')->get('account');
-        $userProfile->birthDay      = $data->get('birth_day');
-        $userProfile->birthMonth    = $data->get('birth_month');
-        $userProfile->birthYear     = $data->get('birth_year');
-        $userProfile->language      = $data->get('locale');
+        $userProfile->birthDay = $data->get('birth_day');
+        $userProfile->birthMonth = $data->get('birth_month');
+        $userProfile->birthYear = $data->get('birth_year');
+        $userProfile->language = $data->get('locale');
 
         return $userProfile;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserContacts()
     {
         $response = $this->apiRequest('me/contacts');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('data')) {
+        if (!$data->exists('data')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
@@ -91,9 +91,9 @@ class WindowsLive extends OAuth2
         foreach ($data->filter('data')->toArray() as $idx => $entry) {
             $userContact = new User\Contact();
 
-            $userContact->identifier  = $entry->get('id');
+            $userContact->identifier = $entry->get('id');
             $userContact->displayName = $entry->get('name');
-            $userContact->email       = $entry->filter('emails')->get('preferred');
+            $userContact->email = $entry->filter('emails')->get('preferred');
 
             $contacts[] = $userContact;
         }

--- a/src/Provider/WordPress.php
+++ b/src/Provider/WordPress.php
@@ -18,46 +18,46 @@ use Hybridauth\User;
 class WordPress extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://public-api.wordpress.com/rest/v1/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://public-api.wordpress.com/oauth2/authenticate';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://public-api.wordpress.com/oauth2/token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://developer.wordpress.com/docs/api/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('me/');
 
         $data = new Data\Collection($response);
 
-        if (! $data->exists('ID')) {
+        if (!$data->exists('ID')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
         }
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('ID');
+        $userProfile->identifier = $data->get('ID');
         $userProfile->displayName = $data->get('display_name');
-        $userProfile->photoURL    = $data->get('avatar_URL');
-        $userProfile->profileURL  = $data->get('profile_URL');
-        $userProfile->email       = $data->get('email');
-        $userProfile->language    = $data->get('language');
+        $userProfile->photoURL = $data->get('avatar_URL');
+        $userProfile->profileURL = $data->get('profile_URL');
+        $userProfile->email = $data->get('email');
+        $userProfile->language = $data->get('language');
 
         $userProfile->displayName = $userProfile->displayName ?: $data->get('username');
 

--- a/src/Provider/Yahoo.php
+++ b/src/Provider/Yahoo.php
@@ -23,52 +23,52 @@ use Hybridauth\User;
 class Yahoo extends OAuth2
 {
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $scope = 'profile';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiBaseUrl = 'https://api.login.yahoo.com/openid/v1/';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $authorizeUrl = 'https://api.login.yahoo.com/oauth2/request_auth';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $accessTokenUrl = 'https://api.login.yahoo.com/oauth2/get_token';
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected $apiDocumentation = 'https://developer.yahoo.com/oauth2/guide/';
 
     /**
-    * Currently authenticated user
-    */
+     * Currently authenticated user
+     */
     protected $userId = null;
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     protected function initialize()
     {
         parent::initialize();
 
         $this->tokenExchangeHeaders = [
-            'Authorization' => 'Basic ' . base64_encode($this->clientId .  ':' . $this->clientSecret)
+            'Authorization' => 'Basic ' . base64_encode($this->clientId . ':' . $this->clientSecret)
         ];
 
         $this->tokenRefreshHeaders = $this->tokenExchangeHeaders;
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('userinfo');
@@ -81,13 +81,13 @@ class Yahoo extends OAuth2
 
         $userProfile = new User\Profile();
 
-        $userProfile->identifier  = $data->get('sub');
-        $userProfile->firstName   = $data->get('given_name');
-        $userProfile->lastName    = $data->get('family_name');
+        $userProfile->identifier = $data->get('sub');
+        $userProfile->firstName = $data->get('given_name');
+        $userProfile->lastName = $data->get('family_name');
         $userProfile->displayName = $data->get('name');
-        $userProfile->gender      = $data->get('gender');
-        $userProfile->language    = $data->get('locale');
-        $userProfile->email       = $data->get('email');
+        $userProfile->gender = $data->get('gender');
+        $userProfile->language = $data->get('locale');
+        $userProfile->email = $data->get('email');
 
         $userProfile->emailVerified = $data->get('email_verified') ? $userProfile->email : '';
 

--- a/src/Provider/Yandex.php
+++ b/src/Provider/Yandex.php
@@ -47,7 +47,7 @@ class Yandex extends OAuth2
     {
         $this->scope = implode(',', []);
 
-        $response = $this->apiRequest($this->apiBaseUrl, 'GET', [ 'format' => 'json' ]);
+        $response = $this->apiRequest($this->apiBaseUrl, 'GET', ['format' => 'json']);
 
         if (!isset($response->id)) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');

--- a/src/Storage/Session.php
+++ b/src/Storage/Session.php
@@ -29,10 +29,10 @@ class Session implements StorageInterface
     protected $keyPrefix = '';
 
     /**
-    * Initiate a new session
-    *
-    * @throws RuntimeException
-    */
+     * Initiate a new session
+     *
+     * @throws RuntimeException
+     */
     public function __construct()
     {
         if (session_id()) {
@@ -44,14 +44,14 @@ class Session implements StorageInterface
             throw new RuntimeException('HTTP headers already sent to browser and Hybridauth won\'t be able to start/resume PHP session. To resolve this, session_start() must be called before outputing any data.');
         }
 
-        if (! session_start()) {
+        if (!session_start()) {
             throw new RuntimeException('PHP session failed to start.');
         }
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function get($key)
     {
         $key = $this->keyPrefix . strtolower($key);
@@ -64,8 +64,8 @@ class Session implements StorageInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function set($key, $value)
     {
         $key = $this->keyPrefix . strtolower($key);
@@ -74,16 +74,16 @@ class Session implements StorageInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function clear()
     {
         $_SESSION[$this->storeNamespace] = [];
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function delete($key)
     {
         $key = $this->keyPrefix . strtolower($key);
@@ -98,8 +98,8 @@ class Session implements StorageInterface
     }
 
     /**
-    * {@inheritdoc}
-    */
+     * {@inheritdoc}
+     */
     public function deleteMatch($key)
     {
         $key = $this->keyPrefix . strtolower($key);
@@ -109,7 +109,7 @@ class Session implements StorageInterface
 
             foreach ($tmp as $k => $v) {
                 if (strstr($k, $key)) {
-                    unset($tmp[ $k ]);
+                    unset($tmp[$k]);
                 }
             }
 

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -13,38 +13,38 @@ namespace Hybridauth\Storage;
 interface StorageInterface
 {
     /**
-    * Retrieve a item from storage
-    *
-    * @param string $key
-    *
-    * @return mixed
-    */
+     * Retrieve a item from storage
+     *
+     * @param string $key
+     *
+     * @return mixed
+     */
     public function get($key);
 
     /**
-    * Add or Update an item to storage
-    *
-    * @param string $key
-    * @param string $value
-    */
+     * Add or Update an item to storage
+     *
+     * @param string $key
+     * @param string $value
+     */
     public function set($key, $value);
 
     /**
-    * Delete an item from storage
-    *
-    * @param string $key
-    */
+     * Delete an item from storage
+     *
+     * @param string $key
+     */
     public function delete($key);
 
     /**
-    * Delete a item from storage
-    *
-    * @param string $key
-    */
+     * Delete a item from storage
+     *
+     * @param string $key
+     */
     public function deleteMatch($key);
 
     /**
-    * Clear all items in storage
-    */
+     * Clear all items in storage
+     */
     public function clear();
 }

--- a/src/Thirdparty/OAuth/OAuthRequest.php
+++ b/src/Thirdparty/OAuth/OAuthRequest.php
@@ -33,9 +33,9 @@ class OAuthRequest
     {
         $parameters = ($parameters) ? $parameters : array();
         $parameters = array_merge(OAuthUtil::parse_parameters(parse_url($http_url, PHP_URL_QUERY)), $parameters);
-        $this->parameters  = $parameters;
+        $this->parameters = $parameters;
         $this->http_method = $http_method;
-        $this->http_url    = $http_url;
+        $this->http_url = $http_url;
     }
 
     /**
@@ -52,7 +52,7 @@ class OAuthRequest
         $scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != "on") ? 'http' : 'https';
         $http_url = ($http_url) ? $http_url : $scheme . '://' . $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['REQUEST_URI'];
         $http_method = ($http_method) ? $http_method : $_SERVER['REQUEST_METHOD'];
-        
+
         // We weren't handed any parameters, so let's find the ones relevant to
         // this request.
         // If you run XML-RPC or similar you should use this to provide your own
@@ -60,17 +60,17 @@ class OAuthRequest
         if (!$parameters) {
             // Find request headers
             $request_headers = OAuthUtil::get_headers();
-            
+
             // Parse the query-string to find GET parameters
             $parameters = OAuthUtil::parse_parameters($_SERVER['QUERY_STRING']);
-            
+
             // It's a POST request of the proper content-type, so parse POST
             // parameters and add those overriding any duplicates from GET
             if ($http_method == "POST" && isset($request_headers['Content-Type']) && strstr($request_headers['Content-Type'], 'application/x-www-form-urlencoded')) {
-                $post_data  = OAuthUtil::parse_parameters(file_get_contents(self::$POST_INPUT));
+                $post_data = OAuthUtil::parse_parameters(file_get_contents(self::$POST_INPUT));
                 $parameters = array_merge($parameters, $post_data);
             }
-            
+
             // We have a Authorization-header with OAuth data. Parse the header
             // and add those overriding any duplicates from GET or POST
             if (isset($request_headers['Authorization']) && substr($request_headers['Authorization'], 0, 6) == 'OAuth ') {
@@ -78,7 +78,7 @@ class OAuthRequest
                 $parameters = array_merge($parameters, $header_parameters);
             }
         }
-        
+
         return new OAuthRequest($http_method, $http_url, $parameters);
     }
 
@@ -90,11 +90,11 @@ class OAuthRequest
      * @param      $http_url
      * @param null $parameters
      * @return OAuthRequest
-*/
+     */
     public static function from_consumer_and_token($consumer, $token, $http_method, $http_url, $parameters = null)
     {
         $parameters = ($parameters) ? $parameters : array();
-        $defaults   = array(
+        $defaults = array(
             "oauth_version" => OAuthRequest::$version,
             "oauth_nonce" => OAuthRequest::generate_nonce(),
             "oauth_timestamp" => OAuthRequest::generate_timestamp(),
@@ -103,9 +103,9 @@ class OAuthRequest
         if ($token) {
             $defaults['oauth_token'] = $token->key;
         }
-        
+
         $parameters = array_merge($defaults, $parameters);
-        
+
         return new OAuthRequest($http_method, $http_url, $parameters);
     }
 
@@ -125,7 +125,7 @@ class OAuthRequest
                     $this->parameters[$name]
                 );
             }
-            
+
             $this->parameters[$name][] = $value;
         } else {
             $this->parameters[$name] = $value;
@@ -157,7 +157,7 @@ class OAuthRequest
     {
         unset($this->parameters[$name]);
     }
-    
+
     /**
      * The request parameters, sorted and concatenated into a normalized string.
      *
@@ -167,16 +167,16 @@ class OAuthRequest
     {
         // Grab all parameters
         $params = $this->parameters;
-        
+
         // Remove oauth_signature if present
         // Ref: Spec: 9.1.1 ("The oauth_signature parameter MUST be excluded.")
         if (isset($params['oauth_signature'])) {
             unset($params['oauth_signature']);
         }
-        
+
         return OAuthUtil::build_http_query($params);
     }
-    
+
     /**
      * Returns the base string of this request
      *
@@ -191,12 +191,12 @@ class OAuthRequest
             $this->get_normalized_http_url(),
             $this->get_signable_parameters()
         );
-        
+
         $parts = OAuthUtil::urlencode_rfc3986($parts);
-        
+
         return implode('&', $parts);
     }
-    
+
     /**
      * just uppercases the http method
      */
@@ -204,7 +204,7 @@ class OAuthRequest
     {
         return strtoupper($this->http_method);
     }
-    
+
     /**
      * parses the url and rebuilds it to be
      * scheme://host/path
@@ -212,31 +212,31 @@ class OAuthRequest
     public function get_normalized_http_url()
     {
         $parts = parse_url($this->http_url);
-        
+
         $scheme = (isset($parts['scheme'])) ? $parts['scheme'] : 'http';
-        $port   = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
-        $host   = (isset($parts['host'])) ? strtolower($parts['host']) : '';
-        $path   = (isset($parts['path'])) ? $parts['path'] : '';
-        
+        $port = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
+        $host = (isset($parts['host'])) ? strtolower($parts['host']) : '';
+        $path = (isset($parts['path'])) ? $parts['path'] : '';
+
         if (($scheme == 'https' && $port != '443') || ($scheme == 'http' && $port != '80')) {
             $host = "$host:$port";
         }
         return "$scheme://$host$path";
     }
-    
+
     /**
      * builds a url usable for a GET request
      */
     public function to_url()
     {
         $post_data = $this->to_postdata();
-        $out       = $this->get_normalized_http_url();
+        $out = $this->get_normalized_http_url();
         if ($post_data) {
             $out .= '?' . $post_data;
         }
         return $out;
     }
-    
+
     /**
      * builds the data one would send in a POST request
      */
@@ -249,17 +249,17 @@ class OAuthRequest
      * builds the Authorization: header
      * @param null $realm
      * @return array
-*/
+     */
     public function to_header($realm = null)
     {
         $first = true;
         if ($realm) {
-            $out   = 'OAuth realm="' . OAuthUtil::urlencode_rfc3986($realm) . '"';
+            $out = 'OAuth realm="' . OAuthUtil::urlencode_rfc3986($realm) . '"';
             $first = false;
         } else {
             $out = 'OAuth';
         }
-        
+
         foreach ($this->parameters as $k => $v) {
             if (substr($k, 0, 5) != "oauth") {
                 continue;
@@ -323,9 +323,9 @@ class OAuthRequest
      */
     private static function generate_nonce()
     {
-        $mt   = microtime();
+        $mt = microtime();
         $rand = mt_rand();
-        
+
         return md5($mt . $rand); // md5s look nicer than numbers
     }
 }

--- a/src/Thirdparty/OAuth/OAuthRequest.php
+++ b/src/Thirdparty/OAuth/OAuthRequest.php
@@ -33,9 +33,9 @@ class OAuthRequest
     {
         $parameters = ($parameters) ? $parameters : array();
         $parameters = array_merge(OAuthUtil::parse_parameters(parse_url($http_url, PHP_URL_QUERY)), $parameters);
-        $this->parameters = $parameters;
+        $this->parameters  = $parameters;
         $this->http_method = $http_method;
-        $this->http_url = $http_url;
+        $this->http_url    = $http_url;
     }
 
     /**
@@ -52,7 +52,7 @@ class OAuthRequest
         $scheme = (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] != "on") ? 'http' : 'https';
         $http_url = ($http_url) ? $http_url : $scheme . '://' . $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['REQUEST_URI'];
         $http_method = ($http_method) ? $http_method : $_SERVER['REQUEST_METHOD'];
-
+        
         // We weren't handed any parameters, so let's find the ones relevant to
         // this request.
         // If you run XML-RPC or similar you should use this to provide your own
@@ -60,17 +60,17 @@ class OAuthRequest
         if (!$parameters) {
             // Find request headers
             $request_headers = OAuthUtil::get_headers();
-
+            
             // Parse the query-string to find GET parameters
             $parameters = OAuthUtil::parse_parameters($_SERVER['QUERY_STRING']);
-
+            
             // It's a POST request of the proper content-type, so parse POST
             // parameters and add those overriding any duplicates from GET
             if ($http_method == "POST" && isset($request_headers['Content-Type']) && strstr($request_headers['Content-Type'], 'application/x-www-form-urlencoded')) {
-                $post_data = OAuthUtil::parse_parameters(file_get_contents(self::$POST_INPUT));
+                $post_data  = OAuthUtil::parse_parameters(file_get_contents(self::$POST_INPUT));
                 $parameters = array_merge($parameters, $post_data);
             }
-
+            
             // We have a Authorization-header with OAuth data. Parse the header
             // and add those overriding any duplicates from GET or POST
             if (isset($request_headers['Authorization']) && substr($request_headers['Authorization'], 0, 6) == 'OAuth ') {
@@ -78,7 +78,7 @@ class OAuthRequest
                 $parameters = array_merge($parameters, $header_parameters);
             }
         }
-
+        
         return new OAuthRequest($http_method, $http_url, $parameters);
     }
 
@@ -90,11 +90,11 @@ class OAuthRequest
      * @param      $http_url
      * @param null $parameters
      * @return OAuthRequest
-     */
+*/
     public static function from_consumer_and_token($consumer, $token, $http_method, $http_url, $parameters = null)
     {
         $parameters = ($parameters) ? $parameters : array();
-        $defaults = array(
+        $defaults   = array(
             "oauth_version" => OAuthRequest::$version,
             "oauth_nonce" => OAuthRequest::generate_nonce(),
             "oauth_timestamp" => OAuthRequest::generate_timestamp(),
@@ -103,9 +103,9 @@ class OAuthRequest
         if ($token) {
             $defaults['oauth_token'] = $token->key;
         }
-
+        
         $parameters = array_merge($defaults, $parameters);
-
+        
         return new OAuthRequest($http_method, $http_url, $parameters);
     }
 
@@ -125,7 +125,7 @@ class OAuthRequest
                     $this->parameters[$name]
                 );
             }
-
+            
             $this->parameters[$name][] = $value;
         } else {
             $this->parameters[$name] = $value;
@@ -157,7 +157,7 @@ class OAuthRequest
     {
         unset($this->parameters[$name]);
     }
-
+    
     /**
      * The request parameters, sorted and concatenated into a normalized string.
      *
@@ -167,16 +167,16 @@ class OAuthRequest
     {
         // Grab all parameters
         $params = $this->parameters;
-
+        
         // Remove oauth_signature if present
         // Ref: Spec: 9.1.1 ("The oauth_signature parameter MUST be excluded.")
         if (isset($params['oauth_signature'])) {
             unset($params['oauth_signature']);
         }
-
+        
         return OAuthUtil::build_http_query($params);
     }
-
+    
     /**
      * Returns the base string of this request
      *
@@ -191,12 +191,12 @@ class OAuthRequest
             $this->get_normalized_http_url(),
             $this->get_signable_parameters()
         );
-
+        
         $parts = OAuthUtil::urlencode_rfc3986($parts);
-
+        
         return implode('&', $parts);
     }
-
+    
     /**
      * just uppercases the http method
      */
@@ -204,7 +204,7 @@ class OAuthRequest
     {
         return strtoupper($this->http_method);
     }
-
+    
     /**
      * parses the url and rebuilds it to be
      * scheme://host/path
@@ -212,31 +212,31 @@ class OAuthRequest
     public function get_normalized_http_url()
     {
         $parts = parse_url($this->http_url);
-
+        
         $scheme = (isset($parts['scheme'])) ? $parts['scheme'] : 'http';
-        $port = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
-        $host = (isset($parts['host'])) ? strtolower($parts['host']) : '';
-        $path = (isset($parts['path'])) ? $parts['path'] : '';
-
+        $port   = (isset($parts['port'])) ? $parts['port'] : (($scheme == 'https') ? '443' : '80');
+        $host   = (isset($parts['host'])) ? strtolower($parts['host']) : '';
+        $path   = (isset($parts['path'])) ? $parts['path'] : '';
+        
         if (($scheme == 'https' && $port != '443') || ($scheme == 'http' && $port != '80')) {
             $host = "$host:$port";
         }
         return "$scheme://$host$path";
     }
-
+    
     /**
      * builds a url usable for a GET request
      */
     public function to_url()
     {
         $post_data = $this->to_postdata();
-        $out = $this->get_normalized_http_url();
+        $out       = $this->get_normalized_http_url();
         if ($post_data) {
             $out .= '?' . $post_data;
         }
         return $out;
     }
-
+    
     /**
      * builds the data one would send in a POST request
      */
@@ -249,17 +249,17 @@ class OAuthRequest
      * builds the Authorization: header
      * @param null $realm
      * @return array
-     */
+*/
     public function to_header($realm = null)
     {
         $first = true;
         if ($realm) {
-            $out = 'OAuth realm="' . OAuthUtil::urlencode_rfc3986($realm) . '"';
+            $out   = 'OAuth realm="' . OAuthUtil::urlencode_rfc3986($realm) . '"';
             $first = false;
         } else {
             $out = 'OAuth';
         }
-
+        
         foreach ($this->parameters as $k => $v) {
             if (substr($k, 0, 5) != "oauth") {
                 continue;
@@ -323,9 +323,9 @@ class OAuthRequest
      */
     private static function generate_nonce()
     {
-        $mt = microtime();
+        $mt   = microtime();
         $rand = mt_rand();
-
+        
         return md5($mt . $rand); // md5s look nicer than numbers
     }
 }

--- a/src/Thirdparty/OAuth/OAuthSignatureMethod.php
+++ b/src/Thirdparty/OAuth/OAuthSignatureMethod.php
@@ -15,34 +15,34 @@ namespace Hybridauth\Thirdparty\OAuth;
 abstract class OAuthSignatureMethod
 {
     /**
-     * Needs to return the name of the Signature Method (ie HMAC-SHA1)
-     *
-     * @return string
-     */
+    * Needs to return the name of the Signature Method (ie HMAC-SHA1)
+    *
+    * @return string
+    */
     abstract public function get_name();
 
     /**
-     * Build up the signature
-     * NOTE: The output of this function MUST NOT be urlencoded.
-     * the encoding is handled in OAuthRequest when the final
-     * request is serialized
-     *
-     * @param OAuthRequest $request
-     * @param OAuthConsumer $consumer
-     * @param OAuthToken $token
-     * @return string
-     */
+    * Build up the signature
+    * NOTE: The output of this function MUST NOT be urlencoded.
+    * the encoding is handled in OAuthRequest when the final
+    * request is serialized
+    *
+    * @param OAuthRequest $request
+    * @param OAuthConsumer $consumer
+    * @param OAuthToken $token
+    * @return string
+    */
     abstract public function build_signature($request, $consumer, $token);
 
     /**
-     * Verifies that a given signature is correct
-     *
-     * @param OAuthRequest $request
-     * @param OAuthConsumer $consumer
-     * @param OAuthToken $token
-     * @param string $signature
-     * @return bool
-     */
+    * Verifies that a given signature is correct
+    *
+    * @param OAuthRequest $request
+    * @param OAuthConsumer $consumer
+    * @param OAuthToken $token
+    * @param string $signature
+    * @return bool
+    */
     public function check_signature($request, $consumer, $token, $signature)
     {
         $built = $this->build_signature($request, $consumer, $token);
@@ -58,7 +58,7 @@ abstract class OAuthSignatureMethod
 
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
-        for ($i = 0; $i < strlen($signature); $i++) {
+        for ($i = 0; $i < strlen($signature); $i ++) {
             $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 

--- a/src/Thirdparty/OAuth/OAuthSignatureMethod.php
+++ b/src/Thirdparty/OAuth/OAuthSignatureMethod.php
@@ -15,34 +15,34 @@ namespace Hybridauth\Thirdparty\OAuth;
 abstract class OAuthSignatureMethod
 {
     /**
-    * Needs to return the name of the Signature Method (ie HMAC-SHA1)
-    *
-    * @return string
-    */
+     * Needs to return the name of the Signature Method (ie HMAC-SHA1)
+     *
+     * @return string
+     */
     abstract public function get_name();
 
     /**
-    * Build up the signature
-    * NOTE: The output of this function MUST NOT be urlencoded.
-    * the encoding is handled in OAuthRequest when the final
-    * request is serialized
-    *
-    * @param OAuthRequest $request
-    * @param OAuthConsumer $consumer
-    * @param OAuthToken $token
-    * @return string
-    */
+     * Build up the signature
+     * NOTE: The output of this function MUST NOT be urlencoded.
+     * the encoding is handled in OAuthRequest when the final
+     * request is serialized
+     *
+     * @param OAuthRequest $request
+     * @param OAuthConsumer $consumer
+     * @param OAuthToken $token
+     * @return string
+     */
     abstract public function build_signature($request, $consumer, $token);
 
     /**
-    * Verifies that a given signature is correct
-    *
-    * @param OAuthRequest $request
-    * @param OAuthConsumer $consumer
-    * @param OAuthToken $token
-    * @param string $signature
-    * @return bool
-    */
+     * Verifies that a given signature is correct
+     *
+     * @param OAuthRequest $request
+     * @param OAuthConsumer $consumer
+     * @param OAuthToken $token
+     * @param string $signature
+     * @return bool
+     */
     public function check_signature($request, $consumer, $token, $signature)
     {
         $built = $this->build_signature($request, $consumer, $token);
@@ -58,7 +58,7 @@ abstract class OAuthSignatureMethod
 
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
-        for ($i = 0; $i < strlen($signature); $i ++) {
+        for ($i = 0; $i < strlen($signature); $i++) {
             $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 

--- a/src/Thirdparty/OAuth/OAuthSignatureMethodHMACSHA1.php
+++ b/src/Thirdparty/OAuth/OAuthSignatureMethodHMACSHA1.php
@@ -34,11 +34,11 @@ class OAuthSignatureMethodHMACSHA1 extends OAuthSignatureMethod
         $base_string = $request->get_signature_base_string();
         $request->base_string = $base_string;
 
-        $key_parts = array( $consumer->secret, $token ? $token->secret : '' );
+        $key_parts = array($consumer->secret, $token ? $token->secret : '');
 
         $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
         $key = implode('&', $key_parts);
-        
+
         return base64_encode(hash_hmac('sha1', $base_string, $key, true));
     }
 }

--- a/src/Thirdparty/OAuth/OAuthSignatureMethodHMACSHA1.php
+++ b/src/Thirdparty/OAuth/OAuthSignatureMethodHMACSHA1.php
@@ -34,11 +34,11 @@ class OAuthSignatureMethodHMACSHA1 extends OAuthSignatureMethod
         $base_string = $request->get_signature_base_string();
         $request->base_string = $base_string;
 
-        $key_parts = array($consumer->secret, $token ? $token->secret : '');
+        $key_parts = array( $consumer->secret, $token ? $token->secret : '' );
 
         $key_parts = OAuthUtil::urlencode_rfc3986($key_parts);
         $key = implode('&', $key_parts);
-
+        
         return base64_encode(hash_hmac('sha1', $base_string, $key, true));
     }
 }

--- a/src/Thirdparty/OAuth/OAuthUtil.php
+++ b/src/Thirdparty/OAuth/OAuthUtil.php
@@ -32,7 +32,7 @@ class OAuthUtil
             return '';
         }
     }
-
+    
     // This decode function isn't taking into consideration the above
     // modifications to the encoding process. However, this method doesn't
     // seem to be used anywhere so leaving it as is.
@@ -45,7 +45,7 @@ class OAuthUtil
     {
         return urldecode($string);
     }
-
+    
     // Utility function for turning the Authorization: header into
     // parameters, has to do some unescaping
     // Can filter out any non-oauth parameters if needed (default behaviour)
@@ -70,7 +70,7 @@ class OAuthUtil
         }
         return $params;
     }
-
+    
     // helper to try to sort out headers for people who aren't running apache
 
     /**
@@ -82,14 +82,14 @@ class OAuthUtil
             // we need this to get the actual Authorization: header
             // because apache tends to tell us it doesn't exist
             $headers = apache_request_headers();
-
+            
             // sanitize the output of apache_request_headers because
             // we always want the keys to be Cased-Like-This and arh()
             // returns the headers in the same case as they are in the
             // request
             $out = array();
             foreach ($headers as $key => $value) {
-                $key = str_replace(" ", "-", ucwords(strtolower(str_replace("-", " ", $key))));
+                $key       = str_replace(" ", "-", ucwords(strtolower(str_replace("-", " ", $key))));
                 $out[$key] = $value;
             }
         } else {
@@ -102,13 +102,13 @@ class OAuthUtil
             if (isset($_ENV['CONTENT_TYPE'])) {
                 $out['Content-Type'] = $_ENV['CONTENT_TYPE'];
             }
-
+            
             foreach ($_SERVER as $key => $value) {
                 if (substr($key, 0, 5) == "HTTP_") {
                     // this is chaos, basically it is just there to capitalize the first
                     // letter of every word that is not an initial HTTP and strip HTTP
                     // code from przemek
-                    $key = str_replace(" ", "-", ucwords(strtolower(str_replace("_", " ", substr($key, 5)))));
+                    $key       = str_replace(" ", "-", ucwords(strtolower(str_replace("_", " ", substr($key, 5)))));
                     $out[$key] = $value;
                 }
             }
@@ -129,19 +129,19 @@ class OAuthUtil
         if (!isset($input) || !$input) {
             return array();
         }
-
+        
         $pairs = explode('&', $input);
-
+        
         $parsed_parameters = array();
         foreach ($pairs as $pair) {
-            $split = explode('=', $pair, 2);
+            $split     = explode('=', $pair, 2);
             $parameter = OAuthUtil::urldecode_rfc3986($split[0]);
-            $value = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
-
+            $value     = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
+            
             if (isset($parsed_parameters[$parameter])) {
                 // We have already recieved parameter(s) with this name, so add to the list
                 // of parameters with this name
-
+                
                 if (is_scalar($parsed_parameters[$parameter])) {
                     // This is the first duplicate, so transform scalar (string) into an array
                     // so we can add the duplicates
@@ -149,7 +149,7 @@ class OAuthUtil
                         $parsed_parameters[$parameter]
                     );
                 }
-
+                
                 $parsed_parameters[$parameter][] = $value;
             } else {
                 $parsed_parameters[$parameter] = $value;
@@ -168,16 +168,16 @@ class OAuthUtil
         if (!$params) {
             return '';
         }
-
+        
         // Urlencode both keys and values
-        $keys = OAuthUtil::urlencode_rfc3986(array_keys($params));
+        $keys   = OAuthUtil::urlencode_rfc3986(array_keys($params));
         $values = OAuthUtil::urlencode_rfc3986(array_values($params));
         $params = array_combine($keys, $values);
-
+        
         // Parameters are sorted by name, using lexicographical byte value ordering.
         // Ref: Spec: 9.1.1 (1)
         uksort($params, 'strcmp');
-
+        
         $pairs = array();
         foreach ($params as $parameter => $value) {
             if (is_array($value)) {

--- a/src/Thirdparty/OAuth/OAuthUtil.php
+++ b/src/Thirdparty/OAuth/OAuthUtil.php
@@ -32,7 +32,7 @@ class OAuthUtil
             return '';
         }
     }
-    
+
     // This decode function isn't taking into consideration the above
     // modifications to the encoding process. However, this method doesn't
     // seem to be used anywhere so leaving it as is.
@@ -45,7 +45,7 @@ class OAuthUtil
     {
         return urldecode($string);
     }
-    
+
     // Utility function for turning the Authorization: header into
     // parameters, has to do some unescaping
     // Can filter out any non-oauth parameters if needed (default behaviour)
@@ -70,7 +70,7 @@ class OAuthUtil
         }
         return $params;
     }
-    
+
     // helper to try to sort out headers for people who aren't running apache
 
     /**
@@ -82,14 +82,14 @@ class OAuthUtil
             // we need this to get the actual Authorization: header
             // because apache tends to tell us it doesn't exist
             $headers = apache_request_headers();
-            
+
             // sanitize the output of apache_request_headers because
             // we always want the keys to be Cased-Like-This and arh()
             // returns the headers in the same case as they are in the
             // request
             $out = array();
             foreach ($headers as $key => $value) {
-                $key       = str_replace(" ", "-", ucwords(strtolower(str_replace("-", " ", $key))));
+                $key = str_replace(" ", "-", ucwords(strtolower(str_replace("-", " ", $key))));
                 $out[$key] = $value;
             }
         } else {
@@ -102,13 +102,13 @@ class OAuthUtil
             if (isset($_ENV['CONTENT_TYPE'])) {
                 $out['Content-Type'] = $_ENV['CONTENT_TYPE'];
             }
-            
+
             foreach ($_SERVER as $key => $value) {
                 if (substr($key, 0, 5) == "HTTP_") {
                     // this is chaos, basically it is just there to capitalize the first
                     // letter of every word that is not an initial HTTP and strip HTTP
                     // code from przemek
-                    $key       = str_replace(" ", "-", ucwords(strtolower(str_replace("_", " ", substr($key, 5)))));
+                    $key = str_replace(" ", "-", ucwords(strtolower(str_replace("_", " ", substr($key, 5)))));
                     $out[$key] = $value;
                 }
             }
@@ -129,19 +129,19 @@ class OAuthUtil
         if (!isset($input) || !$input) {
             return array();
         }
-        
+
         $pairs = explode('&', $input);
-        
+
         $parsed_parameters = array();
         foreach ($pairs as $pair) {
-            $split     = explode('=', $pair, 2);
+            $split = explode('=', $pair, 2);
             $parameter = OAuthUtil::urldecode_rfc3986($split[0]);
-            $value     = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
-            
+            $value = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
+
             if (isset($parsed_parameters[$parameter])) {
                 // We have already recieved parameter(s) with this name, so add to the list
                 // of parameters with this name
-                
+
                 if (is_scalar($parsed_parameters[$parameter])) {
                     // This is the first duplicate, so transform scalar (string) into an array
                     // so we can add the duplicates
@@ -149,7 +149,7 @@ class OAuthUtil
                         $parsed_parameters[$parameter]
                     );
                 }
-                
+
                 $parsed_parameters[$parameter][] = $value;
             } else {
                 $parsed_parameters[$parameter] = $value;
@@ -168,16 +168,16 @@ class OAuthUtil
         if (!$params) {
             return '';
         }
-        
+
         // Urlencode both keys and values
-        $keys   = OAuthUtil::urlencode_rfc3986(array_keys($params));
+        $keys = OAuthUtil::urlencode_rfc3986(array_keys($params));
         $values = OAuthUtil::urlencode_rfc3986(array_values($params));
         $params = array_combine($keys, $values);
-        
+
         // Parameters are sorted by name, using lexicographical byte value ordering.
         // Ref: Spec: 9.1.1 (1)
         uksort($params, 'strcmp');
-        
+
         $pairs = array();
         foreach ($params as $parameter => $value) {
             if (is_array($value)) {

--- a/src/User/Activity.php
+++ b/src/User/Activity.php
@@ -15,55 +15,55 @@ use Hybridauth\Exception\UnexpectedValueException;
 final class Activity
 {
     /**
-    * activity id on the provider side, usually given as integer
-    *
-    * @var string
-    */
+     * activity id on the provider side, usually given as integer
+     *
+     * @var string
+     */
     public $id = null;
 
     /**
-    * activity date of creation
-    *
-    * @var string
-    */
+     * activity date of creation
+     *
+     * @var string
+     */
     public $date = null;
 
     /**
-    * activity content as a string
-    *
-    * @var string
-    */
+     * activity content as a string
+     *
+     * @var string
+     */
     public $text = null;
 
     /**
-    * user who created the activity
-    *
-    * @var object
-    */
+     * user who created the activity
+     *
+     * @var object
+     */
     public $user = null;
 
     /**
-    *
-    */
+     *
+     */
     public function __construct()
     {
         $this->user = new \stdClass();
 
         // typically, we should have a few information about the user who created the event from social apis
-        $this->user->identifier  = null;
+        $this->user->identifier = null;
         $this->user->displayName = null;
-        $this->user->profileURL  = null;
-        $this->user->photoURL    = null;
+        $this->user->profileURL = null;
+        $this->user->photoURL = null;
     }
 
     /**
      * Prevent the providers adapters from adding new fields.
      *
-     * @var mixed $value
-     *
+     * @throws UnexpectedValueException
      * @var string $name
      *
-     * @throws UnexpectedValueException
+     * @var mixed $value
+     *
      */
     public function __set($name, $value)
     {

--- a/src/User/Contact.php
+++ b/src/User/Contact.php
@@ -15,62 +15,62 @@ use Hybridauth\Exception\UnexpectedValueException;
 final class Contact
 {
     /**
-    * The Unique contact user ID
-    *
-    * @var string
-    */
+     * The Unique contact user ID
+     *
+     * @var string
+     */
     public $identifier = null;
 
     /**
-    * User website, blog, web page
-    *
-    * @var string
-    */
+     * User website, blog, web page
+     *
+     * @var string
+     */
     public $webSiteURL = null;
 
     /**
-    * URL link to profile page on the IDp web site
-    *
-    * @var string
-    */
+     * URL link to profile page on the IDp web site
+     *
+     * @var string
+     */
     public $profileURL = null;
 
     /**
-    * URL link to user photo or avatar
-    *
-    * @var string
-    */
+     * URL link to user photo or avatar
+     *
+     * @var string
+     */
     public $photoURL = null;
 
     /**
-    * User displayName provided by the IDp or a concatenation of first and last name
-    *
-    * @var string
-    */
+     * User displayName provided by the IDp or a concatenation of first and last name
+     *
+     * @var string
+     */
     public $displayName = null;
 
     /**
-    * A short about_me
-    *
-    * @var string
-    */
+     * A short about_me
+     *
+     * @var string
+     */
     public $description = null;
 
     /**
-    * User email. Not all of IDp grant access to the user email
-    *
-    * @var string
-    */
+     * User email. Not all of IDp grant access to the user email
+     *
+     * @var string
+     */
     public $email = null;
 
     /**
-    * Prevent the providers adapters from adding new fields.
-    *
-    * @param string $name
-    * @param mixed $value
-    *
-    * @throws UnexpectedValueException
-    */
+     * Prevent the providers adapters from adding new fields.
+     *
+     * @param string $name
+     * @param mixed $value
+     *
+     * @throws UnexpectedValueException
+     */
     public function __set($name, $value)
     {
         throw new UnexpectedValueException(sprintf('Adding new property "%s" to %s is not allowed.', $name, __CLASS__));

--- a/src/User/Profile.php
+++ b/src/User/Profile.php
@@ -15,174 +15,174 @@ use Hybridauth\Exception\UnexpectedValueException;
 final class Profile
 {
     /**
-    * The Unique user's ID on the connected provider
-    *
-    * @var integer|null
-    */
+     * The Unique user's ID on the connected provider
+     *
+     * @var int|null
+     */
     public $identifier = null;
 
     /**
-    * User website, blog, web page
-    *
-    * @var string|null
-    */
+     * User website, blog, web page
+     *
+     * @var string|null
+     */
     public $webSiteURL = null;
 
     /**
-    * URL link to profile page on the IDp web site
-    *
-    * @var string|null
-    */
+     * URL link to profile page on the IDp web site
+     *
+     * @var string|null
+     */
     public $profileURL = null;
 
     /**
-    * URL link to user photo or avatar
-    *
-    * @var string|null
-    */
+     * URL link to user photo or avatar
+     *
+     * @var string|null
+     */
     public $photoURL = null;
 
     /**
-    * User displayName provided by the IDp or a concatenation of first and last name.
-    *
-    * @var string|null
-    */
+     * User displayName provided by the IDp or a concatenation of first and last name.
+     *
+     * @var string|null
+     */
     public $displayName = null;
 
     /**
-    * A short about_me
-    *
-    * @var string|null
-    */
+     * A short about_me
+     *
+     * @var string|null
+     */
     public $description = null;
 
     /**
-    * User's first name
-    *
-    * @var string|null
-    */
+     * User's first name
+     *
+     * @var string|null
+     */
     public $firstName = null;
 
     /**
-    * User's last name
-    *
-    * @var string|null
-    */
+     * User's last name
+     *
+     * @var string|null
+     */
     public $lastName = null;
 
     /**
-    * male or female
-    *
-    * @var string|null
-    */
+     * male or female
+     *
+     * @var string|null
+     */
     public $gender = null;
 
     /**
-    * Language
-    *
-    * @var string|null
-    */
+     * Language
+     *
+     * @var string|null
+     */
     public $language = null;
 
     /**
-    * User age, we don't calculate it. we return it as is if the IDp provide it.
-    *
-    * @var integer|null
-    */
+     * User age, we don't calculate it. we return it as is if the IDp provide it.
+     *
+     * @var int|null
+     */
     public $age = null;
 
     /**
-    * User birth Day
-    *
-    * @var integer|null
-    */
+     * User birth Day
+     *
+     * @var int|null
+     */
     public $birthDay = null;
 
     /**
-    * User birth Month
-    *
-    * @var integer|null
-    */
+     * User birth Month
+     *
+     * @var int|null
+     */
     public $birthMonth = null;
 
     /**
-    * User birth Year
-    *
-    * @var integer|null
-    */
+     * User birth Year
+     *
+     * @var int|null
+     */
     public $birthYear = null;
 
     /**
-    * User email. Note: not all of IDp grant access to the user email
-    *
-    * @var string|null
-    */
+     * User email. Note: not all of IDp grant access to the user email
+     *
+     * @var string|null
+     */
     public $email = null;
 
     /**
-    * Verified user email. Note: not all of IDp grant access to verified user email
-    *
-    * @var string|null
-    */
+     * Verified user email. Note: not all of IDp grant access to verified user email
+     *
+     * @var string|null
+     */
     public $emailVerified = null;
 
     /**
-    * Phone number
-    *
-    * @var string|null
-    */
+     * Phone number
+     *
+     * @var string|null
+     */
     public $phone = null;
 
     /**
-    * Complete user address
-    *
-    * @var string|null
-    */
+     * Complete user address
+     *
+     * @var string|null
+     */
     public $address = null;
 
     /**
-    * User country
-    *
-    * @var string|null
-    */
+     * User country
+     *
+     * @var string|null
+     */
     public $country = null;
 
     /**
-    * Region
-    *
-    * @var string|null
-    */
+     * Region
+     *
+     * @var string|null
+     */
     public $region = null;
 
     /**
-    * City
-    *
-    * @var string|null
-    */
+     * City
+     *
+     * @var string|null
+     */
     public $city = null;
 
     /**
-    * Postal code
-    *
-    * @var string|null
-    */
+     * Postal code
+     *
+     * @var string|null
+     */
     public $zip = null;
 
     /**
-    * An extra data which is related to the user
-    *
-    * @var array
-    */
+     * An extra data which is related to the user
+     *
+     * @var array
+     */
     public $data = [];
 
     /**
-    * Prevent the providers adapters from adding new fields.
-    *
-    * @var string $name
-    * @var mixed  $value
-    *
-    * @throws UnexpectedValueException
-    */
+     * Prevent the providers adapters from adding new fields.
+     *
+     * @throws UnexpectedValueException
+     * @var mixed $value
+     *
+     * @var string $name
+     */
     public function __set($name, $value)
     {
         throw new UnexpectedValueException(sprintf('Adding new property "%s" to %s is not allowed.', $name, __CLASS__));

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -27,8 +27,8 @@ spl_autoload_register(
 
         // base directory for the namespace prefix.
         $base_dir = __DIR__;   // By default, it points to this same folder.
-                               // You may change this path if having trouble detecting the path to
-                               // the source files.
+        // You may change this path if having trouble detecting the path to
+        // the source files.
 
         // does the class use the namespace prefix?
         $len = strlen($prefix);
@@ -43,7 +43,7 @@ spl_autoload_register(
         // replace the namespace prefix with the base directory, replace namespace
         // separators with directory separators in the relative class name, append
         // with .php
-        $file = $base_dir.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $relative_class).'.php';
+        $file = $base_dir . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $relative_class) . '.php';
 
         // if the file exists, require it
         if (file_exists($file)) {

--- a/tests/Data/CollectionTest.php
+++ b/tests/Data/CollectionTest.php
@@ -32,7 +32,7 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
 
     public function test_instance_of()
     {
-        $collection = new Collection;
+        $collection = new Collection();
 
         $this->assertInstanceOf('\\Hybridauth\\Data\\Collection', $collection);
     }
@@ -49,8 +49,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @covers Collection::exists
-    */
+     * @covers Collection::exists
+     */
     public function test_exists()
     {
         $array = $this->some_random_array();
@@ -73,8 +73,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @covers Collection::get
-    */
+     * @covers Collection::get
+     */
     public function test_get()
     {
         $array = $this->some_random_array();
@@ -97,8 +97,8 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @covers Collection::filter
-    */
+     * @covers Collection::filter
+     */
     public function test_filter()
     {
         $array = $this->some_random_array();

--- a/tests/Data/ParserTest.php
+++ b/tests/Data/ParserTest.php
@@ -8,18 +8,18 @@ class ParserTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {
-        $parser = new Parser;
+        $parser = new Parser();
 
         $this->assertInstanceOf('\\Hybridauth\\Data\\Parser', $parser);
     }
 
     /**
-    * @covers Parser::parse
-    * @covers Parser::parseJson
-    */
+     * @covers Parser::parse
+     * @covers Parser::parseJson
+     */
     public function test_parser_json()
     {
-        $parser = new Parser;
+        $parser = new Parser();
 
         $object = new \StdClass();
         $object->id = 69;
@@ -45,12 +45,12 @@ class ParserTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @covers Parser::parse
-    * @covers Parser::parseQueryString
-    */
+     * @covers Parser::parse
+     * @covers Parser::parseQueryString
+     */
     public function test_parser_querystring()
     {
-        $parser = new Parser;
+        $parser = new Parser();
 
         $object = new \StdClass();
         $object->id = 69;

--- a/tests/Storage/SessionTest.php
+++ b/tests/Storage/SessionTest.php
@@ -11,38 +11,38 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     public function some_random_session_data()
     {
         return [
-            [ 'foo', 'bar' ],
-            [  1234, 'bar' ],
-            [ 'foo',  1234 ],
+            ['foo', 'bar'],
+            [1234, 'bar'],
+            ['foo', 1234],
 
-            [ 'Bonjour', '안녕하세요' ],
-            [ 'ஹலோ'   , 'Γεια σας' ],
+            ['Bonjour', '안녕하세요'],
+            ['ஹலோ', 'Γεια σας'],
 
-            [ 'array', [ 1, 2, 3 ] ],
-            [ 'string',  json_encode($this) ],
-            [ 'object', $this ],
+            ['array', [1, 2, 3]],
+            ['string', json_encode($this)],
+            ['object', $this],
 
-            [ 'provider.token.request_token', '9DYPEJ&qhvhP3eJ!' ],
-            [ 'provider.token.oauth_token', '80359084-clg1DEtxQF3wstTcyUdHF3wsdHM' ],
-            [ 'provider.token.oauth_token_secret', 'qiHTi1znz6qiH3tTcyUdHnz6qiH3tTcyUdH3xW3wsDvV08e' ],
+            ['provider.token.request_token', '9DYPEJ&qhvhP3eJ!'],
+            ['provider.token.oauth_token', '80359084-clg1DEtxQF3wstTcyUdHF3wsdHM'],
+            ['provider.token.oauth_token_secret', 'qiHTi1znz6qiH3tTcyUdHnz6qiH3tTcyUdH3xW3wsDvV08e'],
         ];
     }
 
     public function test_instance_of()
     {
-        $storage = new Session;
+        $storage = new Session();
 
         $this->assertInstanceOf('\\Hybridauth\\Storage\\StorageInterface', $storage);
     }
 
     /**
-    * @dataProvider some_random_session_data
-    * @covers Session::get
-    * @covers Session::set
-    */
+     * @dataProvider some_random_session_data
+     * @covers       Session::get
+     * @covers       Session::set
+     */
     public function test_set_and_get_data($key, $value)
     {
-        $storage = new Session;
+        $storage = new Session();
 
         $storage->set($key, $value);
 
@@ -52,12 +52,12 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @dataProvider some_random_session_data
-    * @covers Session::delete
-    */
+     * @dataProvider some_random_session_data
+     * @covers       Session::delete
+     */
     public function test_delete_data($key, $value)
     {
-        $storage = new Session;
+        $storage = new Session();
 
         $storage->set($key, $value);
 
@@ -69,12 +69,12 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @dataProvider some_random_session_data
-    * @covers Session::clear
-    */
+     * @dataProvider some_random_session_data
+     * @covers       Session::clear
+     */
     public function test_clear_data($key, $value)
     {
-        $storage = new Session;
+        $storage = new Session();
 
         $storage->set($key, $value);
 
@@ -86,19 +86,19 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @covers Session::clear
-    */
+     * @covers Session::clear
+     */
     public function test_clear_data_bulk()
     {
-        $storage = new Session;
+        $storage = new Session();
 
-        foreach ((array) $this->some_random_session_data() as $key => $value) {
+        foreach ((array)$this->some_random_session_data() as $key => $value) {
             $storage->set($key, $value);
         }
 
         $storage->clear();
 
-        foreach ((array) $this->some_random_session_data() as $key => $value) {
+        foreach ((array)$this->some_random_session_data() as $key => $value) {
             $data = $storage->get($key);
 
             $this->assertNull($data);
@@ -106,12 +106,12 @@ class SessionTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * @dataProvider some_random_session_data
-    * @covers Session::deleteMatch
-    */
+     * @dataProvider some_random_session_data
+     * @covers       Session::deleteMatch
+     */
     public function test_delete_match_data($key, $value)
     {
-        $storage = new Session;
+        $storage = new Session();
 
         $storage->set($key, $value);
 

--- a/tests/User/ActivityTest.php
+++ b/tests/User/ActivityTest.php
@@ -8,7 +8,7 @@ class ActivityTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {
-        $activity = new Activity;
+        $activity = new Activity();
 
         $this->assertInstanceOf('\\Hybridauth\\User\\Activity', $activity);
     }
@@ -23,7 +23,7 @@ class ActivityTest extends \PHPUnit\Framework\TestCase
 
     public function test_set_attributes()
     {
-        $activity = new Activity;
+        $activity = new Activity();
 
         $activity->id = true;
         $activity->date = true;
@@ -36,7 +36,7 @@ class ActivityTest extends \PHPUnit\Framework\TestCase
      */
     public function test_property_overloading()
     {
-        $activity = new Activity;
+        $activity = new Activity();
         $activity->slug = true;
     }
 }

--- a/tests/User/ContactTest.php
+++ b/tests/User/ContactTest.php
@@ -8,7 +8,7 @@ class ContactTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {
-        $contact = new Contact;
+        $contact = new Contact();
 
         $this->assertInstanceOf('\\Hybridauth\\User\\Contact', $contact);
     }
@@ -26,7 +26,7 @@ class ContactTest extends \PHPUnit\Framework\TestCase
 
     public function test_set_attributes()
     {
-        $contact = new Contact;
+        $contact = new Contact();
 
         $contact->identifier = true;
         $contact->webSiteURL = true;
@@ -42,7 +42,7 @@ class ContactTest extends \PHPUnit\Framework\TestCase
      */
     public function test_property_overloading()
     {
-        $contact = new Contact;
+        $contact = new Contact();
         $contact->slug = true;
     }
 }

--- a/tests/User/ProfileTest.php
+++ b/tests/User/ProfileTest.php
@@ -8,7 +8,7 @@ class ProfileTest extends \PHPUnit\Framework\TestCase
 {
     public function test_instance_of()
     {
-        $profile = new Profile;
+        $profile = new Profile();
 
         $this->assertInstanceOf('\\Hybridauth\\User\\Profile', $profile);
     }
@@ -41,7 +41,7 @@ class ProfileTest extends \PHPUnit\Framework\TestCase
 
     public function test_set_attributes()
     {
-        $profile = new Profile;
+        $profile = new Profile();
 
         $profile->identifier = true;
         $profile->webSiteURL = true;
@@ -72,7 +72,7 @@ class ProfileTest extends \PHPUnit\Framework\TestCase
      */
     public function test_property_overloading()
     {
-        $profile = new Profile;
+        $profile = new Profile();
         $profile->slug = true;
     }
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1221
| Patch: Bug Fix?          | Kinda
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

Hybridauth is documented to be using PSR-2, but in many cases it is not. Fix this consistently across the whole code base, except from third-party code.

This was done using PHPStorm. I tweaked it a little bit to restrict it to PHP, and to make sure phpcs still passes.

Obviously this is a big commit.