### PR TITLE
Add support for keycloak organization claim

### DIFF
--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -91,6 +91,12 @@ class Keycloak extends OAuth2
         $userProfile->lastName = $data->get('family_name');
         $userProfile->emailVerified = $data->get('email_verified');
 
+        // Collect organization claim if provided in the IDToken
+        if ($data->exists('organization')) {
+            $kc_orgs = array_keys($data->get('organization'));
+            $userProfile->data['organization'] = array_shift($kc_orgs); //Get the first key
+        }
+
         return $userProfile;
     }
 }

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -93,7 +93,7 @@ class Keycloak extends OAuth2
 
         // Collect organization claim if provided in the IDToken
         if ($data->exists('organization')) {
-            $kc_orgs = array_keys($data->get('organization'));
+            $kc_orgs = array_keys((array) $data->get('organization'));
             $userProfile->data['organization'] = array_shift($kc_orgs); //Get the first key
         }
 

--- a/tests/Provider/KeycloakTest.php
+++ b/tests/Provider/KeycloakTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace HybridauthTest\Hybridauth\Provider;
+
+use Hybridauth\Provider\Keycloak;
+use Hybridauth\User\Profile;
+
+class KeycloakTest extends \PHPUnit\Framework\TestCase
+{
+    public function test_getUserProfile()
+    {
+        //Mock OAuth2 Api request
+        $keycloak = $this->getMockBuilder(Keycloak::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['apiRequest'])
+            ->getMock();
+        $keycloak->expects($this->once())
+            ->method('apiRequest')
+            ->willReturn([
+                'sub' => 1,
+                'preferred_username' => 'alice@example.com',
+                'email' => 'alice@example.com',
+                'given_name' => 'Alice',
+                'family_name' => 'Jenkins',
+                'email_verified' => true
+            ]);
+
+        $profile = new Profile();
+        $profile->identifier = 1;
+        $profile->displayName = 'alice@example.com';
+        $profile->firstName = 'Alice';
+        $profile->lastName = 'Jenkins';
+        $profile->email = 'alice@example.com';
+        $profile->emailVerified = true;
+
+        $this->assertEquals($profile, $keycloak->getUserProfile());
+    }
+
+    /* Test parsing keycloak user profile with organization feature enabled. The issued ID token is similar but contains the organization scope with this format:    
+        "name": "Alice Jenkins",
+        "preferred_username": "alice@acme.org",
+        "given_name": "Alice",
+        "family_name": "Jenkins",
+        "email": "alice@acme.org" 
+        "email_verified": true,
+        "organization":    {
+            "my_org": {}
+        },
+    */
+    public function test_getUserProfileWithOrganization()
+    {
+        //Mock OAuth2 Api request
+        $keycloak = $this->getMockBuilder(Keycloak::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['apiRequest'])
+            ->getMock();
+        $keycloak->expects($this->once())
+            ->method('apiRequest')
+            ->willReturn([
+                'sub' => 2,
+                'preferred_username' => 'alice@example.com',
+                'email' => 'alice@example.com',
+                'given_name' => 'Alice',
+                'family_name' => 'Jenkins',
+                'email_verified' => true,
+                'organization' => [
+                    'my_org' => []
+                ]
+            ]);
+
+        $profile = new Profile();
+        $profile->identifier = 2;
+        $profile->displayName = 'alice@example.com';
+        $profile->firstName = 'Alice';
+        $profile->lastName = 'Jenkins';
+        $profile->email = 'alice@example.com';
+        $profile->emailVerified = true;
+        $profile->data = ['organization' => 'my_org'];
+
+        $this->assertEquals($profile, $keycloak->getUserProfile());
+    }
+}

--- a/tests/Provider/KeycloakTest.php
+++ b/tests/Provider/KeycloakTest.php
@@ -63,9 +63,7 @@ class KeycloakTest extends \PHPUnit\Framework\TestCase
                 'given_name' => 'Alice',
                 'family_name' => 'Jenkins',
                 'email_verified' => true,
-                'organization' => [
-                    'my_org' => []
-                ]
+                'organization' => json_decode('{ "my_org": {} }'),
             ]);
 
         $profile = new Profile();


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change?  | No
| Minor: New Feature?      | Support Keycloak organization claim

<!-- Describe your changes below in as much detail as possible -->

Keycloak now supports "[organizations](https://www.keycloak.org/2024/06/announcement-keycloak-organizations)". 
As a result, the token issued by keycloak may contain a claim as follows:
```json
"given_name" : "Alice",
"family_name" : "Jenkins",
"organization": {
    "orga": {}
}
```

The `organization` claim is useful in a multitenant context as it can be used by clients (e.g.: from ID Tokens) and resource servers (e.g.: from access tokens) to authorize access to protected resources based on the organization that a user belongs to.


This change is adding (when present) the `organization` claim into the `data` field of the User Profile using the `Keycloak` Adapter:
```php
Hybridauth\User\Profile Object(
    [firstName] => Alice
    [lastName] => Jenkins
    [data] => Array
        (
            [organization] => orga
        )

)
```
