### PR TITLE
getConfig() Update AbstractAdapter.php

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -114,6 +114,14 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
+     * @return mixed
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
      * Load adapter's configuration
      */
     abstract protected function configure();


### PR DESCRIPTION
add getConfig() to allow handle special use cases like calling via apiRequest() additional resources an passing for example $adapter->getConfig()->get('keys')['secret'] to ->apiRequest('revoke', ...) for Apple Auth

| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Yes

<!-- Describe your changes below in as much detail as possible -->
allow for flexible integrations by allowing reading for example generated secret by Adapter

<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
