### PR TITLE
Initial LinkedIn OpenID support

### DIFF
--- a/src/Provider/LinkedInOpenID.php
+++ b/src/Provider/LinkedInOpenID.php
@@ -1,0 +1,90 @@
+<?php
+/*!
+ * Hybridauth
+ * https://hybridauth.github.io | https://github.com/hybridauth/hybridauth
+ *  (c) 2017 Hybridauth authors | https://hybridauth.github.io/license.html
+ */
+
+namespace Hybridauth\Provider;
+
+use Hybridauth\Adapter\OAuth2;
+use Hybridauth\Data;
+use Hybridauth\Exception\UnexpectedApiResponseException;
+use Hybridauth\User;
+
+/**
+ * LinkedIn OAuth2 provider adapter.
+ */
+class LinkedInOpenID extends OAuth2
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $scope = 'openid profile email';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiBaseUrl = 'https://api.linkedin.com/v2/';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $authorizeUrl = 'https://www.linkedin.com/oauth/v2/authorization';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $accessTokenUrl = 'https://www.linkedin.com/oauth/v2/accessToken';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $apiDocumentation = 'https://docs.microsoft.com/en-us/linkedin/shared/authentication/authentication';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret
+            ];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserProfile()
+    {
+
+        $response = $this->apiRequest('/userinfo', 'GET', []);
+        $data = new Data\Collection($response);
+
+        if (!$data->exists('sub')) {
+            throw new UnexpectedApiResponseException('Provider API returned an unexpected response.');
+        }
+
+        $userProfile = new User\Profile();
+
+        // Handle localized names.
+        $userProfile->firstName = $data->get('given_name');
+
+        $userProfile->lastName = $data->get('family_name');
+
+        $userProfile->identifier = $data->get('sub');
+        $userProfile->email = $data->get('email');
+        $userProfile->emailVerified = $data->get('email_verified');
+        $userProfile->displayName = $data->get('name');
+
+        $userProfile->photoURL = $data->get('picture');
+
+        return $userProfile;
+    }
+
+}

--- a/src/Provider/LinkedInOpenID.php
+++ b/src/Provider/LinkedInOpenID.php
@@ -72,16 +72,12 @@ class LinkedInOpenID extends OAuth2
 
         $userProfile = new User\Profile();
 
-        // Handle localized names.
         $userProfile->firstName = $data->get('given_name');
-
         $userProfile->lastName = $data->get('family_name');
-
         $userProfile->identifier = $data->get('sub');
         $userProfile->email = $data->get('email');
         $userProfile->emailVerified = $data->get('email_verified');
         $userProfile->displayName = $data->get('name');
-
         $userProfile->photoURL = $data->get('picture');
 
         return $userProfile;


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | [Fixes #1](https://github.com/hybridauth/hybridauth/issues/1385)
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | Yes
| Minor: New Feature?      | Yes

Current LinkedIn OAuth method is [deprecated](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin) since August 1, 2023. 

We should migrate to OpenID.

If you create a new LinkedIn app, `r_liteprofile` and `r_emailaddress` scopes no longer exist. `r_liteprofile` and `r_emailaddress` still works for old App prior to August 1, 2023.

New scopes are : `openid`, `profile` & `email`
