### PR TITLE
Bugfix scope "email" Update Apple.php

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -244,9 +244,11 @@ class Apple extends OAuth2
             $user = new Data\Collection($objUser);
             if (!$user->isEmpty()) {
                 $name = $user->get('name');
-                $userProfile->firstName = $name->firstName;
-                $userProfile->lastName = $name->lastName;
-                $userProfile->displayName = join(' ', [$userProfile->firstName, $userProfile->lastName]);
+                if (!empty($name->firstName)) {
+                    $userProfile->firstName = $name->firstName;
+                    $userProfile->lastName = $name->lastName;
+                    $userProfile->displayName = join(' ', [$userProfile->firstName, $userProfile->lastName]);
+                }
             }
         }
 


### PR DESCRIPTION
solves an undefined property on null error if scope is kept with "email" instead of "name email".

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

<!-- Describe your changes below in as much detail as possible -->
solves an undefined property on null error if scope is keeped with "email" instead of "name email".

<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
