### PR TITLE
Provide support for Firebase/JWT version 6.2

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -7,8 +7,8 @@
 
 namespace Hybridauth\Provider;
 
-use Hybridauth\Exception\InvalidArgumentException;
-use Hybridauth\Exception\UnexpectedApiResponseException;
+use Exception;
+use Firebase\JWT\ExpiredException;
 use Hybridauth\Exception\InvalidApplicationCredentialsException;
 use Hybridauth\Exception\UnexpectedValueException;
 
@@ -19,8 +19,7 @@ use Hybridauth\User;
 use phpseclib\Crypt\RSA;
 use phpseclib\Math\BigInteger;
 
-use \Firebase\JWT\JWT;
-use \Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 
 /**
  * Apple OAuth2 provider adapter.
@@ -110,7 +109,7 @@ class Apple extends OAuth2
         $keys = $this->config->get('keys');
         $keys['secret'] = $this->getSecret();
         $this->config->set('keys', $keys);
-        return parent::configure();
+        parent::configure();
     }
 
     /**
@@ -170,7 +169,7 @@ class Apple extends OAuth2
             // validate the token signature and get the payload
             $publicKeys = $this->apiRequest('keys');
 
-            \Firebase\JWT\JWT::$leeway = 120;
+            JWT::$leeway = 120;
 
             $error = false;
             $payload = null;
@@ -190,15 +189,15 @@ class Apple extends OAuth2
 
                     $payload = JWT::decode($id_token, $pem, ['RS256']);
                     break;
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     $error = $e->getMessage();
-                    if ($e instanceof \Firebase\JWT\ExpiredException) {
+                    if ($e instanceof ExpiredException) {
                         break;
                     }
                 }
             }
             if ($error) {
-                throw new \Exception($error);
+                throw new Exception($error);
             }
         }
 

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -7,6 +7,7 @@
 
 namespace Hybridauth\Provider;
 
+use Composer\InstalledVersions;
 use Exception;
 use Firebase\JWT\ExpiredException;
 use Hybridauth\Exception\InvalidApplicationCredentialsException;
@@ -20,6 +21,7 @@ use phpseclib\Crypt\RSA;
 use phpseclib\Math\BigInteger;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 /**
  * Apple OAuth2 provider adapter.
@@ -187,7 +189,9 @@ class Apple extends OAuth2
                     );
                     $pem = $rsa->getPublicKey();
 
-                    $payload = JWT::decode($id_token, $pem, ['RS256']);
+                    $payload = ($this->getJwtVersion() < '6.2') ?
+                        JWT::decode($id_token, $pem, ['RS256']) :
+                        JWT::decode($id_token, new Key($pem, 'RS256'));
                     break;
                 } catch (Exception $e) {
                     $error = $e->getMessage();
@@ -283,5 +287,10 @@ class Apple extends OAuth2
         $secret = JWT::encode($data, $key_content, 'ES256', $key_id);
 
         return $secret;
+    }
+
+    private function getJwtVersion()
+    {
+        return InstalledVersions::getVersion('firebase/php-jwt');
     }
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1331
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

fIrebase/jwt 6.2.0 has changed the way `jwt::decode()` is called. Because this is just a suggested package in hybridauth, the version can not be restricted in composer.json. Instead this patch adds an implementation to call `jwt::decode()` required by fIrebase/jwt 6.2.0 and later and does a version check to decide which call to use.

The patch has been tested with firebase/php-jwt version 5.5.1 and with version v6.2.0 successfully.