### PR TITLE
Fix php84 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,17 @@ dist: "bionic"
 php:
   - "7.4"
   - "7.3"
-  - "7.2"
   - "8.0"
 
 jobs:
   include:
-    - name: "PHP 5.6"
+    - name: "PHP 7.3"
       dist: "xenial"
-      php: "5.6"
-    # "php": ">=5.4.0"
-    - name: "PHP 5.4"
+      php: "7.3"
+    # "php": ">=7.3.0"
+    - name: "PHP 7.3"
       dist: "trusty"
-      php: "5.4"
+      php: "7.3"
 
 cache:
   directories:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ actually made to a file on your Pull Request.
 Additional providers, minor enhancements, bugs and typos fixes are most welcome. Large and "breaking" changes should be 
 discussed ahead of time. **Please ask first**.
 
-Hybridauth 3 is compatible with **PHP 5.4** and therefore all code supplied must stick to this requirement.
+Hybridauth 4 is compatible with **PHP 7.3** and therefore all code supplied must stick to this requirement.
 
 **License**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![SWUbanner](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://supportukrainenow.org/)
 
-## [Hybridauth](https://hybridauth.github.io/) 3.11
+## [Hybridauth](https://hybridauth.github.io/) 4.0
 
 [![Build Status](https://travis-ci.org/hybridauth/hybridauth.svg?branch=master)](https://travis-ci.org/hybridauth/hybridauth) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/hybridauth/hybridauth/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/hybridauth/hybridauth/?branch=master) [![Latest Stable Version](https://poser.pugx.org/hybridauth/hybridauth/v/stable.png)](https://packagist.org/packages/hybridauth/hybridauth) [![Join the chat at https://gitter.im/hybridauth/hybridauth](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/hybridauth/hybridauth?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -40,7 +40,7 @@ catch (\Exception $e) {
 
 #### Requirements
 
-* PHP 5.4+
+* PHP 7.3+
 * PHP Session
 * PHP cURL
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "gitter": "https://gitter.im/hybridauth/hybridauth"
     },
     "require": {
-        "php": "^5.4 || ^7.0 || ^8.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "ext-curl": "*",

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -92,9 +92,9 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function __construct(
         $config = [],
-        HttpClientInterface $httpClient = null,
-        StorageInterface $storage = null,
-        LoggerInterface $logger = null
+        ?HttpClientInterface $httpClient = null,
+        ?StorageInterface $storage = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->providerId = (new \ReflectionClass($this))->getShortName();
 
@@ -243,7 +243,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setHttpClient(HttpClientInterface $httpClient = null)
+    public function setHttpClient(?HttpClientInterface $httpClient = null)
     {
         $this->httpClient = $httpClient ?: new HttpClient();
 
@@ -263,7 +263,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setStorage(StorageInterface $storage = null)
+    public function setStorage(?StorageInterface $storage = null)
     {
         $this->storage = $storage ?: new Session();
     }
@@ -279,7 +279,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setLogger(LoggerInterface $logger = null)
+    public function setLogger(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: new Logger(
             $this->config->get('debug_mode'),

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -122,7 +122,7 @@ interface AdapterInterface
      *
      * @param HttpClientInterface $httpClient
      */
-    public function setHttpClient(HttpClientInterface $httpClient = null);
+    public function setHttpClient(?HttpClientInterface $httpClient = null);
 
     /**
      * Return http client instance.
@@ -134,7 +134,7 @@ interface AdapterInterface
      *
      * @param StorageInterface $storage
      */
-    public function setStorage(StorageInterface $storage = null);
+    public function setStorage(?StorageInterface $storage = null);
 
     /**
      * Return storage instance.
@@ -146,7 +146,7 @@ interface AdapterInterface
      *
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger = null);
+    public function setLogger(?LoggerInterface $logger = null);
 
     /**
      * Return logger instance.

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -62,9 +62,9 @@ class Hybridauth
      */
     public function __construct(
         $config,
-        HttpClientInterface $httpClient = null,
-        StorageInterface $storage = null,
-        LoggerInterface $logger = null
+        ?HttpClientInterface $httpClient = null,
+        ?StorageInterface $storage = null,
+        ?LoggerInterface $logger = null
     ) {
         if (is_string($config) && file_exists($config)) {
             $config = include $config;

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -181,7 +181,7 @@ class Instagram extends OAuth2
      * @throws \Hybridauth\Exception\InvalidAccessTokenException
      * @throws \Hybridauth\Exception\UnexpectedApiResponseException
      */
-    public function getUserMedia($limit = 12, $pageId = null, array $fields = null)
+    public function getUserMedia($limit = 12, $pageId = null, ?array $fields = null)
     {
         if (empty($fields)) {
             $fields = [
@@ -227,7 +227,7 @@ class Instagram extends OAuth2
      * @throws \Hybridauth\Exception\InvalidAccessTokenException
      * @throws \Hybridauth\Exception\UnexpectedApiResponseException
      */
-    public function getMedia($mediaId, array $fields = null)
+    public function getMedia($mediaId, ?array $fields = null)
     {
         if (empty($fields)) {
             $fields = [

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -6,8 +6,8 @@
  * Note that you'd ONLY need this file if you are not using composer.
  */
 
-if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-    throw new Exception('Hybridauth 3 requires PHP version 5.4 or higher.');
+if (version_compare(PHP_VERSION, '7.3.0', '<')) {
+    throw new Exception('Hybridauth 4 requires PHP version 7.3 or higher.');
 }
 
 /**


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Major: Requires PHP 7.1  | This fixes PHP 8.4 deprecation warnings but needs PHP 7.1

<!-- Describe your changes below in as much detail as possible -->
<!-- For documentation fixes, pls create a PR in https://github.com/hybridauth/hybridauth.github.io -->
As fixing the "Implicitly nullable parameter" deprecation warning for PHP 8.4 requires new syntax introduced PHP 7.1 I would propose to start a v4 so the PHP requirements can be pushed to PHP 7.3 as documented in the README.md.

The commits where split to reflect the different parts of the change: The warning fixes, the changes to requirements, documentation and Travis CI configuration.

The warning fixes are trivial but the decision whether this justifies v4 (plus the decision if we bump the requirements to 7.3 or only to the strictly required 7.1 due to the new syntax) is up to you.
I couldn't think of an alternative path to fix the issue but maybe there is a better approach.