### PR TITLE
Refresh token fixes

### DIFF
--- a/src/Provider/GitHub.php
+++ b/src/Provider/GitHub.php
@@ -45,6 +45,21 @@ class GitHub extends OAuth2
     /**
      * {@inheritdoc}
      */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret
+            ];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getUserProfile()
     {
         $response = $this->apiRequest('user');

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -80,13 +80,14 @@ class Google extends OAuth2
         parent::initialize();
 
         $this->AuthorizeUrlParameters += [
-            'access_type' => 'offline'
+            'access_type' => 'offline',
+            'prompt' => 'consent'
         ];
 
         if ($this->isRefreshTokenAvailable()) {
             $this->tokenRefreshParameters += [
                 'client_id' => $this->clientId,
-                'client_secret' => $this->clientSecret
+                'client_secret' => $this->clientSecret,
             ];
         }
     }

--- a/src/Provider/MicrosoftGraph.php
+++ b/src/Provider/MicrosoftGraph.php
@@ -46,7 +46,7 @@ class MicrosoftGraph extends OAuth2
     /**
      * {@inheritdoc}
      */
-    protected $scope = 'openid user.read contacts.read';
+    protected $scope = 'openid user.read contacts.read offline_access';
 
     /**
      * {@inheritdoc}
@@ -75,6 +75,10 @@ class MicrosoftGraph extends OAuth2
     {
         parent::initialize();
 
+        $this->AuthorizeUrlParameters += [
+			'prompt' => 'consent',
+        ];
+
         $tenant = $this->config->get('tenant');
         if (!empty($tenant)) {
             $adjustedEndpoints = [
@@ -83,6 +87,13 @@ class MicrosoftGraph extends OAuth2
             ];
 
             $this->setApiEndpoints($adjustedEndpoints);
+        }
+
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ];
         }
     }
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes (Google/Github/MSGraph providers)
| Major: Breaking Change? | No
| Minor: New Feature?      | No

**Description**:
After successful authentication, access token is properly returned by below Identity Providers: Google/Github/MSGraph. But without the refresh_token needed in case of expiration. then it is not possible to renew the access token later on. 

Current PR aims at enhancing HTTP parameters sent and received to make Google/Github/MSGraph work from authentication to access token renewal.
