### PR TITLE
Implement new Atom API

### DIFF
--- a/src/Adapter/AtomInterface.php
+++ b/src/Adapter/AtomInterface.php
@@ -1,0 +1,170 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Adapter;
+
+use Hybridauth\Atom\Category;
+
+/**
+ * AtomInterface is a standardized interface that roughly corresponds with Atom.
+ * In the ideal world every provider would implement AtomPub, or at least Atom or RSS feeds.
+ * In the real world, they have a disincentive to be cross-compatible,
+ * so we must make them cross compatible via our middleware.
+ * The interface is generic enough to work for
+ * feeds/streams, content repositories, and file systems.
+ */
+interface AtomInterface
+{
+    /**
+     * Build an Atom feed.
+     *
+     * @param \Hybridauth\Atom\Filter $filter Filters
+     * @param bool $trulyValid Try extra hard to be valid, even if it makes things clunky
+     *
+     * @return string Atom feed
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function buildAtomFeed($filters = null, $trulyValid = false);
+
+    /**
+     * Get a list of atoms matching the filters (if given), in recency order.
+     *
+     * @param \Hybridauth\Atom\Filter $filter Filters
+     *
+     * @return array A pair: Array of atoms, Whether there were results [needed in case all were filtered out]
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function getAtoms($filter = null);
+
+    /**
+     * Get all details of an individual atom.
+     *
+     * @param string $identifier Atom ID
+     *
+     * @return \Hybridauth\Atom\Atom Atom
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function getAtomFull($identifier);
+
+    /**
+     * Get all details of an individual atom, by URL.
+     * Useful for oEmbed-style link display.
+     *
+     * @param string $url URL
+     *
+     * @return ?\Hybridauth\Atom\Atom Atom (or null if we do not recognise the URL)
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function getAtomFullFromURL($url);
+
+    /**
+     * Get oEmbed from a URL.
+     * Only bother implementing for providers that have OAuth behind a a key.
+     * Often useful as a fallback for providers whose APIs don't allow getAtomFullFromURL.
+     *
+     * @param string $url URL
+     * @param array $params Map of extra oEmbed parameters to include
+     *
+     * @return ?object oEmbed data (or null if not supported)
+     */
+    public function getOEmbedFromURL($url, $params = []);
+
+    /**
+     * Save an atom.
+     * If the ID element of the atom is null then it will be an insert,
+     * otherwise it will depend if an existing ID exists.
+     *
+     * @param \Hybridauth\Atom\Atom $atom Atom
+     * @param array $messages List of non-fatal error messages returned by reference
+     *
+     * @return string Atom ID
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\InvalidArgumentException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function saveAtom($atom, &$messages = []);
+
+    /**
+     * Delete an atom.
+     *
+     * @param string $identifier Atom ID
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function deleteAtom($identifier);
+
+    /**
+     * Get a list of categories.
+     *
+     * @return array List of Category objects; array keys should be category identifiers
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function getCategories();
+
+    /**
+     * Save a category.
+     * If the ID element of the category is null then it will be an insert,
+     * otherwise it will depend if an existing ID exists.
+     *
+     * @param Category $category Category
+     *
+     * @return string Category ID
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function saveCategory($category);
+
+    /**
+     * Delete a category.
+     *
+     * @param string $identifier Category ID
+     *
+     * @throws \Hybridauth\Exception\NotImplementedException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     * @throws \Hybridauth\Exception\UnexpectedApiResponseException
+     */
+    public function deleteCategory($identifier);
+}

--- a/src/Atom/Atom.php
+++ b/src/Atom/Atom.php
@@ -1,0 +1,111 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Atom;
+
+/**
+ * An atom, which represents a content entry on a provider.
+ * Roughly follows the conventions of the Atom data format (https://tools.ietf.org/html/rfc4287).
+ * When saved, code will do its best with what is has, typically reducing to what a provider can support.
+ * It is not designed to be round-trip safe - retrieval and saving are optimized independently.
+ * We are optimizing for user-experience, not trying to cram things in.
+ */
+class Atom
+{
+    /**
+     * Identifier.
+     * Null means auto-set for a new one, no existing one will be null.
+     *
+     * @var ?string
+     */
+    public $identifier;
+
+    /**
+     * Whether this is an incomplete object.
+     * For use when reading, not writing.
+     * False means getAtomFull must be called to get full content.
+     *
+     * @var bool
+     */
+    public $isIncomplete = true;
+
+    /**
+     * Author.
+     *
+     * @var ?\Hybridauth\Atom\Author
+     */
+    public $author;
+
+    /**
+     * List of category objects.
+     *
+     * @var array
+     */
+    public $categories = [];
+
+    /**
+     * Published date.
+     *
+     * @var \DateTime
+     */
+    public $published;
+
+    /**
+     * Modification date.
+     *
+     * @var ?\DateTime
+     */
+    public $updated;
+
+    /**
+     * Title.
+     * In plain text.
+     * Assumed less that 256 characters long (if we are choosing whether to make a single text result title or content).
+     *
+     * @var ?string
+     */
+    public $title;
+
+    /**
+     * Summary. Defined as a reduced version of the full content.
+     * In HTML.
+     *
+     * @var ?string
+     */
+    public $summary;
+
+    /**
+     * Content.
+     * In HTML.
+     *
+     * @var ?string
+     */
+    public $content;
+
+    /**
+     * List of Enclosure objects.
+     * Should be in precedence priority.
+     *
+     * @var array
+     */
+    public $enclosures = [];
+
+    /**
+     * Permalink URL.
+     *
+     * @var ?string
+     */
+    public $url;
+
+    /**
+     * Standalone hashtags, in precedence order. No leading "#".
+     * Likely to only work for saving, as detecting standalone vs in-sentence is usually not possible.
+     *
+     * @var array
+     */
+    public $hashTags = [];
+}

--- a/src/Atom/AtomFeedBuilder.php
+++ b/src/Atom/AtomFeedBuilder.php
@@ -1,0 +1,159 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Atom;
+
+/**
+ * Build an Atom feed from an array of atoms.
+ */
+class AtomFeedBuilder
+{
+    /**
+     * Build an Atom feed.
+     *
+     * @param string $title Title for feed
+     * @param string $url URL to the web version of the feed
+     * @param string $feedId ID for the feed
+     * @param string $urnStub Stub to put before each entry's permalink
+     * @param array $atoms List of atoms
+     * @param bool $trulyValid Try extra hard to be valid, even if it makes things clunky
+     *
+     * @return string The feed
+     */
+    public function buildAtomFeed($title, $url, $feedId, $urnStub, $atoms, $trulyValid)
+    {
+        $xml = '';
+
+        $updatedDate = isset($atoms[0]) ? $atoms[0]->published : new \DateTime();
+
+        $xml .= '
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>' . htmlentities($title, ENT_XML1) . '</title>
+    <updated>' . $updatedDate->format(\DateTime::ATOM) . '</updated>
+    <id>' . htmlentities($feedId, ENT_XML1) . '</id>
+    <link rel="alternate" href="' . htmlentities($url, ENT_XML1) . '" />
+        ';
+
+        foreach ($atoms as $atom) {
+            $xml .= '
+    <entry>
+            ';
+
+            $title = $atom->title;
+            if (($title == '') && ($trulyValid)) {
+                if ($atom->summary !== null) {
+                    $title = AtomHelper::htmlToPlainText($atom->summary);
+                } elseif ($atom->content !== null) {
+                    $title = AtomHelper::htmlToPlainText($atom->content);
+                }
+                AtomHelper::limitLengthTo($title, 50);
+            }
+            $xml .= '
+        <title>' . htmlentities($title, ENT_XML1) . '</title>
+            ';
+
+            if ($atom->url !== null) {
+                $xml .= '
+        <link rel="alternate" href="' . htmlentities($atom->url, ENT_XML1) . '" />
+                ';
+            }
+
+            if ($atom->identifier !== null) {
+                $xml .= '
+        <id>' . htmlentities($urnStub . $atom->identifier, ENT_XML1) . '</id>
+                ';
+            }
+
+            $xml .= '
+        <published>' . htmlentities($atom->published->format(\DateTime::ATOM), ENT_XML1) . '</published>
+            ';
+
+            $dateOb = ($atom->updated === null) ? $atom->published : $atom->updated;
+            $xml .= '
+        <updated>' . htmlentities($dateOb->format(\DateTime::ATOM), ENT_XML1) . '</updated>
+            ';
+
+            if ($atom->summary !== null) {
+                $xml .= '
+        <summary type="html">' . htmlentities($atom->summary, ENT_XML1) . '</summary>
+                ';
+            }
+
+            if ($atom->content !== null) {
+                $xml .= '
+        <content type="html">' . htmlentities($atom->content, ENT_XML1) . '</content>
+                ';
+            }
+
+            if (($atom->summary === null) && ($atom->content === null)) {
+                // Mandated that we provide some kind of text, so we'll repurpose the title
+                $xml .= '
+        <summary type="html">' . htmlentities($atom->title, ENT_XML1) . '</summary>
+                ';
+            }
+
+            if ($atom->author !== null) {
+                $xml .= '
+        <author><name>' . htmlentities($atom->author->displayName, ENT_XML1) . '</name></author>
+                ';
+            }
+
+            foreach ($atom->categories as $category) {
+                $term = $category->identifier;
+                $label = $category->label;
+                $xml .= '
+        <category term="' . htmlentities($term, ENT_XML1) . '" label="' . htmlentities($label, ENT_XML1) . '" />
+                ';
+            }
+
+            foreach ($atom->enclosures as $enclosure) {
+                $lengthAttribute = '';
+                $hrefAttribute = '';
+                $typeAttribute = '';
+                if ($enclosure->contentLength !== null) {
+                    $lengthAttribute = ' length="' . strval($enclosure->contentLength) . '"';
+                }
+                if ($enclosure->url !== null) {
+                    $hrefAttribute = ' href="' . htmlentities($enclosure->url, ENT_XML1) . '"';
+                }
+                $mimeType = $enclosure->mimeType;
+                if ($mimeType === null) {
+                    $mimeType = Enclosure::guessMimeType($enclosure->url);
+                }
+                if ($mimeType !== null) {
+                    $typeAttribute = ' type="' . htmlentities($enclosure->mimeType, ENT_XML1) . '"';
+                }
+                $xml .= '
+        <link' . $lengthAttribute . $hrefAttribute . $typeAttribute . ' rel="enclosure" />
+                ';
+                if (($enclosure->thumbnailUrl !== null) && ($enclosure->type != Enclosure::ENCLOSURE_IMAGE)) {
+                    $thumbHrefAttribute = ' href="' . htmlentities($enclosure->thumbnailUrl, ENT_XML1) . '"';
+                    $thumbMimeType = Enclosure::guessMimeType($enclosure->thumbnailUrl);
+                    if ($thumbMimeType != null) {
+                        $thumbTypeAttribute = ' type="' . htmlentities($thumbMimeType, ENT_XML1) . '"';
+                    } else {
+                        $thumbTypeAttribute = '';
+                    }
+                    $xml .= '
+        <link' . $thumbHrefAttribute . $thumbTypeAttribute . ' rel="enclosure" />
+                    ';
+                }
+            }
+
+            $xml .= '
+    </entry>
+            ';
+        }
+
+        $xml .= '
+</feed>
+        ';
+
+        return trim($xml);
+    }
+}

--- a/src/Atom/AtomHelper.php
+++ b/src/Atom/AtomHelper.php
@@ -1,0 +1,151 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Atom;
+
+/**
+ * Constants and helper functions for working with the atom API.
+ */
+class AtomHelper
+{
+    /**
+     * Convert HTML to plain text.
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    public static function htmlToPlainText($html)
+    {
+        $decoded = $html;
+        $decoded = preg_replace('#\s+#', ' ', $decoded);
+        $decoded = str_replace('<br />', "\n", $decoded);
+        $decoded = preg_replace('#<a[^<>]*\shref="([^<>]*)">([^<>]*)</a>#', '$1 ($2)', $decoded);
+        $decoded = strip_tags($decoded);
+        $decoded = html_entity_decode($decoded, ENT_QUOTES | ENT_HTML401, 'utf-8');
+        return $decoded;
+    }
+
+    /**
+     * Convert plain text to HTML.
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    public static function plainTextToHtml($text)
+    {
+        $encoded = $text;
+        $encoded = htmlentities($encoded, ENT_QUOTES | ENT_HTML401, 'utf-8');
+        $encoded = nl2br($encoded);
+        return $encoded;
+    }
+
+    /**
+     * Convert special codes within text to HTML.
+     * Assumes plainTextToHtml-style conversion has already happened.
+     *
+     * @param string $text
+     * @param ?string $urlUsernames Regexp-replacement-value for replacing usernames, or null
+     * @param ?string $urlHashtags Regexp-replacement-value for replacing hashtags, or null
+     * @param bool $detectUrls Convert raw URLs to hyperlinks
+     *
+     * @return array A pair: string of new text, and whether a replacement happened
+     */
+    public static function processCodes($text, $urlUsernames, $urlHashtags, $detectUrls = false)
+    {
+        $textIn = $text;
+        if ($urlUsernames !== null) {
+            $text = preg_replace('/@((\w|\.)+)/', $urlUsernames, $text); // users
+        }
+        if ($urlHashtags !== null) {
+            $text = preg_replace('/\s#(\w+)/', ' ' . $urlHashtags, $text); // hashtags
+        }
+        if ($detectUrls) {
+            $urlRegexp = '#([^"\'])(https?://([\w\-\.]+)+(/([\w/\-_\.]*(\?[^\s<>.!?,]+)?(\#\S+)?)?)?)#';
+            $text = preg_replace($urlRegexp, '$1<a href="$2">$2</a>', $text); // links
+        }
+        return [$text, $text != $textIn];
+    }
+
+    /**
+     * Get string length, with utf-8 awareness.
+     *
+     * @param string $in The string to get the length of
+     *
+     * @return integer The string length
+     */
+    public static function mbStrlen($in)
+    {
+        if (function_exists('mb_strlen')) {
+            return mb_strlen($in, 'utf-8');
+        }
+        if (function_exists('iconv_strlen')) {
+            return iconv_strlen($in, 'utf-8');
+        }
+        return strlen($in);
+    }
+
+    /**
+     * Return part of a string, with utf-8 awareness.
+     *
+     * @param  string $in The subject
+     * @param  integer $from The start position
+     * @param  ?integer $amount The length to extract (null: all remaining)
+     *
+     * @return string|false String part (false: $start was over the end of the string)
+     */
+    public static function mbSubstr($in, $from, $amount = null)
+    {
+        if ($amount === null) {
+            $amount = self::mbStrlen($in) - $from;
+        }
+
+        if (function_exists('mb_substr')) {
+            return mb_substr($in, $from, $amount, 'utf-8');
+        }
+        if (function_exists('iconv_substr')) {
+            return iconv_substr($in, $from, $amount, 'utf-8');
+        }
+        return substr($in, $from, $amount);
+    }
+
+    /**
+     * Limit the length of some text, using an ellipsis as required.
+     *
+     * @param  string $text The text
+     * @param  integer $limit Maximum length
+     *
+     * @return boolean Whether truncation happened
+     */
+    public static function limitLengthTo(&$text, $limit)
+    {
+        if (AtomHelper::mbStrlen($text) <= $limit) {
+            return false;
+        }
+
+        $ellipsis = hex2bin('E280A6'); // Can be made cleaner in PHP-8
+
+        $text = AtomHelper::mbSubstr($text, 0, $limit) . $ellipsis;
+
+        return true;
+    }
+
+    /**
+     * Append some text, but only if it will not break a character limit.
+     *
+     * @param  string $text The text
+     * @param  string $append What to append
+     * @param  integer $limit Maximum length
+     */
+    public static function appendIfWithinLimit(&$text, $append, $limit)
+    {
+        if (AtomHelper::mbStrlen($text) + AtomHelper::mbStrlen($append) <= $limit) {
+            $text .= $append;
+        }
+    }
+}

--- a/src/Atom/Author.php
+++ b/src/Atom/Author.php
@@ -1,0 +1,42 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Atom;
+
+/**
+ * An enclosure (a file)
+ */
+class Author
+{
+    /**
+     * Identifier.
+     *
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * Human-readable name.
+     *
+     * @var string
+     */
+    public $displayName;
+
+    /**
+     * URL.
+     *
+     * @var ?string
+     */
+    public $profileURL;
+
+    /**
+     * Photo image URL (to raw file).
+     *
+     * @var ?string
+     */
+    public $photoURL;
+}

--- a/src/Atom/Category.php
+++ b/src/Atom/Category.php
@@ -1,0 +1,42 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Atom;
+
+/**
+ * A category (might be a literal category, or some way of subdividing different kinds of streams a provider may have)
+ */
+class Category
+{
+    /**
+     * Identifier.
+     *
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * Title.
+     *
+     * @var string
+     */
+    public $label;
+
+    /**
+     * Parent category.
+     *
+     * @var ?string
+     */
+    public $parent_identifier;
+
+    /**
+     * Date last modified.
+     *
+     * @var ?\DateTime
+     */
+    public $modified;
+}

--- a/src/Atom/Enclosure.php
+++ b/src/Atom/Enclosure.php
@@ -1,0 +1,106 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Atom;
+
+/**
+ * An enclosure (a file).
+ * It is advisable for web media to be only image/gif, image/png, image/jpeg, or video/mp4.
+ */
+class Enclosure
+{
+    const ENCLOSURE_IMAGE = 1;
+    const ENCLOSURE_VIDEO = 2;
+    const ENCLOSURE_AUDIO = 4;
+    const ENCLOSURE_BINARY = 8;
+
+    /**
+     * An ENCLOSURE_* constant.
+     *
+     * @var int
+     */
+    public $type = 8;
+
+    /**
+     * Mime-type.
+     *
+     * @var ?string
+     */
+    public $mimeType;
+
+    /**
+     * Content length.
+     *
+     * @var ?int
+     */
+    public $contentLength;
+
+    /**
+     * URL. Ideally to the raw file, but if necessary to the web page that views it.
+     * Should be an absolute URL, not protocol relative.
+     * Should be accessible to your own web server and the world.
+     * Can be dynamic.
+     *
+     * @var string
+     */
+    public $url;
+
+    /**
+     * Thumbnail URL, to a raw image file.
+     * Should be an absolute URL, not protocol relative.
+     * Should be accessible to your own web server and the world.
+     * Can be dynamic.
+     *
+     * @var ?string
+     */
+    public $thumbnailUrl;
+
+    /**
+     * Guess a mime-type based on file extension.
+     *
+     * @param string $url URL
+     *
+     * @return ?string Mime type or null
+     */
+    public static function guessMimeType($url)
+    {
+        if (preg_match('#\.(jpg|jpe|jpeg)($|\?)#', $url) != 0) {
+            return 'image/jpeg';
+        }
+        if (preg_match('#\.(png)($|\?)#', $url) != 0) {
+            return 'image/png';
+        }
+        if (preg_match('#\.(gif)($|\?)#', $url) != 0) {
+            return 'image/gif';
+        }
+        if (preg_match('#\.(svg)($|\?)#', $url) != 0) {
+            return 'image/svg+xml';
+        }
+        if (preg_match('#\.(webp)($|\?)#', $url) != 0) {
+            return 'image/webp';
+        }
+
+        if (preg_match('#\.(mp4|m4v)($|\?)#', $url) != 0) {
+            return 'video/mp4';
+        }
+        if (preg_match('#\.(webm)($|\?)#', $url) != 0) {
+            return 'image/webm';
+        }
+
+        if (preg_match('#\.(mp3)($|\?)#', $url) != 0) {
+            return 'video/mpeg';
+        }
+        if (preg_match('#\.(aac)($|\?)#', $url) != 0) {
+            return 'image/aac';
+        }
+        if (preg_match('#\.(weba)($|\?)#', $url) != 0) {
+            return 'image/webm';
+        }
+
+        return null;
+    }
+}

--- a/src/Atom/Filter.php
+++ b/src/Atom/Filter.php
@@ -1,0 +1,79 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Atom;
+
+/**
+ * A filter.
+ */
+class Filter
+{
+    /**
+     * Maximum number of results to return.
+     *
+     * @var integer
+     */
+    public $limit = 12;
+
+    /**
+     * Whether to dip into pagination to get as close to $limit as possible.
+     * This only has an effect if filtering isn't happening API-side,
+     * or if $limit is too large for what the API supports in a single request.
+     *
+     * @var bool
+     */
+    public $deepProbe = true;
+
+    /**
+     * The ID of a category.
+     *
+     * @var string
+     */
+    public $categoryFilter = null;
+
+    /**
+     * A bitmask of Enclosure::ENCLOSURE_* constants.
+     * Returned atoms must have at least one enclosure type referenced in the bitmask.
+     *
+     * @var int
+     */
+    public $enclosureTypeFilter = null;
+
+    /**
+     * Include content 3rd-parties have contributed, if applicable.
+     *
+     * @var boolean
+     */
+    public $includeContributedContent = false;
+
+    /**
+     * Include private content, if applicable.
+     *
+     * @var boolean
+     */
+    public $includePrivate = false;
+
+    /**
+     * Whether the filter's enclosure passes.
+     *
+     * @param array $enclosures
+     *
+     * @return boolean
+     */
+    public function passesEnclosureTest($enclosures)
+    {
+        if (($this->enclosureTypeFilter === null) || ($this->enclosureTypeFilter == 0)) {
+            return true;
+        }
+        foreach ($enclosures as $enclosure) {
+            if (($this->enclosureTypeFilter & $enclosure->type) != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -9,9 +9,21 @@ namespace Hybridauth\Provider;
 
 use Hybridauth\Exception\InvalidArgumentException;
 use Hybridauth\Exception\UnexpectedApiResponseException;
+use Hybridauth\Exception\HttpRequestFailedException;
+use Hybridauth\Exception\NotImplementedException;
+use Hybridauth\Exception\BadMethodCallException;
 use Hybridauth\Adapter\OAuth2;
-use Hybridauth\Data;
+use Hybridauth\Adapter\AtomInterface;
+use Hybridauth\Data\Collection;
+use Hybridauth\Data\Parser;
 use Hybridauth\User;
+use Hybridauth\Atom\Atom;
+use Hybridauth\Atom\Enclosure;
+use Hybridauth\Atom\Category;
+use Hybridauth\Atom\Author;
+use Hybridauth\Atom\AtomFeedBuilder;
+use Hybridauth\Atom\AtomHelper;
+use Hybridauth\Atom\Filter;
 
 /**
  * Facebook OAuth2 provider adapter.
@@ -26,8 +38,9 @@ use Hybridauth\User;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys' => ['id' => '', 'secret' => ''],
- *       'scope' => 'email, user_status, user_posts',
+ *       'keys' => [ 'id' => '', 'secret' => '' ],
+ *       'scope => 'email, user_posts, pages_manage_posts, pages_read_engagement,
+ *                  pages_show_list, manage_pages, publish_pages, user_videos',
  *       'exchange_by_expiry_days' => 45, // null for no token exchange
  *   ];
  *
@@ -43,12 +56,12 @@ use Hybridauth\User;
  *       echo $e->getMessage() ;
  *   }
  */
-class Facebook extends OAuth2
+class Facebook extends OAuth2 implements AtomInterface
 {
     /**
      * {@inheritdoc}
      */
-    protected $scope = 'email, public_profile';
+    protected $scope = 'email';
 
     /**
      * {@inheritdoc}
@@ -155,7 +168,7 @@ class Facebook extends OAuth2
             'hometown',
             'birthday',
         ];
-        
+
         if (strpos($this->scope, 'user_link') !== false) {
             $fields[] = 'link';
         }
@@ -171,7 +184,7 @@ class Facebook extends OAuth2
             'locale' => $locale,
         ]);
 
-        $data = new Data\Collection($response);
+        $data = new Collection($response);
 
         if (!$data->exists('id')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
@@ -197,10 +210,7 @@ class Facebook extends OAuth2
 
         $userProfile->region = $data->filter('hometown')->get('name');
 
-        $photoSize = $this->config->get('photo_size') ?: '150';
-
-        $userProfile->photoURL = $this->apiBaseUrl . $userProfile->identifier;
-        $userProfile->photoURL .= '/picture?width=' . $photoSize . '&height=' . $photoSize;
+        $userProfile->photoURL = $this->generatePhotoURL($userProfile->identifier);
 
         $userProfile->emailVerified = $userProfile->email;
 
@@ -209,6 +219,25 @@ class Facebook extends OAuth2
         $userProfile = $this->fetchBirthday($userProfile, $data->get('birthday'));
 
         return $userProfile;
+    }
+
+    /**
+     * Generate a photo URL for a user.
+     *
+     * @param string $identifier
+     * @param ?int $photoSize
+     *
+     * @return string
+     */
+    protected function generatePhotoURL($identifier, $photoSize = null)
+    {
+        if ($photoSize === null) {
+            $photoSize = intval($this->config->get('photo_size')) ?: 150;
+        }
+
+        $photoURL = $this->apiBaseUrl . $identifier . '/picture';
+        $photoURL .= '?width=' . strval($photoSize) . '&height=' . strval($photoSize);
+        return $photoURL;
     }
 
     /**
@@ -242,7 +271,7 @@ class Facebook extends OAuth2
      */
     protected function fetchBirthday(User\Profile $userProfile, $birthday)
     {
-        $result = (new Data\Parser())->parseBirthday($birthday, '/');
+        $result = (new Parser())->parseBirthday($birthday, '/');
 
         $userProfile->birthYear = (int)$result[0];
         $userProfile->birthMonth = (int)$result[1];
@@ -267,7 +296,7 @@ class Facebook extends OAuth2
         do {
             $response = $this->apiRequest($apiUrl);
 
-            $data = new Data\Collection($response);
+            $data = new Collection($response);
 
             if (!$data->exists('data')) {
                 throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
@@ -302,7 +331,7 @@ class Facebook extends OAuth2
     {
         $userContact = new User\Contact();
 
-        $item = new Data\Collection($item);
+        $item = new Collection($item);
 
         $userContact->identifier = $item->get('id');
         $userContact->displayName = $item->get('name');
@@ -310,7 +339,7 @@ class Facebook extends OAuth2
         $userContact->profileURL = $item->exists('link')
             ?: $this->getProfileUrl($userContact->identifier);
 
-        $userContact->photoURL = $this->apiBaseUrl . $userContact->identifier . '/picture?width=150&height=150';
+        $userContact->photoURL = $this->generatePhotoURL($userContact->identifier, 150);
 
         return $userContact;
     }
@@ -327,6 +356,23 @@ class Facebook extends OAuth2
             return $this->setUserStatus($status);
         }
 
+        list(, $tokenHeaders, $tokenParameters) = $this->getPageAccessTokenDetails($pageId);
+
+        $parameters = $tokenParameters + $status;
+
+        return $this->apiRequest("{$pageId}/feed", 'POST', $parameters, $tokenHeaders);
+    }
+
+    /**
+     * Get a page access token.
+     *
+     * @param string $pageId Page we need to work with
+     *
+     * @return array A list: Access token, extra headers for auth, extra parameters for auth
+     * @throws InvalidArgumentException
+     */
+    protected function getPageAccessTokenDetails($pageId)
+    {
         // Retrieve writable user pages and filter by given one.
         $pages = $this->getUserPages(true);
         $pages = array_filter($pages, function ($page) use ($pageId) {
@@ -334,24 +380,23 @@ class Facebook extends OAuth2
         });
 
         if (!$pages) {
-            throw new InvalidArgumentException('Could not find a page with given id.');
+            throw new InvalidArgumentException('Could not find a writable page with given id.');
         }
 
         $page = reset($pages);
+        $pageAccessToken = $page->access_token;
 
         // Use page access token instead of user access token.
-        $headers = [
-            'Authorization' => 'Bearer ' . $page->access_token,
+        $tokenHeaders = [
+            'Authorization' => 'Bearer ' . $pageAccessToken,
         ];
 
         // Refresh proof for API call.
-        $parameters = $status + [
-                'appsecret_proof' => hash_hmac('sha256', $page->access_token, $this->clientSecret),
-            ];
+        $tokenParameters = [
+            'appsecret_proof' => hash_hmac('sha256', $pageAccessToken, $this->clientSecret),
+        ];
 
-        $response = $this->apiRequest("{$pageId}/feed", 'POST', $parameters, $headers);
-
-        return $response;
+        return [$pageAccessToken, $tokenHeaders, $tokenParameters];
     }
 
     /**
@@ -359,6 +404,11 @@ class Facebook extends OAuth2
      */
     public function getUserPages($writable = false)
     {
+        static $cache = [];
+        if (isset($cache[$writable])) {
+            return $cache[$writable];
+        }
+
         $pages = $this->apiRequest('me/accounts');
 
         if (!$writable) {
@@ -366,9 +416,11 @@ class Facebook extends OAuth2
         }
 
         // Filter user pages by CREATE_CONTENT permission.
-        return array_filter($pages->data, function ($page) {
+        $cache[$writable] = array_filter($pages->data, function ($page) {
             return in_array('CREATE_CONTENT', $page->tasks);
         });
+
+        return $cache[$writable];
     }
 
     /**
@@ -380,7 +432,7 @@ class Facebook extends OAuth2
 
         $response = $this->apiRequest($apiUrl);
 
-        $data = new Data\Collection($response);
+        $data = new Collection($response);
 
         if (!$data->exists('data')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
@@ -404,7 +456,7 @@ class Facebook extends OAuth2
     {
         $userActivity = new User\Activity();
 
-        $item = new Data\Collection($item);
+        $item = new Collection($item);
 
         $userActivity->id = $item->get('id');
         $userActivity->date = $item->get('created_time');
@@ -427,8 +479,7 @@ class Facebook extends OAuth2
 
             $userActivity->user->profileURL = $this->getProfileUrl($userActivity->user->identifier);
 
-            $userActivity->user->photoURL = $this->apiBaseUrl . $userActivity->user->identifier;
-            $userActivity->user->photoURL .= '/picture?width=150&height=150';
+            $userActivity->user->photoURL = $this->generatePhotoURL($userActivity->user->identifier, 150);
         }
 
         return $userActivity;
@@ -438,6 +489,7 @@ class Facebook extends OAuth2
      * Get profile URL.
      *
      * @param int $identity User ID.
+     *
      * @return string|null NULL when identity is not provided.
      */
     protected function getProfileUrl($identity)
@@ -447,5 +499,731 @@ class Facebook extends OAuth2
         }
 
         return sprintf($this->profileUrlTemplate, $identity);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildAtomFeed($filter = null, $trulyValid = false)
+    {
+        if ($filter === null) {
+            $filter = new Filter();
+        }
+
+        $category = $this->getDefaultCategory($filter);
+
+        $userProfile = $this->getUserProfile();
+        list($atoms) = $this->getAtoms($filter);
+
+        $utility = new AtomFeedBuilder();
+        if ($category->identifier == '-') {
+            $title = 'Facebook feed of ' . $userProfile->displayName;
+        } else {
+            $title = 'Facebook feed of ' . $category->label;
+        }
+        $feedId = 'urn:hybridauth:facebook:' . $userProfile->identifier . ':' . md5(serialize(func_get_args()));
+        $urnStub = 'urn:hybridauth:facebook:';
+        $url = $userProfile->profileURL;
+        return $utility->buildAtomFeed($title, $url, $feedId, $urnStub, $atoms, $trulyValid);
+    }
+
+    /**
+     * Get default category for reading from.
+     *
+     * @param \Hybridauth\Atom\Filter $filter Filter
+     *
+     * @return \Hybridauth\Atom\Category
+     */
+    protected function getDefaultCategory($filter)
+    {
+        $categories = $this->getCategories();
+        if ($filter->categoryFilter !== null) {
+            $category = $categories[$filter->categoryFilter];
+        } else {
+            $pageId = $this->config->get('default_page_id') ?: '-';
+
+            if (isset($categories[$pageId])) {
+                $category = $categories[$pageId];
+            } else {
+                $category = new Category();
+                $category->identifier = $pageId;
+                $category->label = $pageId; // Don't know the correct one
+            }
+        }
+        return $category;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtoms($filter = null)
+    {
+        if ($filter === null) {
+            $filter = new Filter();
+        }
+
+        $fieldsShared = [
+            'id',
+            'created_time',
+            'from',
+            'is_hidden',
+            'is_published',
+            'message',
+            'permalink_url',
+            'privacy',
+
+            // Edges
+            'attachments',
+        ];
+
+        $atoms = [];
+        $hasResults = false;
+
+        $category = $this->getDefaultCategory($filter);
+
+        $isPersonal = ($category->identifier == '-');
+
+        if ($isPersonal) {
+            $path = 'me';
+        } else {
+            $path = $category->identifier;
+        }
+        if ($filter->includeContributedContent) {
+            $path .= '/feed';
+        } else {
+            $path .= '/posts';
+        }
+
+        $fields = $fieldsShared;
+        if ($isPersonal) {
+            // Links done like this for personal feed
+            $fields[] = 'type';
+            $fields[] = 'link';
+            $fields[] = 'name';
+            $fields[] = 'description';
+        }
+
+        $params = [
+            'fields' => implode(',', $fields),
+            'limit' => min(100, $filter->limit),
+        ];
+
+        do {
+            $response = $this->apiRequest($path, 'GET', $params);
+
+            $data = new Collection($response);
+            if (!$data->exists('data')) {
+                throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+            }
+
+            $dataArray = $data->get('data');
+            foreach ($dataArray as $item) {
+                $hasResults = true;
+
+                // Don't show private stuff
+                if (!$filter->includePrivate) {
+                    if (!in_array($item->privacy->value, ['ALL_FRIENDS', 'EVERYONE'])) {
+                        continue;
+                    }
+                    if ($item->is_hidden) {
+                        continue;
+                    }
+                }
+                if (!$item->is_published) {
+                    continue;
+                }
+
+                $atom = $this->parseFacebookPost($item, $category, $isPersonal);
+
+                if (!$filter->passesEnclosureTest($atom->enclosures)) {
+                    continue;
+                }
+
+                $atoms[] = $atom;
+                if (count($atoms) == $filter->limit) {
+                    break 2;
+                }
+            }
+
+            if (!empty($data->get('paging')->next)) {
+                $queryString = parse_url($data->get('paging')->next, PHP_URL_QUERY);
+                parse_str($queryString, $params);
+            }
+        } while (($filter->deepProbe) && (!empty($dataArray)) && (!empty($data->get('paging')->next)));
+
+        return [$atoms, $hasResults];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtomFull($identifier)
+    {
+        $fieldsShared = [
+            'id',
+            'created_time',
+            'from',
+            'is_hidden',
+            'is_published',
+            'message',
+            'permalink_url',
+            'privacy',
+
+            // Edges
+            'attachments',
+        ];
+
+        $categories = $this->getCategories();
+
+        $identifier_parts = explode('_', $identifier);
+
+        $isPersonal = !isset($categories[$identifier_parts[0]]);
+
+        $path = $identifier;
+
+        $fields = $fieldsShared;
+        if ($isPersonal) {
+            // Links done like this for personal feed
+            $fields[] = 'type';
+            $fields[] = 'link';
+            $fields[] = 'name';
+            $fields[] = 'description';
+        }
+        $params = [
+            'fields' => implode(',', $fields),
+        ];
+
+        $item = $this->apiRequest($path, 'GET', $params);
+
+        return $this->parseFacebookPost($item, $categories[$isPersonal ? '-' : $identifier_parts[0]], $isPersonal);
+    }
+
+    /**
+     * Convert a Facebook post into an atom.
+     *
+     * @param object $item Data from Facebook
+     * @param \Hybridauth\Atom\Category $category Category we're currently operating in
+     * @param bool $isPersonal Whether it is from a personal feed
+     *
+     * @return \Hybridauth\Atom\Atom
+     * @throws \Exception
+     */
+    protected function parseFacebookPost($item, $category, $isPersonal)
+    {
+        $atom = new Atom();
+
+        // Facebook API varies based on whether it is a personal feed or a page
+        $linkURL = null;
+        $linkText = null;
+        $linkDescription = null;
+        if ($isPersonal) {
+            $isLink = false;
+            if ($item->type == 'link') {
+                $isLink = true;
+            }
+            if ((isset($item->attachments->data[0]->type)) && ($item->attachments->data[0]->type == 'share')) {
+                $isLink = true;
+            }
+            if ($isLink) {
+                $linkURL = $item->link;
+                $linkText = isset($item->name) ? $item->name : $linkURL;
+                $linkDescription = isset($item->description) ? $item->description : '';
+            }
+        } else {
+            $isLink = (isset($item->attachments->data[0]->type)) && ($item->attachments->data[0]->type == 'share');
+            if ($isLink) {
+                $linkURL = $item->attachments->data[0]->target->url;
+                $linkText = isset($item->attachments->data[0]->title) ? $item->attachments->data[0]->title : $linkURL;
+                if (isset($item->attachments->data[0]->description)) {
+                    $linkDescription = $item->attachments->data[0]->description;
+                } else {
+                    $linkDescription = '';
+                }
+            }
+        }
+
+        $atom->identifier = $item->id;
+        $atom->isIncomplete = false;
+        $atom->published = new \DateTime($item->created_time);
+        $atom->url = $item->permalink_url;
+
+        $urlUsernames = null;
+        $urlHashtags = '<a href="https://facebook.com/hashtag/$1">#$1</a>';
+        $detectUrls = true;
+        if (!empty($item->message)) {
+            $text = $item->message;
+        } elseif (!empty($item->name)) {
+            $text = $item->name;
+        } else {
+            $text = '';
+        }
+        $textPlain = $text;
+        $text = AtomHelper::plainTextToHtml($text);
+        list($text, $repped) = AtomHelper::processCodes($text, $urlUsernames, $urlHashtags, $detectUrls);
+        $atom->content = $text;
+        if ($isLink) {
+            if (($text == '') && (!empty($linkDescription))) {
+                $text = AtomHelper::plainTextToHtml($linkDescription);
+                // NB: ^ Intentionally not passed through processCodes
+            }
+            if ($text != '') {
+                $text .= '<br />';
+            }
+            $text .= '<a href="' . htmlentities($linkURL) . '">' . htmlentities($linkText) . '</a>';
+            $atom->content = $text;
+        }
+
+        $atom->author = new Author();
+        $atom->author->identifier = $item->from->id;
+        $atom->author->displayName = $item->from->name;
+        $atom->author->profileURL = $this->getProfileUrl($item->from->id);
+        $atom->author->photoURL = $this->generatePhotoURL($item->from->id, 150);
+
+        $atom->categories = [];
+        $atom->categories[] = $category;
+
+        $atom->enclosures = [];
+        if (isset($item->attachments)) {
+            foreach ($item->attachments->data as $attachment) {
+                $enclosure = $this->processEnclosure($item, $attachment);
+                if ($enclosure !== null) {
+                    $atom->enclosures[] = $enclosure;
+
+                    if (isset($attachment->subattachments)) {
+                        foreach ($attachment->subattachments->data as $subattachment) {
+                            $subenclosure = $this->processEnclosure($item, $subattachment);
+                            if ($subenclosure !== null) {
+                                $atom->enclosures[] = $subenclosure;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $atom;
+    }
+
+    /**
+     * Process an enclosure into an atom attachment.
+     *
+     * @param object $item Main data from Facebook
+     * @param object $attachment Attachment data from Facebook
+     *
+     * @return ?\Hybridauth\Atom\Enclosure
+     */
+    protected function processEnclosure($item, $attachment)
+    {
+        if (!isset($attachment->url)) {
+            return null;
+        }
+
+        $enclosure = new Enclosure();
+        $enclosure->url = $attachment->url;
+        switch ($attachment->type) {
+            case 'photo':
+            case 'photo_inline':
+                if (!empty($attachment->media->image->src)) {
+                    $enclosure->url = $attachment->media->image->src;
+                }
+                $enclosure->type = Enclosure::ENCLOSURE_IMAGE;
+                break;
+
+            case 'video':
+            case 'video_inline':
+                $enclosure->type = Enclosure::ENCLOSURE_VIDEO;
+                if (isset($attachment->media->image->src)) {
+                    $enclosure->thumbnailUrl = $attachment->media->image->src;
+                }
+                break;
+
+            case 'share':
+                $enclosure = null; // This is done as a link
+                break;
+
+            default:
+                $enclosure->type = Enclosure::ENCLOSURE_BINARY; // We don't recognize this
+                break;
+        }
+        return $enclosure;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtomFullFromURL($url)
+    {
+        // Can't work now, see https://stackoverflow.com/questions/31353591/how-should-we-retrieve-an-individual-post-now-that-post-id-is-deprecated-in-v
+        //  Indications suggest FB management doesn't want us pulling out individual posts for some reason
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOEmbedFromURL($url, $params = [])
+    {
+        // Note that oEmbed must be enabled on the Facebook App you are using for Instagram
+
+        if (preg_match('#^https://www\.facebook\.com/([^/]+/posts/[^/?]+|.*[&?]id=\d+)#', $url) == 0) {
+            return null;
+        }
+
+        $appId = $this->config->filter('keys')->get('id') ?: null;
+        $clientToken = $this->config->filter('keys')->get('client_token') ?: null;
+        if (($appId === null) || ($clientToken === null)) {
+            return;
+        }
+        $comboToken = $appId . '|' . $clientToken;
+        $endpoint = 'https://graph.facebook.com/oembed_post?url=' . urlencode($url);
+        $endpoint .= '&access_token=' . urlencode($comboToken);
+        foreach ($params as $key => $val) {
+            $endpoint .= '&' . $key . '=' . urlencode($val);
+        }
+
+        $allow_url_fopen = @ini_get('allow_url_fopen');
+        @ini_set('allow_url_fopen', 'On');
+        $oembed = file_get_contents($endpoint);
+        @ini_set('allow_url_fopen', $allow_url_fopen);
+
+        return json_decode($oembed);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveAtom($atom, &$messages = [])
+    {
+        $allCategories = $this->getCategories();
+
+        unset($allCategories['-']);
+        if (empty($allCategories)) {
+            throw new NotImplementedException('No access to any Facebook page to post to.');
+        }
+
+        // Find what Facebook page to post to
+        $pageId = null;
+        foreach ($atom->categories as $categoryId) {
+            foreach ($allCategories as $_pageId => $category) {
+                if (($_pageId == $categoryId) || ($category->label == $categoryId)) {
+                    $pageId = $_pageId;
+                    break 2;
+                }
+            }
+        }
+        if ($pageId === null) {
+            $pageId = $this->config->get('default_page_id') ?: null;
+        }
+        if ($pageId === null) {
+            $category = array_shift($allCategories);
+            $pageId = $category->identifier;
+        }
+
+        $path = $pageId . '/feed';
+
+        // Work out message...
+
+        if ($atom->url !== null) {
+            $precedence = [[$atom->summary, true], [$atom->title, false], [$atom->content, true]];
+        } else {
+            $precedence = [[$atom->content, true], [$atom->summary, true], [$atom->title, false]];
+        }
+        $message = '';
+        foreach ($precedence as $_field) {
+            list($field, $isHtml) = $_field;
+            if (!empty($field)) {
+                $message = $isHtml ? AtomHelper::htmlToPlainText($field) : $field;
+                break;
+            }
+        }
+
+        $maximumPostLength = 63206;
+
+        AtomHelper::limitLengthTo($message, $maximumPostLength);
+
+        foreach ($atom->hashTags as $hashTag) {
+            AtomHelper::appendIfWithinLimit($message, ' #' . $hashTag, $maximumPostLength);
+        }
+
+        $params = [];
+
+        $params['message'] = $message;
+
+        // Misc...
+
+        if ($atom->published !== null) {
+            $timestamp = $atom->published->getTimestamp();
+        } else {
+            $timestamp = null;
+        }
+        if ($timestamp !== null) {
+            $params['backdated_time'] = $timestamp;
+        }
+
+        if ($atom->url !== null) {
+            $params['link'] = $atom->url;
+        }
+
+        // Media...
+
+        if (empty($atom->url)) {
+            $allow_url_fopen = @ini_get('allow_url_fopen');
+            @ini_set('allow_url_fopen', 'On');
+
+            // Start with images, we can have any number
+            $mediaIds = [];
+            foreach ($atom->enclosures as $enclosure) {
+                try {
+                    if ($enclosure->type == Enclosure::ENCLOSURE_IMAGE) {
+                        $mediaId = $this->uploadPhoto($pageId, $enclosure);
+                        if ($mediaId !== null) {
+                            $mediaIds[] = $mediaId;
+                        }
+                    }
+                } catch (HttpRequestFailedException $e) {
+                    // FB could give all kinds of issues, should not stop our post
+                }
+            }
+
+            // FB doesn't document this, but we can only post one lone video, unattached
+            //  So we do this in a weird way
+            if (empty($mediaIds)) {
+                foreach ($atom->enclosures as $enclosure) {
+                    try {
+                        if (in_array($enclosure->type, [Enclosure::ENCLOSURE_VIDEO, Enclosure::ENCLOSURE_AUDIO])) {
+                            $mediaId = $this->uploadVideo($pageId, $enclosure, $message, $timestamp);
+                            if ($mediaId !== null) {
+                                return $mediaId;
+                            }
+                        }
+                    } catch (\Exception $e) {
+                        // FB could give all kinds of issues, should not stop our post
+                    }
+                }
+            }
+
+            if (!empty($mediaIds)) {
+                $params['attached_media'] = [];
+                foreach ($mediaIds as $i => $mediaId) {
+                    $params['attached_media'][] = ['media_fbid' => $mediaId];
+                }
+            }
+
+            @ini_set('allow_url_fopen', $allow_url_fopen);
+        }
+
+        // Go ahead...
+
+        list(, $tokenHeaders, $tokenParameters) = $this->getPageAccessTokenDetails($pageId);
+
+        $params += $tokenParameters;
+
+        $headers = ['Content-Type' => 'application/json'];
+        $headers += $tokenHeaders;
+
+        $result = $this->apiRequest($path, 'POST', $params, $headers, true);
+        return $result->id;
+    }
+
+    /**
+     * Upload a photo.
+     *
+     * @param string $pageId Page to post to
+     * @param \Hybridauth\Atom\Enclosure $enclosure
+     *
+     * @return ?string Photo ID
+     * @throws HttpRequestFailedException
+     * @throws InvalidArgumentException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     */
+    protected function uploadPhoto($pageId, $enclosure)
+    {
+        $mediaType = $enclosure->mimeType;
+        $totalBytes = $enclosure->contentLength;
+
+        if (($mediaType === null) || ($totalBytes === null)) {
+            // We need to look this up by calling HTTP early
+            $myfile = @fopen($enclosure->url, 'rb');
+            if ($myfile === false) {
+                return null;
+            }
+            if (isset($http_response_header)) {
+                $matches = [];
+                foreach ($http_response_header as $header) {
+                    if (preg_match('#^Content-Type: ([^/\s]*/[^/\s]*)(\s|;|$)#i', $header, $matches) != 0) {
+                        if ($mediaType === null) {
+                            $mediaType = $matches[1];
+                        }
+                    } elseif (preg_match('#^Content-Length: (\d+)*(;|$)#i', $header, $matches) != 0) {
+                        $totalBytes = intval($matches[1]);
+                    }
+                }
+            }
+            fclose($myfile);
+            if (($mediaType === null) || ($totalBytes === null)) {
+                return null;
+            }
+        }
+
+        if (!in_array($mediaType, ['image/gif', 'image/png', 'image/jpeg', 'image/tiff', 'image/bmp'])) {
+            return null;
+        }
+
+        $maxSize = 4 * 1000 * 1000; // An FB limit
+
+        if ($totalBytes > $maxSize) {
+            return null;
+        }
+
+        $path = $pageId . '/photos';
+
+        $params = [
+            'url' => $enclosure->url,
+            'no_story' => true,
+            'published' => false,
+        ];
+
+        list(, $tokenHeaders, $tokenParameters) = $this->getPageAccessTokenDetails($pageId);
+
+        $params += $tokenParameters;
+
+        $result = $this->apiRequest($path, 'POST', $params, $tokenHeaders);
+
+        return $result->id;
+    }
+
+    /**
+     * Upload a video.
+     *
+     * @param string $pageId Page to post to
+     * @param \Hybridauth\Atom\Enclosure $enclosure
+     * @param string $message
+     * @param integer $timestamp
+     *
+     * @return ?string Video ID
+     * @throws HttpRequestFailedException
+     * @throws InvalidArgumentException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     */
+    protected function uploadVideo($pageId, $enclosure, $message, $timestamp)
+    {
+        $mediaType = $enclosure->mimeType;
+        $totalBytes = $enclosure->contentLength;
+
+        list(, $tokenHeaders, $tokenParameters) = $this->getPageAccessTokenDetails($pageId);
+
+        if (($mediaType === null) || ($totalBytes === null)) {
+            // We need to look this up by calling HTTP early
+            $myfile = @fopen($enclosure->url, 'rb');
+            if ($myfile === false) {
+                return null;
+            }
+            if (isset($http_response_header)) {
+                $matches = [];
+                foreach ($http_response_header as $header) {
+                    if (preg_match('#^Content-Type: ([^/\s]*/[^/\s]*)(\s|;|$)#i', $header, $matches) != 0) {
+                        if ($mediaType === null) {
+                            $mediaType = $matches[1];
+                        }
+                    } elseif (preg_match('#^Content-Length: (\d+)*(;|$)#i', $header, $matches) != 0) {
+                        $totalBytes = intval($matches[1]);
+                    }
+                }
+            }
+            fclose($myfile);
+            if (($mediaType === null) || ($totalBytes === null)) {
+                return null;
+            }
+        } else {
+            $myfile = null;
+        }
+
+        $apiUrl = 'https://graph-video.facebook.com/' . $pageId . '/videos';
+
+        $params = [
+            'file_url' => $enclosure->url,
+            'description' => $message,
+        ];
+
+        if ($timestamp !== null) {
+            $params['backdated_post'] = [
+                'backdated_time' => $timestamp,
+            ];
+        }
+
+        if ($enclosure->thumbnailUrl !== null) {
+            $thumbData = @file_get_contents($enclosure->thumbnailUrl);
+            if (!empty($thumbData)) {
+                $params['thumb'] = $thumbData;
+            }
+        }
+
+        $params += $tokenParameters;
+
+        $headers = ['Content-Type' => 'application/json'];
+        $headers += $tokenHeaders;
+
+        $result = $this->apiRequest($apiUrl, 'POST', $params, $headers, true);
+
+        return $result->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteAtom($identifier)
+    {
+        if (strpos($identifier, '/') !== false) {
+            throw new BadMethodCallException('$identifier cannot include a slash.');
+        }
+
+        $this->apiRequest($identifier, 'DELETE');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCategories()
+    {
+        $dataArray = $this->getUserPages(true);
+
+        static $categories = [];
+        if (!empty($categories)) {
+            return $categories;
+        }
+
+        $category = new Category();
+        $category->identifier = '-';
+        $category->label = 'Personal feed';
+        $categories['-'] = $category;
+
+        foreach ($dataArray as $item) {
+            $category = new Category();
+            $category->identifier = $item->id;
+            $category->label = $item->name;
+            $categories[$category->identifier] = $category;
+        }
+
+        return $categories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveCategory($category)
+    {
+        // Could in theory implement, but nobody would want their Pages being manipulated by this API
+        throw new NotImplementedException('Provider does not support this feature.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteCategory($identifier)
+    {
+        // Could in theory implement, but nobody would want their Pages being manipulated by this API
+        throw new NotImplementedException('Provider does not support this feature.');
     }
 }

--- a/src/Provider/Twitter.php
+++ b/src/Provider/Twitter.php
@@ -8,9 +8,17 @@
 namespace Hybridauth\Provider;
 
 use Hybridauth\Adapter\OAuth1;
+use Hybridauth\Adapter\AtomInterface;
+use Hybridauth\Exception\NotImplementedException;
 use Hybridauth\Exception\UnexpectedApiResponseException;
-use Hybridauth\Data;
+use Hybridauth\Data\Collection;
 use Hybridauth\User;
+use Hybridauth\Atom\Atom;
+use Hybridauth\Atom\Enclosure;
+use Hybridauth\Atom\Author;
+use Hybridauth\Atom\AtomFeedBuilder;
+use Hybridauth\Atom\AtomHelper;
+use Hybridauth\Atom\Filter;
 
 /**
  * Twitter OAuth1 provider adapter.
@@ -20,7 +28,7 @@ use Hybridauth\User;
  *
  *   $config = [
  *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
- *       'keys' => ['key' => '', 'secret' => ''], // OAuth1 uses 'key' not 'id'
+ *       'keys' => [ 'key' => '', 'secret' => '' ], // OAuth1 uses 'key' not 'id'
  *       'authorize' => true // Needed to perform actions on behalf of users (see below link)
  *         // https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
  *   ];
@@ -38,7 +46,7 @@ use Hybridauth\User;
  *       echo $e->getMessage() ;
  *   }
  */
-class Twitter extends OAuth1
+class Twitter extends OAuth1 implements AtomInterface
 {
     /**
      * {@inheritdoc}
@@ -86,7 +94,7 @@ class Twitter extends OAuth1
             'include_email' => $this->config->get('include_email') === false ? 'false' : 'true',
         ]);
 
-        $data = new Data\Collection($response);
+        $data = new Collection($response);
 
         if (!$data->exists('id_str')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
@@ -130,7 +138,7 @@ class Twitter extends OAuth1
 
         $response = $this->apiRequest('friends/ids.json', 'GET', $parameters);
 
-        $data = new Data\Collection($response);
+        $data = new Collection($response);
 
         if (!$data->exists('ids')) {
             throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
@@ -171,7 +179,7 @@ class Twitter extends OAuth1
      */
     protected function fetchUserContact($item)
     {
-        $item = new Data\Collection($item);
+        $item = new Collection($item);
 
         $userContact = new User\Contact();
 
@@ -208,9 +216,7 @@ class Twitter extends OAuth1
             $params['media_ids'] = $media->media_id;
         }
 
-        $response = $this->apiRequest('statuses/update.json', 'POST', $params);
-
-        return $response;
+        return $this->apiRequest('statuses/update.json', 'POST', $params);
     }
 
     /**
@@ -239,11 +245,12 @@ class Twitter extends OAuth1
 
     /**
      * @param $item
+     *
      * @return User\Activity
      */
     protected function fetchUserActivity($item)
     {
-        $item = new Data\Collection($item);
+        $item = new Collection($item);
 
         $userActivity = new User\Activity();
 
@@ -260,5 +267,414 @@ class Twitter extends OAuth1
             : '';
 
         return $userActivity;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildAtomFeed($filter = null, $trulyValid = false)
+    {
+        $userProfile = $this->getUserProfile();
+        list($atoms) = $this->getAtoms($filter);
+
+        $utility = new AtomFeedBuilder();
+        $title = 'Twitter feed of ' . $userProfile->displayName;
+        $feedId = 'urn:hybridauth:twitter:' . $userProfile->identifier . ':' . md5(serialize(func_get_args()));
+        $urnStub = 'urn:hybridauth:twitter:';
+        $url = $userProfile->profileURL;
+        return $utility->buildAtomFeed($title, $url, $feedId, $urnStub, $atoms, $trulyValid);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtoms($filter = null)
+    {
+        if ($filter === null) {
+            $filter = new Filter();
+        }
+
+        $apiUrl = 'statuses/user_timeline.json';
+
+        $atoms = [];
+        $hasResults = false;
+
+        $params = [
+            'count' => min(200, $filter->limit),
+        ];
+
+        do {
+            $response = $this->apiRequest($apiUrl, 'GET', $params);
+
+            $data = new Collection($response);
+            $dataArray = $data->toArray();
+
+            foreach ($dataArray as $item) {
+                $hasResults = true;
+
+                $params['max_id'] = $item->id_str;
+
+                $atom = $this->parseTweet($item);
+
+                if (!$filter->passesEnclosureTest($atom->enclosures)) {
+                    continue;
+                }
+
+                $atoms[] = $atom;
+                if (count($atoms) == $filter->limit) {
+                    break 2;
+                }
+            }
+        } while (($filter->deepProbe) && (!empty($dataArray)) && (isset($params['max_id'])));
+
+        return [$atoms, $hasResults];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtomFull($identifier)
+    {
+        $apiUrl = 'statuses/show/' . $identifier . '.json';
+
+        $item = $this->apiRequest($apiUrl);
+
+        return $this->parseTweet($item);
+    }
+
+    /**
+     * Convert a Tweet into an atom.
+     *
+     * @param object $item
+     *
+     * @return \Hybridauth\Atom\Atom
+     * @throws \Exception
+     */
+    protected function parseTweet($item)
+    {
+        $atom = new Atom();
+
+        $atom->identifier = $item->id_str;
+        $atom->isIncomplete = false;
+        $atom->published = new \DateTime($item->created_at);
+        $atom->url = "https://twitter.com/{$item->user->screen_name}/status/{$item->id_str}";
+
+        $urlUsernames = '<a href="http://twitter.com/$1">@$1</a>';
+        $urlHashtags = '<a href="https://twitter.com/hashtag/$1?src=hash">#$1</a>';
+        $detectUrls = true;
+        list($text, $repped) = AtomHelper::processCodes($item->text, $urlUsernames, $urlHashtags, $detectUrls);
+        if ((!$repped) && (AtomHelper::plainTextToHtml(AtomHelper::htmlToPlainText($text)) == $text)) {
+            $atom->title = $text;
+        } else {
+            $atom->content = $text;
+        }
+
+        $atom->author = new Author();
+        $atom->author->identifier = strval($item->user->id);
+        $atom->author->displayName = $item->user->screen_name;
+        $atom->author->profileURL = 'https://twitter.com/' . $item->user->screen_name;
+        if (!empty($item->user->profile_image_url_https)) {
+            $atom->author->photoURL = str_replace('_normal', '', $item->user->profile_image_url_https);
+        }
+
+        $enclosures = [];
+        if (isset($item->extended_entities)) {
+            foreach ($item->extended_entities->media as $entity) {
+                $enclosure = new Enclosure();
+
+                switch ($entity->type) {
+                    case 'photo':
+                        $enclosure->type = Enclosure::ENCLOSURE_IMAGE;
+                        $enclosure->url = $entity->media_url_https;
+                        $enclosure->mimeType = Enclosure::guessMimeType($enclosure->url);
+                        $enclosure->thumbnailUrl = $entity->media_url_https . '?name=thumb';
+                        break;
+
+                    case 'video':
+                    case 'animated_gif':
+                        $enclosure->type = Enclosure::ENCLOSURE_VIDEO;
+                        $enclosure->url = $entity->video_info->variants[0]->url;
+                        $enclosure->mimeType = $entity->video_info->variants[0]->content_type;
+                        $enclosure->thumbnailUrl = $entity->media_url_https;
+                        break;
+
+                    default:
+                        $enclosure->type = Enclosure::ENCLOSURE_BINARY;
+                        $enclosure->url = $entity->media_url_https;
+                        break;
+                }
+
+                $enclosures[] = $enclosure;
+            }
+        }
+        $atom->enclosures = $enclosures;
+
+        return $atom;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtomFullFromURL($url)
+    {
+        $ret = null;
+
+        $matches = [];
+        if (preg_match('#^https://twitter\.com/[^/]+/status/(\d+)#', $url, $matches) != 0) {
+            $identifier = $matches[1];
+            $ret = $this->getAtomFull($identifier);
+        }
+
+        return $ret;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOEmbedFromURL($url, $params = [])
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveAtom($atom, &$messages = [])
+    {
+        if ($atom->identifier !== null) {
+            throw new NotImplementedException('Twitter does not allow edits or identifier-specifying.');
+        }
+
+        // Work out status...
+
+        // Lots of work to stay within the Twitter limits!
+
+        $maxLength = intval($this->config->get('max_length')) ?: 240;
+        $segmentSize = intval($this->config->get('segment_size')) ?: (512 * 1024);
+
+        $ellipsis = hex2bin('E280A6'); // Can be made cleaner in PHP-8
+
+        $parts = []; // Will be maximum of 2
+        if (!empty($atom->title)) {
+            $parts[] = $atom->title;
+            if ((!empty($atom->url)) && (strpos($parts[0], $atom->url) === false)) {
+                $parts[] = $atom->url;
+            }
+        } elseif (!empty($atom->summary)) {
+            $parts[] = AtomHelper::htmlToPlainText($atom->summary);
+            if ((!empty($atom->url)) && (strpos($parts[0], $atom->url) === false)) {
+                $parts[] = $atom->url;
+            }
+        } elseif (!empty($atom->content)) {
+            $parts[] = AtomHelper::htmlToPlainText($atom->content);
+            if ((!empty($atom->url)) && (strpos($parts[0], $atom->url) === false)) {
+                $parts[] = $atom->url;
+            }
+        } else {
+            $parts[] = '';
+        }
+        if ((count($parts) == 2) && (AtomHelper::mbStrlen($parts[1]) > $maxLength)) {
+            // URL too long to include
+            unset($parts[1]);
+        }
+        if ((count($parts) == 2) && (AtomHelper::mbStrlen($parts[1]) >= $maxLength - 2)) {
+            // Only space for URL (considering joining space also and the ellipsis)
+            unset($parts[0]);
+            $parts = array_values($parts);
+        }
+        if (count($parts) == 2) {
+            if (AtomHelper::mbStrlen($parts[0] . ' ' . $parts[1]) <= $maxLength) {
+                $status = $parts[0] . ' ' . $parts[1];
+            } else {
+                $maxLength -= AtomHelper::mbStrlen($parts[1]);
+                $maxLength -= 2; // considering joining space also and the ellipsis
+                $status = AtomHelper::mbSubstr($parts[0], 0, $maxLength) . $ellipsis . ' ' . $parts[1];
+            }
+        } else {
+            if (AtomHelper::mbStrlen($parts[0]) <= $maxLength) {
+                $status = $parts[0];
+            } else {
+                $maxLength--; // for the ellipsis
+                $status = AtomHelper::mbSubstr($parts[0], 0, $maxLength) . $ellipsis;
+            }
+        }
+
+        foreach ($atom->hashTags as $hashTag) {
+            AtomHelper::appendIfWithinLimit($status, ' #' . $hashTag, $maxLength);
+        }
+
+        // Uploading as required...
+
+        $allow_url_fopen = @ini_get('allow_url_fopen');
+        @ini_set('allow_url_fopen', 'On');
+
+        $mediaIds = [];
+        $numImagesDone = 0;
+        $numVideosDone = 0;
+        foreach ($atom->enclosures as $enclosure) {
+            $mediaType = $enclosure->mimeType;
+            $totalBytes = $enclosure->contentLength;
+
+            if (($mediaType === null) || ($totalBytes === null)) {
+                // We need to look this up by calling HTTP early
+                $myfile = @fopen($enclosure->url, 'rb');
+                if ($myfile === false) {
+                    continue;
+                }
+                if (isset($http_response_header)) {
+                    $matches = [];
+                    foreach ($http_response_header as $header) {
+                        if (preg_match('#^Content-Type: ([^/\s]*/[^/\s]*)(\s|;|$)#i', $header, $matches) != 0) {
+                            if ($mediaType === null) {
+                                $mediaType = $matches[1];
+                            }
+                        } elseif (preg_match('#^Content-Length: (\d+)*(;|$)#i', $header, $matches) != 0) {
+                            $totalBytes = intval($matches[1]);
+                        }
+                    }
+                }
+                if (($mediaType === null) || ($totalBytes === null)) {
+                    fclose($myfile);
+                    continue;
+                }
+            } else {
+                $myfile = null;
+            }
+
+            switch ($enclosure->type) {
+                case Enclosure::ENCLOSURE_IMAGE:
+                    $gif = ($mediaType == 'image/gif');
+
+                    if (!$gif) {
+                        if (($numImagesDone > 4) || ($numVideosDone > 0)) {
+                            continue 2;
+                        }
+
+                        $numImagesDone++;
+
+                        if (!in_array($mediaType, ['image/jpeg', 'image/png', 'image/webp'])) {
+                            continue 2;
+                        }
+
+                        if ($totalBytes > 5000000) {
+                            continue 2;
+                        }
+
+                        break;
+                    }
+                    // no break
+
+                case Enclosure::ENCLOSURE_VIDEO:
+                case Enclosure::ENCLOSURE_AUDIO:
+                    if (($numImagesDone > 0) || ($numVideosDone > 0)) {
+                        continue 2;
+                    }
+
+                    $numVideosDone++;
+
+                    if (!in_array($mediaType, ['video/mp4', 'image/gif'])) {
+                        continue 2;
+                    }
+
+                    if ($totalBytes > 15000000) {
+                        continue 2;
+                    }
+
+                    break;
+
+                default:
+                    continue 2;
+            }
+
+            if ($myfile === null) {
+                $myfile = @fopen($enclosure->url, 'rb');
+                if ($myfile === false) {
+                    continue;
+                }
+            }
+
+            $apiUrl = 'https://upload.twitter.com/1.1/media/upload.json';
+            $parameters = [
+                'command' =>'INIT',
+                'media_type' => $mediaType,
+                'total_bytes' => strval($totalBytes),
+            ];
+            $mediaResult = $this->apiRequest($apiUrl, 'POST', $parameters, [], true);
+            $mediaId = $mediaResult->media_id_string;
+
+            $segmentIndex = 0;
+            do {
+                $bytes = fread($myfile, $segmentSize);
+
+                $parameters = [
+                    'command' => 'APPEND',
+                    'media' => $bytes,
+                    'media_id' => $mediaId,
+                    'segment_index' => $segmentIndex,
+                ];
+                $this->apiRequest($apiUrl, 'POST', $parameters, [], true);
+
+                $segmentIndex++;
+            } while (!feof($myfile));
+
+            fclose($myfile);
+
+            $parameters = [
+                'command' => 'FINALIZE',
+                'media_id' => $mediaId,
+            ];
+            $this->apiRequest($apiUrl, 'POST', $parameters);
+
+            $mediaIds[] = $mediaId;
+        }
+
+        @ini_set('allow_url_fopen', $allow_url_fopen);
+
+        // Make request...
+
+        $apiUrl = 'statuses/update.json';
+        $parameters = [
+            'status' => $status,
+        ];
+        if (!empty($mediaIds)) {
+            $parameters['media_ids'] = implode(',', $mediaIds);
+        }
+        $result = $this->apiRequest($apiUrl, 'POST', $parameters);
+
+        return $result->id_str;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteAtom($identifier)
+    {
+        $apiUrl = 'statuses/destroy/' . $identifier . '.json';
+
+        $this->apiRequest($apiUrl, 'POST');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCategories()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveCategory($category)
+    {
+        throw new NotImplementedException('There are no categories on Twitter.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteCategory($identifier)
+    {
+        throw new NotImplementedException('There are no categories on Twitter.');
     }
 }

--- a/src/Provider/YouTube.php
+++ b/src/Provider/YouTube.php
@@ -1,0 +1,837 @@
+<?php
+/*!
+* Hybridauth
+* https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+*  (c) 2020 Hybridauth authors | https://hybridauth.github.io/license.html
+*/
+
+namespace Hybridauth\Provider;
+
+use Hybridauth\Adapter\OAuth2;
+use Hybridauth\Adapter\AtomInterface;
+use Hybridauth\Exception\UnexpectedApiResponseException;
+use Hybridauth\Exception\InvalidArgumentException;
+use Hybridauth\Exception\RuntimeException;
+use Hybridauth\Exception\NotImplementedException;
+use Hybridauth\Data;
+use Hybridauth\User;
+use Hybridauth\Atom\Atom;
+use Hybridauth\Atom\Enclosure;
+use Hybridauth\Atom\Category;
+use Hybridauth\Atom\Author;
+use Hybridauth\Atom\AtomFeedBuilder;
+use Hybridauth\Atom\AtomHelper;
+use Hybridauth\Atom\Filter;
+
+/**
+ * YouTube OAuth2 provider adapter.
+ *
+ * Example:
+ *
+ *   $config = [
+ *       'callback'   => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys'       => [ 'id' => '', 'secret' => '' ],
+ *       'scope'      => 'https://www.googleapis.com/auth/userinfo.profile
+ *           https://www.googleapis.com/auth/youtube.force-ssl',
+ *       'channel_id' => '',
+ *   ];
+ *
+ *   $adapter = new Hybridauth\Provider\YouTube( $config );
+ *
+ *   try {
+ *       $adapter->authenticate();
+ *
+ *       $userProfile = $adapter->getUserProfile();
+ *       $tokens = $adapter->getAccessToken();
+ *   }
+ *   catch( Exception $e ){
+ *       echo $e->getMessage() ;
+ *   }
+ */
+class YouTube extends OAuth2 implements AtomInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    // phpcs:ignore
+    protected $scope = 'https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/youtube.force-ssl';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiBaseUrl = 'https://www.googleapis.com/';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $authorizeUrl = 'https://accounts.google.com/o/oauth2/auth';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $accessTokenUrl = 'https://accounts.google.com/o/oauth2/token';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://developers.google.com/youtube/v3/docs';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        $this->AuthorizeUrlParameters += [
+            'access_type' => 'offline'
+        ];
+
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret
+            ];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * See: https://developers.google.com/identity/protocols/OpenIDConnect#obtainuserinfo
+     */
+    public function getUserProfile()
+    {
+        $userProfile = new User\Profile();
+
+        $response = $this->apiRequest('oauth2/v3/userinfo');
+
+        $data = new Data\Collection($response);
+
+        if (!$data->exists('sub')) {
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+        }
+
+        $userProfile->photoURL    = $data->get('picture');
+        if ($this->config->get('photo_size')) {
+            $userProfile->photoURL .= '?sz=' . $this->config->get('photo_size');
+        }
+
+        $userProfile->language    = $data->get('locale');
+
+        // We'll actually use channel data for certain things...
+
+        $channel = $this->getChannel();
+
+        $snippet = $channel->snippet;
+
+        $userProfile->photoURL = $this->getBestThumbnail($snippet);
+        $userProfile->identifier  = $channel->id;
+        $userProfile->displayName = $snippet->title;
+        if (empty($snippet->customUrl)) {
+            $userProfile->profileURL  = 'https://www.youtube.com/channel/' . $channel->id;
+        } else {
+            $userProfile->profileURL  = $snippet->customUrl;
+        }
+
+        return $userProfile;
+    }
+
+    /**
+     * Get the best thumbnail for a channel.
+     *
+     * @return ?string
+     */
+    protected function getBestThumbnail($snippet)
+    {
+        $photoURL = null;
+
+        $thumbnails = [];
+        foreach ($snippet->thumbnails as $key => $thumbnail) {
+            if (isset($thumbnail->width)) {
+                $width = $thumbnail->width;
+            } else {
+                switch ($key) {
+                    case 'medium':
+                        $width = 240;
+                        break;
+                    case 'high':
+                        $width = 800;
+                        break;
+                    default:
+                        $width = 88;
+                        break;
+                }
+            }
+            $thumbnails[$thumbnail->url] = $width;
+        }
+
+        if ($this->config->get('photo_size')) {
+            foreach ($thumbnails as $url => $width) {
+                if (($width == $this->config->get('photo_size'))) {
+                    $photoURL = $url;
+                }
+            }
+        }
+        if ($photoURL === null) {
+            $maxWidth = null;
+            foreach ($thumbnails as $url => $width) {
+                if (($maxWidth === null) || ($width > $maxWidth)) {
+                    $maxWidth = $width;
+                    $photoURL = $url;
+                }
+            }
+        }
+
+        return $photoURL;
+    }
+
+    /**
+     * Get the user's channel object.
+     *
+     * @return object
+     * @throws RuntimeException
+     */
+    protected function getChannel()
+    {
+        $channelId = $this->config->get('channel_id') ?: null;
+
+        $params = [
+            'part' => 'id,snippet,contentDetails',
+            'mine' => 'true',
+            'maxResults' => '30',
+        ];
+        $response = $this->apiRequest('youtube/v3/channels', 'GET', $params);
+
+        $data = new Data\Collection($response);
+
+        foreach ($data->get('items') as $channel) {
+            if (($channelId === null) || ($data->get('id') == $channelId)) {
+                return $channel;
+            }
+        }
+
+        if ($channelId === null) {
+            throw new RuntimeException('Could not find a channel');
+        } else {
+            throw new RuntimeException('Could not find specified channel, ' . $channelId);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserContacts()
+    {
+        $contacts = [];
+
+        $apiUrl = 'youtube/v3/subscriptions';
+        $nextPageToken = [];
+
+        do {
+            $params = [
+                'mine' => 'true',
+                'maxResults' => 50,
+                'part' => 'snippet',
+            ];
+            if ($nextPageToken !== null) {
+                $params['pageToken'] = $nextPageToken;
+            }
+            $response = $this->apiRequest($apiUrl, 'GET', $params);
+
+            $data = new Data\Collection($response);
+
+            if (!$data->exists('items')) {
+                throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+            }
+
+            foreach ($data->get('items') as $item) {
+                $contacts[] = $this->fetchUserContact($item);
+            }
+
+            if ($data->exists('nextPageToken')) {
+                $nextPageToken = $data->get('nextPageToken');
+            } else {
+                $nextPageToken = null;
+            }
+        } while ($nextPageToken !== null);
+
+        return $contacts;
+    }
+
+    /**
+     * Parse the user contact.
+     *
+     * @param object $item
+     *
+     * @return \Hybridauth\User\Contact
+     */
+    protected function fetchUserContact($item)
+    {
+        $userContact = new User\Contact();
+
+        $snippet = $item->snippet;
+
+        $userContact->identifier = $snippet->channelId;
+        $userContact->displayName = $snippet->title;
+
+        $userContact->profileURL = 'https://www.youtube.com/channel/' . $snippet->channelId;
+
+        $userContact->photoURL = $this->getBestThumbnail($snippet);
+
+        return $userContact;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildAtomFeed($filter = null, $trulyValid = false)
+    {
+        $userProfile = $this->getUserProfile();
+        list($atoms) = $this->getAtoms($filter);
+
+        $utility = new AtomFeedBuilder();
+        $title = 'YouTube feed of ' . $userProfile->displayName;
+        $feedId = 'urn:hybridauth:youtube:' . $userProfile->identifier . ':' . md5(serialize(func_get_args()));
+        $urnStub = 'urn:hybridauth:youtube:';
+        $url = $userProfile->profileURL;
+        return $utility->buildAtomFeed($title, $url, $feedId, $urnStub, $atoms, $trulyValid);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtoms($filter = null)
+    {
+        if ($filter === null) {
+            $filter = new Filter();
+        }
+
+        $atoms = [];
+        $hasResults = false;
+
+        $etf = $filter->enclosureTypeFilter;
+        if (($etf !== null) && (($etf & Enclosure::ENCLOSURE_VIDEO) != 0)) {
+            return $atoms;
+        }
+
+        if ($filter->categoryFilter !== null) {
+            throw new NotImplementedException('Category filtering is not implementable efficiently');
+        }
+
+        $userProfile = $this->getUserProfile();
+
+        $channel = $this->getChannel();
+
+        $playlistId = $channel->contentDetails->relatedPlaylists->uploads;
+
+        $nextPageToken = null;
+        do {
+            $url = 'youtube/v3/playlistItems';
+            $params = [
+                'part' => 'id,snippet,status',
+                'maxResults' => min(50, $filter->limit - count($atoms)),
+                'playlistId' => $playlistId,
+            ];
+            if ($nextPageToken !== null) {
+                $params['pageToken'] = $nextPageToken;
+            }
+            $videosResponse = $this->apiRequest($url, 'GET', $params);
+            $videosData = new Data\Collection($videosResponse);
+            if (!$videosData->exists('items')) {
+                throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+            }
+
+            foreach ($videosData->get('items') as $remoteVideo) {
+                $hasResults = true;
+
+                if ((!$filter->includePrivate) && ($remoteVideo->status->privacyStatus != 'public')) {
+                    continue;
+                }
+
+                $detectedVideo = $this->parseYouTubeVideo($remoteVideo, $userProfile);
+                if ($detectedVideo !== null) {
+                    $atoms[] = $detectedVideo;
+
+                    if (count($atoms) == $filter->limit) {
+                        break 2;
+                    }
+                }
+            }
+
+            if (empty($videosData->get('nextPageToken'))) {
+                $nextPageToken = null;
+            } else {
+                $nextPageToken = $videosData->get('nextPageToken');
+            }
+        } while ($nextPageToken !== null);
+
+        return [$atoms, $hasResults];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtomFull($identifier)
+    {
+        $userProfile = $this->getUserProfile();
+
+        $url = 'youtube/v3/videos';
+        $params = [
+            'part' => 'id,snippet,status',
+            'id' => $identifier,
+        ];
+        $videosResponse = $this->apiRequest($url, 'GET', $params);
+        $videosData = new Data\Collection($videosResponse);
+        if (!$videosData->exists('items')) {
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+        }
+
+        if (empty($videosData->get('items'))) {
+            throw new UnexpectedApiResponseException('Could not find the video.');
+        }
+
+        return $this->parseYouTubeVideo($videosData->get('items')[0], $userProfile);
+    }
+
+    /**
+     * Convert a YouTube video into an atom.
+     *
+     * @param object $remoteVideo Data from video
+     * @param User\Profile $userProfile User profile of channel owner
+     *
+     * @return Atom
+     * @throws \Exception
+     */
+    protected function parseYouTubeVideo($remoteVideo, $userProfile)
+    {
+        $atom = new Atom();
+
+        $snippet = $remoteVideo->snippet;
+
+        // Find highest resolution thumbnail
+        $bestWidth = null;
+        $thumbUrl = null;
+        foreach ($snippet->thumbnails as $thumbnail) {
+            if (($bestWidth === null) || ($thumbnail->width > $bestWidth)) {
+                $thumbUrl = $thumbnail->url;
+                $bestWidth = $thumbnail->width;
+            }
+        }
+
+        if (isset($snippet->resourceId->videoId)) {
+            $atom->identifier = $snippet->resourceId->videoId;
+            $atom->isIncomplete = true; // As comes from playlist
+        } else {
+            $atom->identifier = $remoteVideo->id;
+            $atom->isIncomplete = false;
+
+            $categories = $this->getCategories();
+            $categoryId = isset($snippet->categoryId) ? $snippet->categoryId : null;
+            $atom->categories = [$categories[$categoryId]];
+
+            $atom->hashTags = $snippet->tags;
+        }
+        $atom->published = new \DateTime($snippet->publishedAt);
+        $atom->title = $snippet->title;
+        $atom->url = 'https://www.youtube.com/watch?v=' . $atom->identifier;
+
+        $text = AtomHelper::plainTextToHtml($snippet->description);
+        list($text, $repped) = AtomHelper::processCodes($text, null, null, true);
+        $atom->content = $text;
+
+        $atom->enclosures = [];
+        $enclosure = new Enclosure();
+        $enclosure->type = Enclosure::ENCLOSURE_VIDEO;
+        $enclosure->url = $atom->url;
+        $enclosure->thumbnailUrl = $thumbUrl;
+        $atom->enclosures[] = $enclosure;
+
+        $author = new Author();
+        $author->identifier = $userProfile->identifier;
+        $author->displayName = $userProfile->displayName;
+        $author->profileURL = $userProfile->profileURL;
+        $author->photoURL = $userProfile->photoURL;
+        $atom->author = $author;
+
+        return $atom;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAtomFullFromURL($url)
+    {
+        $matches = [];
+        if (preg_match('#^https?://youtu\.be/([\w\-]+)#', $url, $matches) != 0) {
+            $identifier = $matches[1];
+            return $this->getAtomFull($identifier);
+        }
+        if (preg_match('#^https?://www\.youtube\.com/watch\?v=([\w\-]+)#', $url, $matches) != 0) {
+            $identifier = $matches[1];
+            return $this->getAtomFull($identifier);
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOEmbedFromURL($url, $params = [])
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveAtom($atom, &$messages = [])
+    {
+        $title = $atom->title;
+        AtomHelper::limitLengthTo($title, 70);
+
+        if (($atom->content !== null) && (($atom->summary === null) || (AtomHelper::mbStrlen($atom->content) < 5000))) {
+            $description = AtomHelper::htmlToPlainText($atom->content);
+        } elseif ($atom->summary !== null) {
+            $description = AtomHelper::htmlToPlainText($atom->summary);
+        }
+        AtomHelper::limitLengthTo($description, 5000);
+        if (!empty($atom->url)) {
+            AtomHelper::appendIfWithinLimit($description, "\n\n" . $atom->url, 5000);
+        }
+
+        if (!empty($atom->categories)) {
+            $categoryId = $atom->categories[0]->identifier;
+        } else {
+            $allCategories = $this->getCategories();
+            $keys = array_keys($allCategories);
+            $categoryId = $keys[0];
+        }
+
+        $request = [
+            'snippet' => [
+                'title' => $title,
+                'description' => $description,
+                'tags' => $atom->hashTags,
+                'categoryId' => $categoryId,
+            ],
+        ];
+
+        if ($atom->identifier === null) {
+            // Add
+            $videoResponse = null;
+            $videoId = null;
+            foreach ($atom->enclosures as $enclosure) {
+                if (in_array($enclosure->type, [Enclosure::ENCLOSURE_VIDEO, Enclosure::ENCLOSURE_AUDIO])) {
+                    $videoResponse = $this->uploadVideo($request, $enclosure);
+                    if ($videoResponse !== null) {
+                        $videoId = $videoResponse->id;
+                        try {
+                            $thumbnailUploadResponse = $this->uploadThumbnail($videoId, $enclosure);
+                        } catch (\Exception $e) {
+                            // We can safely ignore exceptions here as they do not matter
+                            //  (YouTube will create its own thumbnail)
+
+                            $messages[] = $e->getMessage();
+                        }
+                    }
+                    break;
+                }
+            }
+            if ($videoResponse === null) {
+                throw new InvalidArgumentException('No video enclosure, so cannot upload to YouTube');
+            }
+
+            return $videoId;
+        } else {
+            // Edit
+            //  Note that this doesn't replace the actual video data, YouTube does not allow that
+            //  We could do a delete and re-add, but the ID would change, and atom API disallows this
+            $request['id'] = $atom->identifier;
+            $url = 'youtube/v3/videos?id=' . urlencode($atom->identifier) . '&part=snippet';
+            $headers = [
+                'Content-Type' => 'application/json',
+            ];
+            $this->apiRequest($url, 'PUT', $request, $headers);
+
+            $messages[] = 'Video data not replaced, unsupported by YouTube';
+
+            return $atom->identifier;
+        }
+    }
+
+    /**
+     * Upload actual YouTube video.
+     *
+     * @param array $request Request structure
+     * @param Enclosure $enclosure Video enclosure
+     *
+     * @return object The metadata response object
+     * @throws InvalidArgumentException
+     * @throws UnexpectedApiResponseException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     */
+    protected function uploadVideo($request, $enclosure)
+    {
+        $videoResponse = null;
+
+        // Get source file, copying it into a temporary file...
+
+        $mediaType = $enclosure->mimeType;
+        $totalBytes = $enclosure->contentLength;
+
+        $allow_url_fopen = @ini_get('allow_url_fopen');
+        @ini_set('allow_url_fopen', 'On');
+
+        $myfile = @fopen($enclosure->url, 'rb');
+        if ($myfile === false) {
+            @ini_set('allow_url_fopen', $allow_url_fopen);
+
+            throw new InvalidArgumentException('Video file not found');
+        }
+        if (isset($http_response_header)) {
+            $matches = [];
+            foreach ($http_response_header as $header) {
+                if (preg_match('#^Content-Type: ([^/\s]*/[^/\s]*)(\s|;|$)#i', $header, $matches) != 0) {
+                    if ($mediaType === null) {
+                        $mediaType = $matches[1];
+                    }
+                } elseif (preg_match('#^Content-Length: (\d+)*(;|$)#i', $header, $matches) != 0) {
+                    $totalBytes = intval($matches[1]);
+                }
+            }
+        }
+        if ($mediaType === null) {
+            $mediaType = 'application/octet-stream';
+        } else {
+            if (strpos($mediaType, 'video/') === false) {
+                fclose($myfile);
+
+                throw new InvalidArgumentException('Not a raw web-safe video file');
+            }
+        }
+
+        if ($totalBytes === null) {
+            @ini_set('allow_url_fopen', $allow_url_fopen);
+
+            throw new InvalidArgumentException('Video file size not found');
+
+            fclose($myfile);
+        }
+
+        try {
+            // Upload metadata...
+
+            stream_set_blocking($myfile, true);
+
+            $chunkSize = 500000;
+
+            $url = 'upload/youtube/v3/videos?uploadType=resumable&part=snippet,status,contentDetails';
+            $headers = [
+                'X-Upload-Content-Length' => min($chunkSize, $totalBytes),
+                'X-Upload-Content-Type' => $mediaType,
+                'Content-Type' => 'application/json',
+            ];
+            $videoResponse = $this->apiRequest($url, 'POST', $request, $headers);
+
+            $responseHeaders = $this->httpClient->getResponseHeader();
+
+            $urlTo = null;
+            foreach ($responseHeaders as $header => $value) {
+                $matches = [];
+                if (strtolower($header) == 'location') {
+                    $urlTo = $value;
+                }
+            }
+
+            if ($urlTo === null) {
+                @ini_set('allow_url_fopen', $allow_url_fopen);
+
+                throw new UnexpectedApiResponseException('Upload initialization failed');
+            }
+
+            // Upload video data in chunks...
+
+            $i = 0;
+            do {
+                // Complex code because of HTTP chunked encoding causing fread to finish early
+                $data = '';
+                do {
+                    $data .= fread($myfile, $chunkSize);
+                } while ((strlen($data) < $chunkSize) && (!feof($myfile)));
+
+                $header = 'Content-Type: ' . $mediaType;
+                $header .= 'Content-Length: ' . strlen($data);
+                foreach ($this->apiRequestHeaders as $key => $val) {
+                    $header .= "\r\n" . $key . ': ' . $val;
+                }
+
+                $opts = ['http' =>
+                    [
+                        'method'  => 'PUT',
+                        'header'  => $header,
+                        'content' => $data,
+                        'ignore_errors' => true,
+                    ]
+                ];
+                $context  = stream_context_create($opts);
+
+                $uploadResult = file_get_contents($urlTo, false, $context);
+                //@var_dump($uploadResult);exit(); //Useful for debugging
+
+                $matches = [];
+                $status_line = $http_response_header[0];
+                preg_match('#^HTTP\/\S*\s(\d{3})#', $status_line, $matches);
+                $status = $matches[1];
+
+                if (substr($status, 0, 1) != '2') {
+                    $err = 'Uploading failed on part #' . ($i + 1) . ' [status=' . $status . ']';
+                    throw new UnexpectedApiResponseException($err);
+                }
+
+                $i++;
+            } while (!feof($myfile));
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            @ini_set('allow_url_fopen', $allow_url_fopen);
+
+            @fclose($myfile);
+        }
+
+        return $videoResponse;
+    }
+
+    /**
+     * Upload actual YouTube thumbnail.
+     *
+     * @param string $id Video ID
+     * @param Enclosure $enclosure Video enclosure
+     *
+     * @return ?object Thumbnail upload response object (null: no thumbnail uploaded)
+     * @throws InvalidArgumentException
+     * @throws \Hybridauth\Exception\HttpClientFailureException
+     * @throws \Hybridauth\Exception\HttpRequestFailedException
+     * @throws \Hybridauth\Exception\InvalidAccessTokenException
+     */
+    protected function uploadThumbnail($id, $enclosure)
+    {
+        if ($enclosure->thumbnailUrl === null) {
+            return null;
+        }
+
+        // Get source file, copying it into a temporary file...
+
+        $mediaType = $enclosure->mimeType;
+
+        $allow_url_fopen = @ini_get('allow_url_fopen');
+        @ini_set('allow_url_fopen', 'On');
+
+        $myfile = @fopen($enclosure->thumbnailUrl, 'rb');
+        if ($myfile === false) {
+            @ini_set('allow_url_fopen', $allow_url_fopen);
+
+            throw new InvalidArgumentException('Video file not found');
+        }
+        if (isset($http_response_header)) {
+            $matches = [];
+            foreach ($http_response_header as $header) {
+                if (preg_match('#^Content-Type: ([^/\s]*/[^/\s]*)(\s|;|$)#i', $header, $matches) != 0) {
+                    if ($mediaType === null) {
+                        $mediaType = $matches[1];
+                    }
+                }
+            }
+        }
+        if ($mediaType !== null) {
+            if (!in_array($mediaType, ['image/png', 'image/jpeg'])) {
+                fclose($myfile);
+
+                $err = 'Not an acceptable image file type for the thumbnail (' . $mediaType . ')';
+                throw new InvalidArgumentException($err);
+            }
+        }
+
+        $tempnam = tempnam(sys_get_temp_dir(), 'youtube_thumbnail');
+        $tmpfile = fopen($tempnam, 'wb');
+        stream_copy_to_stream($myfile, $tmpfile);
+        fclose($myfile);
+
+        @ini_set('allow_url_fopen', $allow_url_fopen);
+
+        try {
+            $url = 'upload/youtube/v3/thumbnails/set?videoId=' . $id;
+
+            $file = new \CURLFile($tempnam, 'image/png', 'file');
+
+            $thumbnailUploadResponse = $this->apiRequest($url, 'POST', ['file' => $file], [], true);
+        } catch (\Exception $e) {
+            throw $e;
+        } finally {
+            @fclose($tmpfile);
+            @unlink($tempnam);
+        }
+
+        return $thumbnailUploadResponse;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteAtom($identifier)
+    {
+        $this->apiRequest('youtube/v3/videos', 'DELETE', ['id' => $identifier]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCategories()
+    {
+        $country = $this->config->get('primary_country') ?: 'US';
+
+        $params = [
+            'part' => 'snippet',
+            'regionCode' => $country,
+        ];
+        $response = $this->apiRequest('youtube/v3/videoCategories', 'GET', $params);
+
+        $data = new Data\Collection($response);
+
+        if (!$data->exists('items')) {
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+        }
+
+        $categories = [];
+
+        foreach ($data->get('items') as $youTubeCategory) {
+            if ($youTubeCategory->snippet->assignable) {
+                $category = new Category();
+                $category->identifier = $youTubeCategory->id;
+                $category->label = $youTubeCategory->snippet->title;
+                $categories[$youTubeCategory->id] = $category;
+            }
+        }
+
+        return $categories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveCategory($category)
+    {
+        throw new NotImplementedException('Provider does not support this feature.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteCategory($identifier)
+    {
+        throw new NotImplementedException('Provider does not support this feature.');
+    }
+}


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes

This is a major expansion of Hybridauth, to be able to do two-way transfer of content data using a data structure based on the Atom feed format. This includes multimedia.

It fixes a major pain point many of us will have working with social media - while the companies give us APIs, they don't follow basic standards for interoperability as they are fundamentally disinterested (i.e. it's against their interests). With this, Hybridauth becomes middleware to provide this missing functionality.

You can even ask Hybridauth to create an actual Atom feed for you with this API.

It is up to individual providers to implement the API, if they can and want to. I've tried to avoid making this bloated, while also making it very flexible.

This initial implementation adds read/write support for Facebook, Twitter, and YouTube. It adds read-support for Instagram (as write-support is not possible in the public API).
YouTube is a totally new provider.

I expect this can all eventually replace the old status API that a few providers currently implement, as this provides all that functionality and a lot more. However, we don't need to worry about that for now.

Btw, some of the HTTP stuff is done using native PHP URL wrappers. This is because I didn't want to try and force the existing HttpClientInterface to deal with the unusual call patterns chunked uploading requires, and we can always rely on PHP URL wrappers working. If this is a problem (and I'm really hoping it's not), we should probably just rip out HttpClientInterface from Hybridauth and directly depend on Guzzle (if even that could do this cleanly, I don't know).