### PR TITLE
Fix PHP 8.1 deprecation in OpenID.php

### DIFF
--- a/src/Adapter/OpenID.php
+++ b/src/Adapter/OpenID.php
@@ -252,7 +252,7 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
      */
     protected function fetchUserGender(User\Profile $userProfile, $gender)
     {
-        $gender = strtolower($gender);
+        $gender = strtolower((string)$gender);
 
         if ('f' == $gender) {
             $gender = 'female';


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->

Fixes the following deprecation message by type casting a function parameter.

```console
Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/hybridauth/hybridauth/src/Adapter/OpenID.php on line 255
```