### PR TITLE
Do not pass null to date_parse

### DIFF
--- a/src/Data/Parser.php
+++ b/src/Data/Parser.php
@@ -112,7 +112,7 @@ final class Parser
      */
     public function parseBirthday($birthday, $seperator)
     {
-        $birthday = date_parse($birthday);
+        $birthday = date_parse((string) $birthday);
 
         return [$birthday['year'], $birthday['month'], $birthday['day']];
     }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1318
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

Fixes `E_DEPRECATED: date_parse(): Passing null to parameter #1 ($datetime) of type string is deprecated`
