### PR TITLE
Fix Problem Stuck in Choose an account in Social Login Google

### DIFF
--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -314,8 +314,19 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
 
         try {
             $this->authenticateCheckError();
-
-            $code = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
+            
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                $code = filter_input(INPUT_POST, 'code');
+            } else {
+                $request_uri = $_SERVER['REQUEST_URI'];
+                $query_string = parse_url($request_uri, PHP_URL_QUERY);
+                parse_str($query_string, $params);
+                if (isset($params['code'])) {
+                    $code = $params['code'];
+                } else {
+                    $code = null;
+                }
+            }
 
             if (empty($code)) {
                 $this->authenticateBegin();
@@ -411,9 +422,22 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             sprintf('%s::authenticateFinish(), callback url:', get_class($this)),
             [HttpClient\Util::getCurrentUrl(true)]
         );
-
-        $state = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'state');
-        $code = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
+        
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $code = filter_input(INPUT_POST, 'code');
+            $state = filter_input(INPUT_POST, 'state');
+        } else {
+            $request_uri = $_SERVER['REQUEST_URI'];
+            $query_string = parse_url($request_uri, PHP_URL_QUERY);
+            parse_str($query_string, $params);
+            if (isset($params['code'])) {
+                $code = $params['code'];
+                $state = $params['state'];
+            } else {
+                $code = null;
+                $state = null;
+            }
+        }
 
         /**
          * Authorization Request State


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | `No` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | `Yes`
| Major: Breaking Change?  | `No`
| Minor: New Feature?      | `No`

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
Related to this problem, it occurs because Google gives a GET request, but on the PHP code side it fails to get the query parameter code and state, which becomes an empty value, and that's what makes it so that after selecting a Google account to log in, you can't enter the webapps dashboard, but there is a loop that must select a Google account again and again, so I changed the retrieval method by parsing the URL sent by Google, and I think this is a good method, if there is a better one, please update it again, and I can use it as a reference in the future
