### PR TITLE
Correct Facebook API (v.8.0, current API)

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -53,7 +53,7 @@ class Facebook extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $apiBaseUrl = 'https://graph.facebook.com/v6.0/';
+    protected $apiBaseUrl = 'https://graph.facebook.com/v8.0/';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Correct Facebook API (v.8.0, current API)

- Introducing API Graph v8.0: https://developers.facebook.com/blog/post/2020/08/04/Introducing-graph-v8-marketing-api-v8/
