### PR TITLE
Apple JWT version check fixed for composer 1

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -299,6 +299,9 @@ class Apple extends OAuth2
 
     private function getJwtVersion()
     {
-        return InstalledVersions::getVersion('firebase/php-jwt');
+        // assume old JWT version if no version check is possible because composer 1 is installed
+        return class_exists('Composer\InstalledVersions') ?
+            InstalledVersions::getVersion('firebase/php-jwt') :
+            '';
     }
 }

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -10,6 +10,9 @@ namespace Hybridauth\Provider;
 use Composer\InstalledVersions;
 use Exception;
 use Firebase\JWT\ExpiredException;
+use Hybridauth\Exception\HttpClientFailureException;
+use Hybridauth\Exception\HttpRequestFailedException;
+use Hybridauth\Exception\InvalidAccessTokenException;
 use Hybridauth\Exception\InvalidApplicationCredentialsException;
 use Hybridauth\Exception\UnexpectedValueException;
 
@@ -112,6 +115,7 @@ class Apple extends OAuth2
 
     /**
      * {@inheritdoc}
+     * @throws InvalidApplicationCredentialsException
      */
     protected function configure()
     {
@@ -161,6 +165,15 @@ class Apple extends OAuth2
         return $collection;
     }
 
+    /**
+     * Get the user profile
+     *
+     * @throws HttpClientFailureException
+     * @throws InvalidAccessTokenException
+     * @throws UnexpectedValueException
+     * @throws HttpRequestFailedException
+     * @throws Exception
+     */
     public function getUserProfile()
     {
         $id_token = $this->getStoredData('id_token');
@@ -239,26 +252,35 @@ class Apple extends OAuth2
     }
 
     /**
+     * Get the Apple secret as a JWT token
+     *
      * @return string secret token
+     * @throws InvalidApplicationCredentialsException
      */
     private function getSecret()
     {
         // Your 10-character Team ID
-        if (!$team_id = $this->config->filter('keys')->get('team_id')) {
+        $team_id = $this->config->filter('keys')->get('team_id');
+
+        if (!$team_id) {
             throw new InvalidApplicationCredentialsException(
                 'Missing parameter team_id: your team id is required to generate the JWS token.'
             );
         }
 
         // Your Services ID, e.g. com.aaronparecki.services
-        if (!$client_id = $this->config->filter('keys')->get('id') ?: $this->config->filter('keys')->get('key')) {
+        $client_id = $this->config->filter('keys')->get('id') ?: $this->config->filter('keys')->get('key');
+
+        if (!$client_id) {
             throw new InvalidApplicationCredentialsException(
                 'Missing parameter id: your client id is required to generate the JWS token.'
             );
         }
 
         // Find the 10-char Key ID value from the portal
-        if (!$key_id = $this->config->filter('keys')->get('key_id')) {
+        $key_id = $this->config->filter('keys')->get('key_id');
+
+        if (!$key_id) {
             throw new InvalidApplicationCredentialsException(
                 'Missing parameter key_id: your key id is required to generate the JWS token.'
             );
@@ -269,7 +291,9 @@ class Apple extends OAuth2
 
         // Save your private key from Apple in a file called `key.txt`
         if (!$key_content) {
-            if (!$key_file = $this->config->filter('keys')->get('key_file')) {
+            $key_file = $this->config->filter('keys')->get('key_file');
+
+            if (!$key_file) {
                 throw new InvalidApplicationCredentialsException(
                     'Missing parameter key_content or key_file: your key is required to generate the JWS token.'
                 );
@@ -292,11 +316,17 @@ class Apple extends OAuth2
             'sub' => $client_id
         ];
 
-        $secret = JWT::encode($data, $key_content, 'ES256', $key_id);
-
-        return $secret;
+        return JWT::encode($data, $key_content, 'ES256', $key_id);
     }
 
+    /**
+     * Try to get the installed JWT version
+     *
+     * If composer 2 is installed use InstalledVersions::getVersion,
+     * otherwise return an empty string because no version check is available
+     *
+     * @return string|null
+     */
     private function getJwtVersion()
     {
         // assume old JWT version if no version check is possible because composer 1 is installed

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -196,7 +196,7 @@ class Apple extends OAuth2
                     );
                     $pem = $rsa->getPublicKey();
 
-                    $payload = ($this->getJwtVersion() < '6.2') ?
+                    $payload = (version_compare($this->getJwtVersion(), '6.2') < 0) ?
                         JWT::decode($id_token, $pem, ['RS256']) :
                         JWT::decode($id_token, new Key($pem, 'RS256'));
                     break;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes #1340
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

<!-- Describe your changes below in as much detail as possible -->

Check if Composer\InstalledVersions is available (not available with composer version 1.x) before checking the installed JWT version. If no version check is available, it is assumed an old JWT version (< 6.2) is installed.

(additionally JWT versions are now compared more safely using version_compare(), and I did some minor code cleanup and phpDoc updates)

<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
