### PR TITLE
Update Odnoklassniki.php

### DIFF
--- a/additional-providers/hybridauth-odnoklassniki/Providers/Odnoklassniki.php
+++ b/additional-providers/hybridauth-odnoklassniki/Providers/Odnoklassniki.php
@@ -111,7 +111,7 @@ class Hybrid_Providers_Odnoklassniki extends Hybrid_Provider_Model_OAuth2
 			$this->authodnoklass($code);
 		}
 		catch (Exception $e) {
-			throw new Exception("User profile request failed! {$this->providerId} returned an error: $e->getMessage() ", 6);
+			throw new Exception("User profile request failed! {$this->providerId} returned an error: {$e->getMessage()} ", 6);
 		}
 		// Check if authenticated
 		if (!$this->api->access_token) {


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

Fix incorrect string interpolation, getMessage in Exception is a method, not a property, so we need curly braces. With out it was "Notice: Undefined property: Exception::$getMessage".
