### PR TITLE
Move apple related deps to suggest section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "gitter": "https://gitter.im/hybridauth/hybridauth"
     },
     "require": {
-        "php": "^5.4 || ^7.0 || ^8.0",
+        "php": "^5.4 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,14 @@
     },
     "require": {
         "php": "^5.4 || ^7.0 || ^8.0",
-        "firebase/php-jwt": "^4.0 || ^5.0",
-        "phpseclib/phpseclib": "~2.0"
     },
     "require-dev": {
         "ext-curl": "*",
         "phpunit/phpunit": "^4.8.35 || ^6.5 || ^8.0"
+    },
+    "suggest": {
+        "firebase/php-jwt": "Needed to support Apple provider",
+        "phpseclib/phpseclib": "Needed to support Apple provider"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Sometimes dependencies will cause conflicts. In my case it was `phpseclib`. I not use apple provider so I do not need those deps.
And even if I used it - phpseclib already exist and loaded in my case.
More detail about problem here https://github.com/zorn-v/nextcloud-social-login/issues/218