### PR TITLE
Fix (only) error coming up in PHP8 linting, with 3rd party OpenID lib

### DIFF
--- a/src/Thirdparty/OpenID/LightOpenID.php
+++ b/src/Thirdparty/OpenID/LightOpenID.php
@@ -274,7 +274,7 @@ class LightOpenID
      * @return array|bool|string
      * @throws ErrorException
      */
-    protected function request_curl($url, $method='GET', $params=array(), $update_claimed_id)
+    protected function request_curl($url, $method='GET', $params=array(), $update_claimed_id=false)
     {
         $params = http_build_query($params, '', '&');
         $curl = curl_init($url . ($method == 'GET' && $params ? '?' . $params : ''));
@@ -419,7 +419,7 @@ class LightOpenID
      * @return array|false|string
      * @throws ErrorException
      */
-    protected function request_streams($url, $method='GET', $params=array(), $update_claimed_id)
+    protected function request_streams($url, $method='GET', $params=array(), $update_claimed_id=false)
     {
         if (!$this->hostExists($url)) {
             throw new ErrorException("Could not connect to $url.", 404);


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

There's a PHP8 compat issue in `src/Thirdparty/OpenID/LightOpenID.php`.
