### PR TITLE
Clear invalid authorization_state during OAuth2 login

### DIFF
--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -427,6 +427,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         if ($this->supportRequestState
             && (!$state || $this->getStoredData('authorization_state') != $state)
         ) {
+            $this->deleteStoredData('authorization_state');
             throw new InvalidAuthorizationStateException(
                 'The authorization state [state=' . substr(htmlentities($state), 0, 100) . '] '
                 . 'of this page is either invalid or has already been consumed.'


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | https://github.com/hybridauth/hybridauth/issues/1301, partially
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

There are some rare interactions where the cached OAuth2 state can get used without the login flow succeeding, like if a timeout happens or the user hits back at just the wrong moment, or other cases which I do not understand. If this happens, the browser gets jammed and cannot login, because it's stuck with an old session cookie with the invalid state.

Erase that invalid state when it is discovered.

This is part of addressing https://github.com/hybridauth/hybridauth/issues/1301. This isn't a full fix because while this defends against the app being jammed, I do not know what the real triggers are and if there is a more direct way to avoid this.
