### PR TITLE
Updating the Seznam.cz provider by the documentation

### DIFF
--- a/src/Provider/Seznam.php
+++ b/src/Provider/Seznam.php
@@ -14,6 +14,24 @@ use Hybridauth\User;
 
 /**
  * Seznam OAuth2 provider adapter.
+ *
+ * Example:
+ *
+ *   $config = [
+ *       'callback' => Hybridauth\HttpClient\Util::getCurrentUrl(),
+ *       'keys' => ['id' => '', 'secret' => ''],
+ *       'scope' => 'identity, contact-phone, avatar',
+ *   ];
+ *
+ *   $adapter = new Hybridauth\Provider\Seznam($config);
+ *
+ *   try {
+ *       $adapter->authenticate();
+ *
+ *       $userProfile = $adapter->getUserProfile();
+ *   } catch (\Exception $e) {
+ *       echo $e->getMessage() ;
+ *   }
  */
 class Seznam extends OAuth2
 {
@@ -53,11 +71,29 @@ class Seznam extends OAuth2
         $userProfile = new User\Profile();
 
         $userProfile->identifier = $data->get('oauth_user_id');
-        $userProfile->email = $data->get('account_name');
+        $userProfile->email = $this->getEmailFromCollection($data);
         $userProfile->firstName = $data->get('firstname');
         $userProfile->lastName = $data->get('lastname');
         $userProfile->photoURL = $data->get('avatar_url');
+        $userProfile->phone = $data->get('contact_phone');
 
         return $userProfile;
     }
+
+    private function getEmailFromCollection(Data\Collection $data)
+    {
+        $email = $data->get('email');
+        if ($email !== NULL) {
+            return $email;
+        }
+
+        $username = $data->get('username');
+        $domain = $data->get('domain');
+        if ($username === NULL || $domain === NULL) {
+            return NULL;
+        }
+
+        return sprintf("%s@%s", $username, $domain);
+    }
+
 }


### PR DESCRIPTION
- Adding a usage example
- Adding phone field from scope contact-phone
- Modifying of getting an email address

Currently, the data returned by the Seznam.cz API contains an `email` field, which is not in the documentation. The email address can be composed from the `username` and `domain` fields. The `account_name` field is not in the documentation and always contains a `NULL` value.