### PR TITLE
Add Basic authorization info before exchange token

### DIFF
--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -428,6 +428,10 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
                 . 'of this page is either invalid or has already been consumed.'
             );
         }
+        
+        // Before request oauth server, the basic authorization info should be provided.
+        $basic = base64_encode($this->tokenExchangeParameters['client_id'] . ':' . $this->tokenExchangeParameters['client_secret']);
+        $this->tokenExchangeHeaders['Authorization'] = 'Basic ' . $basic;
 
         /**
          * Authorization Request Code


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->

Support some oauth2 server need basic authorization.