### PR TITLE
Remove unused $separator in parseBirthday

### DIFF
--- a/src/Data/Parser.php
+++ b/src/Data/Parser.php
@@ -106,11 +106,10 @@ final class Parser
      * needs to be improved
      *
      * @param $birthday
-     * @param $seperator
      *
      * @return array
      */
-    public function parseBirthday($birthday, $seperator)
+    public function parseBirthday($birthday)
     {
         $birthday = date_parse($birthday);
 

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -242,7 +242,7 @@ class Facebook extends OAuth2
      */
     protected function fetchBirthday(User\Profile $userProfile, $birthday)
     {
-        $result = (new Data\Parser())->parseBirthday($birthday, '/');
+        $result = (new Data\Parser())->parseBirthday($birthday);
 
         $userProfile->birthYear = (int)$result[0];
         $userProfile->birthMonth = (int)$result[1];

--- a/src/Provider/Spotify.php
+++ b/src/Provider/Spotify.php
@@ -82,7 +82,7 @@ class Spotify extends OAuth2
      */
     protected function fetchBirthday(User\Profile $userProfile, $birthday)
     {
-        $result = (new Data\Parser())->parseBirthday($birthday, '-');
+        $result = (new Data\Parser())->parseBirthday($birthday);
 
         $userProfile->birthDay = (int)$result[0];
         $userProfile->birthMonth = (int)$result[1];


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | none
| Patch: Bug Fix?          | no
| Major: Breaking Change?  | TBD
| Minor: New Feature?      | no

This is a proposal for a code cleanup. Since Parser is an internal class it should not be considered a breaking change. Feel free to discard it if it is a breaking change
