### PR TITLE
Make Keycloak refresh token work

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -83,7 +83,7 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $validateApiResponseHttpCode = true;
 
     /**
-     * @var FilterService : used for testing purpose to specify filter_input behaviours
+     * @var mixed : used for testing purpose to specify filter_input behaviours
      */
     protected static $filterService;
 
@@ -380,19 +380,24 @@ abstract class AbstractAdapter implements AdapterInterface
      * @param int $type: One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV
      * @param string $var_name: Name of a variable to get
      * @param int $filter: [optional] The ID of the filter to apply. The manual page lists the available filters.
-     * @param array|int $options: Associative array of options or bitwise disjunction of flags. If filter accepts options, flags can be provided in "flags" field of array.
+     * @param mixed $options: Associative array of options or bitwise disjunction of flags. If filter accepts options, flags can be provided in "flags" field of array.
      *
      * @return mixed: Value of the requested variable on success, FALSE if the filter fails, or NULL if the variable_name variable is not set. If the flag FILTER_NULL_ON_FAILURE is used, it returns FALSE if the variable is not set and NULL if the filter fails.
      * https://php.net/manual/en/function.filter-input.php
      */
-    public function filter_input(int $type, string $var_name, int $filter = FILTER_DEFAULT, array|int $options = 0): mixed {
+    public function filterInput($type, $var_name, $filter = FILTER_DEFAULT, $options = 0) {
         if (isset(self::$filterService)){
-            return self::$filterService->filter_input($type, $var_name, $filter, $options);
+            self::$filterService = new FilterService();
         }
-        return filter_input($type, $var_name, $filter, $options);
+        return self::$filterService->filterInput($type, $var_name, $filter, $options);
     }
 
-    public static function setFilterService(?FilterService $filterService) : void {
+    /**
+     * @param \Hybridauth\Adapter\FilterService|null $filterService
+     *
+     * @return void
+     */
+    public static function setFilterService($filterService) {
         self::$filterService = $filterService;
     }
 }

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -83,6 +83,11 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $validateApiResponseHttpCode = true;
 
     /**
+     * @var FilterService : used for testing purpose to specify filter_input behaviours
+     */
+    protected static $filterService;
+
+    /**
      * Common adapters constructor.
      *
      * @param array $config
@@ -368,5 +373,26 @@ abstract class AbstractAdapter implements AdapterInterface
                 '. Raw Provider API response: ' . $this->httpClient->getResponseBody() . '.'
             );
         }
+    }
+
+    /**
+     *
+     * @param int $type: One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV
+     * @param string $var_name: Name of a variable to get
+     * @param int $filter: [optional] The ID of the filter to apply. The manual page lists the available filters.
+     * @param array|int $options: Associative array of options or bitwise disjunction of flags. If filter accepts options, flags can be provided in "flags" field of array.
+     *
+     * @return mixed: Value of the requested variable on success, FALSE if the filter fails, or NULL if the variable_name variable is not set. If the flag FILTER_NULL_ON_FAILURE is used, it returns FALSE if the variable is not set and NULL if the filter fails.
+     * https://php.net/manual/en/function.filter-input.php
+     */
+    public function filter_input(int $type, string $var_name, int $filter = FILTER_DEFAULT, array|int $options = 0): mixed {
+        if (isset(self::$filterService)){
+            return self::$filterService->filter_input($type, $var_name, $filter, $options);
+        }
+        return filter_input($type, $var_name, $filter, $options);
+    }
+
+    public static function setFilterService(?FilterService $filterService) : void {
+        self::$filterService = $filterService;
     }
 }

--- a/src/Adapter/FilterService.php
+++ b/src/Adapter/FilterService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Hybridauth\Adapter;
+
+class FilterService {
+    /**
+     *
+     * @param int $type: One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV
+     * @param string $var_name: Name of a variable to get
+     * @param int $filter: [optional] The ID of the filter to apply. The manual page lists the available filters.
+     * @param array|int $options: Associative array of options or bitwise disjunction of flags. If filter accepts options, flags can be provided in "flags" field of array.
+     *
+     * @return mixed: Value of the requested variable on success, FALSE if the filter fails, or NULL if the variable_name variable is not set. If the flag FILTER_NULL_ON_FAILURE is used, it returns FALSE if the variable is not set and NULL if the filter fails.
+     * https://php.net/manual/en/function.filter-input.php
+     */
+    public function filter_input(int $type, string $var_name, int $filter = FILTER_DEFAULT, array|int $options = 0): mixed {
+        return filter_input($type, $var_name, $filter, $options);
+    }
+
+
+}

--- a/src/Adapter/FilterService.php
+++ b/src/Adapter/FilterService.php
@@ -8,14 +8,12 @@ class FilterService {
      * @param int $type: One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV
      * @param string $var_name: Name of a variable to get
      * @param int $filter: [optional] The ID of the filter to apply. The manual page lists the available filters.
-     * @param array|int $options: Associative array of options or bitwise disjunction of flags. If filter accepts options, flags can be provided in "flags" field of array.
+     * @param mixed $options: Associative array of options or bitwise disjunction of flags. If filter accepts options, flags can be provided in "flags" field of array.
      *
      * @return mixed: Value of the requested variable on success, FALSE if the filter fails, or NULL if the variable_name variable is not set. If the flag FILTER_NULL_ON_FAILURE is used, it returns FALSE if the variable is not set and NULL if the filter fails.
      * https://php.net/manual/en/function.filter-input.php
      */
-    public function filter_input(int $type, string $var_name, int $filter = FILTER_DEFAULT, array|int $options = 0): mixed {
+    public function filterInput($type, $var_name, $filter = FILTER_DEFAULT, $options = 0) {
         return filter_input($type, $var_name, $filter, $options);
     }
-
-
 }

--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -278,10 +278,10 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
             [HttpClient\Util::getCurrentUrl(true)]
         );
 
-        $denied = $this->filter_input(INPUT_GET, 'denied');
-        $oauth_problem = $this->filter_input(INPUT_GET, 'oauth_problem');
-        $oauth_token = $this->filter_input(INPUT_GET, 'oauth_token');
-        $oauth_verifier = $this->filter_input(INPUT_GET, 'oauth_verifier');
+        $denied = $this->filterInput(INPUT_GET, 'denied');
+        $oauth_problem = $this->filterInput(INPUT_GET, 'oauth_problem');
+        $oauth_token = $this->filterInput(INPUT_GET, 'oauth_token');
+        $oauth_verifier = $this->filterInput(INPUT_GET, 'oauth_verifier');
 
         if ($denied) {
             throw new AuthorizationDeniedException(

--- a/src/Adapter/OAuth1.php
+++ b/src/Adapter/OAuth1.php
@@ -278,10 +278,10 @@ abstract class OAuth1 extends AbstractAdapter implements AdapterInterface
             [HttpClient\Util::getCurrentUrl(true)]
         );
 
-        $denied = filter_input(INPUT_GET, 'denied');
-        $oauth_problem = filter_input(INPUT_GET, 'oauth_problem');
-        $oauth_token = filter_input(INPUT_GET, 'oauth_token');
-        $oauth_verifier = filter_input(INPUT_GET, 'oauth_verifier');
+        $denied = $this->filter_input(INPUT_GET, 'denied');
+        $oauth_problem = $this->filter_input(INPUT_GET, 'oauth_problem');
+        $oauth_token = $this->filter_input(INPUT_GET, 'oauth_token');
+        $oauth_verifier = $this->filter_input(INPUT_GET, 'oauth_verifier');
 
         if ($denied) {
             throw new AuthorizationDeniedException(

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -315,7 +315,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         try {
             $this->authenticateCheckError();
 
-            $code = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
+            $code = $this->filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
 
             if (empty($code)) {
                 $this->authenticateBegin();
@@ -366,11 +366,11 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
      */
     protected function authenticateCheckError()
     {
-        $error = filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
+        $error = $this->filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
 
         if (!empty($error)) {
-            $error_description = filter_input(INPUT_GET, 'error_description', FILTER_SANITIZE_SPECIAL_CHARS);
-            $error_uri = filter_input(INPUT_GET, 'error_uri', FILTER_SANITIZE_SPECIAL_CHARS);
+            $error_description = $this->filter_input(INPUT_GET, 'error_description', FILTER_SANITIZE_SPECIAL_CHARS);
+            $error_uri = $this->filter_input(INPUT_GET, 'error_uri', FILTER_SANITIZE_SPECIAL_CHARS);
 
             $collated_error = sprintf('Provider returned an error: %s %s %s', $error, $error_description, $error_uri);
 
@@ -412,8 +412,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             [HttpClient\Util::getCurrentUrl(true)]
         );
 
-        $state = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'state');
-        $code = filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
+        $state = $this->filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'state');
+        $code = $this->filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
 
         /**
          * Authorization Request State

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -260,7 +260,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         if ($this->config->exists('tokens')) {
             $this->setAccessToken($this->config->get('tokens'));
         }
-        
+
         if ($this->config->exists('supportRequestState')) {
             $this->supportRequestState = $this->config->get('supportRequestState');
         }
@@ -315,7 +315,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         try {
             $this->authenticateCheckError();
 
-            $code = $this->filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
+            $code = $this->filterInput($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
 
             if (empty($code)) {
                 $this->authenticateBegin();
@@ -366,11 +366,11 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
      */
     protected function authenticateCheckError()
     {
-        $error = $this->filter_input(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
+        $error = $this->filterInput(INPUT_GET, 'error', FILTER_SANITIZE_SPECIAL_CHARS);
 
         if (!empty($error)) {
-            $error_description = $this->filter_input(INPUT_GET, 'error_description', FILTER_SANITIZE_SPECIAL_CHARS);
-            $error_uri = $this->filter_input(INPUT_GET, 'error_uri', FILTER_SANITIZE_SPECIAL_CHARS);
+            $error_description = $this->filterInput(INPUT_GET, 'error_description', FILTER_SANITIZE_SPECIAL_CHARS);
+            $error_uri = $this->filterInput(INPUT_GET, 'error_uri', FILTER_SANITIZE_SPECIAL_CHARS);
 
             $collated_error = sprintf('Provider returned an error: %s %s %s', $error, $error_description, $error_uri);
 
@@ -412,8 +412,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
             [HttpClient\Util::getCurrentUrl(true)]
         );
 
-        $state = $this->filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'state');
-        $code = $this->filter_input($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
+        $state = $this->filterInput($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'state');
+        $code = $this->filterInput($_SERVER['REQUEST_METHOD'] === 'POST' ? INPUT_POST : INPUT_GET, 'code');
 
         /**
          * Authorization Request State

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -162,7 +162,8 @@ class Hybridauth
             throw new InvalidArgumentException('Unknown Provider.');
         }
 
-        if (!$providersConfig[$name]['enabled']) {
+        $enabled = $providersConfig[$name]['enabled'] ?? false;
+        if (!$enabled) {
             throw new UnexpectedValueException('Disabled Provider.');
         }
 

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -66,7 +66,21 @@ class Keycloak extends OAuth2
 
         $this->authorizeUrl = $this->apiBaseUrl . 'auth';
         $this->accessTokenUrl = $this->apiBaseUrl . 'token';
+    }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ];
+        }
     }
 
     /**

--- a/src/Provider/Telegram.php
+++ b/src/Provider/Telegram.php
@@ -88,7 +88,7 @@ class Telegram extends AbstractAdapter implements AdapterInterface
     public function authenticate()
     {
         $this->logger->info(sprintf('%s::authenticate()', get_class($this)));
-        if (!$this->filter_input(INPUT_GET, 'hash')) {
+        if (!$this->filterInput(INPUT_GET, 'hash')) {
             $this->authenticateBegin();
         } else {
             $this->authenticateCheckError();
@@ -209,13 +209,13 @@ HTML
     protected function parseAuthData()
     {
         return [
-            'id' => $this->filter_input(INPUT_GET, 'id'),
-            'first_name' => $this->filter_input(INPUT_GET, 'first_name'),
-            'last_name' => $this->filter_input(INPUT_GET, 'last_name'),
-            'username' => $this->filter_input(INPUT_GET, 'username'),
-            'photo_url' => $this->filter_input(INPUT_GET, 'photo_url'),
-            'auth_date' => $this->filter_input(INPUT_GET, 'auth_date'),
-            'hash' => $this->filter_input(INPUT_GET, 'hash'),
+            'id' => $this->filterInput(INPUT_GET, 'id'),
+            'first_name' => $this->filterInput(INPUT_GET, 'first_name'),
+            'last_name' => $this->filterInput(INPUT_GET, 'last_name'),
+            'username' => $this->filterInput(INPUT_GET, 'username'),
+            'photo_url' => $this->filterInput(INPUT_GET, 'photo_url'),
+            'auth_date' => $this->filterInput(INPUT_GET, 'auth_date'),
+            'hash' => $this->filterInput(INPUT_GET, 'hash'),
         ];
     }
 }

--- a/src/Provider/Telegram.php
+++ b/src/Provider/Telegram.php
@@ -88,7 +88,7 @@ class Telegram extends AbstractAdapter implements AdapterInterface
     public function authenticate()
     {
         $this->logger->info(sprintf('%s::authenticate()', get_class($this)));
-        if (!filter_input(INPUT_GET, 'hash')) {
+        if (!$this->filter_input(INPUT_GET, 'hash')) {
             $this->authenticateBegin();
         } else {
             $this->authenticateCheckError();
@@ -209,13 +209,13 @@ HTML
     protected function parseAuthData()
     {
         return [
-            'id' => filter_input(INPUT_GET, 'id'),
-            'first_name' => filter_input(INPUT_GET, 'first_name'),
-            'last_name' => filter_input(INPUT_GET, 'last_name'),
-            'username' => filter_input(INPUT_GET, 'username'),
-            'photo_url' => filter_input(INPUT_GET, 'photo_url'),
-            'auth_date' => filter_input(INPUT_GET, 'auth_date'),
-            'hash' => filter_input(INPUT_GET, 'hash'),
+            'id' => $this->filter_input(INPUT_GET, 'id'),
+            'first_name' => $this->filter_input(INPUT_GET, 'first_name'),
+            'last_name' => $this->filter_input(INPUT_GET, 'last_name'),
+            'username' => $this->filter_input(INPUT_GET, 'username'),
+            'photo_url' => $this->filter_input(INPUT_GET, 'photo_url'),
+            'auth_date' => $this->filter_input(INPUT_GET, 'auth_date'),
+            'hash' => $this->filter_input(INPUT_GET, 'hash'),
         ];
     }
 }

--- a/src/Storage/StorageImpl.php
+++ b/src/Storage/StorageImpl.php
@@ -3,7 +3,7 @@
 namespace Hybridauth\Storage;
 
 class StorageImpl implements StorageInterface {
-    private array $data;
+    private $data;
 
     public function __construct()
     {

--- a/src/Storage/StorageImpl.php
+++ b/src/Storage/StorageImpl.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Hybridauth\Storage;
+
+class StorageImpl implements StorageInterface {
+    private array $data;
+
+    public function __construct()
+    {
+        $this->data = [];
+    }
+
+    public function get($key) {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set($key, $value) {
+        $this->data[$key] = $value;
+    }
+
+    public function delete($key) {
+        if (array_key_exists($key, $this->data)){
+            unset($this->data[$key]);
+        }
+    }
+
+    public function deleteMatch($key) {
+        foreach ($this->data as $k => $v) {
+            if (strstr($k, $key)) {
+                unset($this->data[$k]);
+            }
+        }
+    }
+
+    public function clear() {
+        $this->data = [];
+    }
+}

--- a/tests/Provider/KeycloakTest.php
+++ b/tests/Provider/KeycloakTest.php
@@ -100,7 +100,6 @@ class KeycloakTest extends \PHPUnit\Framework\TestCase
         ];
 
         $httpClient = $this->createMock(HttpClientInterface::class);
-        $storage = $this->createMock(StorageInterface::class);
         $keycloak = new Keycloak($config, $httpClient, new StorageImpl());
 
         $httpClient->expects($this->once())

--- a/tests/Provider/KeycloakTest.php
+++ b/tests/Provider/KeycloakTest.php
@@ -2,7 +2,10 @@
 
 namespace HybridauthTest\Hybridauth\Provider;
 
+use Hybridauth\HttpClient\HttpClientInterface;
 use Hybridauth\Provider\Keycloak;
+use Hybridauth\Storage\StorageImpl;
+use Hybridauth\Storage\StorageInterface;
 use Hybridauth\User\Profile;
 
 class KeycloakTest extends \PHPUnit\Framework\TestCase
@@ -36,7 +39,7 @@ class KeycloakTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($profile, $keycloak->getUserProfile());
     }
 
-    /* Test parsing keycloak user profile with organization feature enabled. The issued ID token is similar but contains the organization scope with this format:    
+    /* Test parsing keycloak user profile with organization feature enabled. The issued ID token is similar but contains the organization scope with this format:
         "name": "Alice Jenkins",
         "preferred_username": "alice@acme.org",
         "given_name": "Alice",
@@ -76,5 +79,53 @@ class KeycloakTest extends \PHPUnit\Framework\TestCase
         $profile->data = ['organization' => 'my_org'];
 
         $this->assertEquals($profile, $keycloak->getUserProfile());
+    }
+
+    public function test_refreshAccessToken_ProviderClientIdAndSecret()
+    {
+        $config = [
+            'url' => 'sha.dok',
+            'keys' => [
+                'id' => 'ga',
+                'secret' => 'bu',
+            ],
+            'tokens' => [
+                'access_token' => 'old_access_token',
+                'token_type' => 'Bearer',
+                'expires_at' => 1731454668,
+                'refresh_token' => 'zo',
+            ],
+            'realm' => 'meu',
+            'callback' => 'http://callbacksha.dok'
+        ];
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $storage = $this->createMock(StorageInterface::class);
+        $keycloak = new Keycloak($config, $httpClient, new StorageImpl());
+
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                'sha.dok/realms/meu/protocol/openid-connect/token',
+                'POST',
+                [
+                    'grant_type' => 'refresh_token',
+                    'client_id' => 'ga',
+                    'client_secret' => 'bu',
+                    'refresh_token' => 'zo',
+                ],
+                []
+            )
+            ->willReturn(json_encode(['access_token' => 'new_access_token']));
+
+        $httpClient->expects($this->once())
+            ->method('getResponseClientError')
+            ->willReturn(false);
+
+        $httpClient->expects($this->once())
+            ->method('getResponseHttpCode')
+            ->willReturn(200);
+
+        $keycloak->refreshAccessToken();
     }
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | Yes (Keycloak)
| Major: Breaking Change? | No
| Minor: New Feature?      | No

**Description**:
Authenticate is working properly with Keycloak provider. We receive the tokens from IdP (access_token/refresh_token). This PR provides a fix to make oAuth2 refresh token mechanism work by providing client_id/client_secret .

We also added StorageImpl class to ease writing tests (avoid Session instanciation and session_start()).