### PR TITLE
Added client id and secret to refresh parameters

### DIFF
--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -45,6 +45,21 @@ class LinkedIn extends OAuth2
     /**
      * {@inheritdoc}
      */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret
+            ];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $fields = [


### PR DESCRIPTION
Both parameters are needed to be able to refresh the access token using the refresh token for LinkedIn.

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
