### PR TITLE
Unknow provider error

### DIFF
--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -127,7 +127,7 @@ class Hybridauth
             foreach ($fs as $file) {
                 if (!$file->isDir()) {
                     $provider = strtok($file->getFilename(), '.');
-                    if (strtolower($name) === mb_strtolower($provider)) {
+                    if (mb_strtolower($name) === mb_strtolower($provider)) {
                         $adapter = sprintf('Hybridauth\\Provider\\%s', $provider);
                         break;
                     }

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -127,7 +127,7 @@ class Hybridauth
             foreach ($fs as $file) {
                 if (!$file->isDir()) {
                     $provider = strtok($file->getFilename(), '.');
-                    if ($name === mb_strtolower($provider)) {
+                    if (strtolower($name) === mb_strtolower($provider)) {
                         $adapter = sprintf('Hybridauth\\Provider\\%s', $provider);
                         break;
                     }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            |  No
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

The provider name passed to getAdapter through the authenticate function is not converted to lowercase, so in the case when the class_exists does not autoload the class, and when the comparison is made with the file name let's say GitHub.php then the condition fails to match with the Provider name(which has not been lowercased) which returns an error "Unknown Provider".
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
