### PR TITLE
Keycloak logout

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -83,6 +83,13 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $validateApiResponseHttpCode = true;
 
     /**
+     * Whether to call logout API before disconnecting
+     *
+     * @var bool
+     */
+    protected $isLogoutRequiredBeforeDisconnect = false;
+
+    /**
      * Common adapters constructor.
      *
      * @param array $config
@@ -197,7 +204,20 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function disconnect()
     {
+        if ($this->isLogoutRequiredBeforeDisconnect){
+            $resp = $this->logout();
+            $this->logger->debug("logout", [$resp]);
+        }
+
         $this->clearStoredData();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function logout()
+    {
+        return false;
     }
 
     /**

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -36,6 +36,13 @@ interface AdapterInterface
     public function disconnect();
 
     /**
+     * Logout from IdP
+     *
+     * @return mixed
+     */
+    public function logout();
+
+    /**
      * Retrieve the connected user profile
      *
      * @return \Hybridauth\User\Profile

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -260,7 +260,7 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         if ($this->config->exists('tokens')) {
             $this->setAccessToken($this->config->get('tokens'));
         }
-        
+
         if ($this->config->exists('supportRequestState')) {
             $this->supportRequestState = $this->config->get('supportRequestState');
         }
@@ -268,8 +268,8 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
         $this->setCallback($this->config->get('callback'));
         $this->setApiEndpoints($this->config->get('endpoints'));
 
-        if ($this->config->exists('isLogoutRequiredBeforeDisconnect')) {
-            $this->isLogoutRequiredBeforeDisconnect = $this->config->get('isLogoutRequiredBeforeDisconnect');
+        if ($this->config->exists('logout_before_disconnect')) {
+            $this->isLogoutRequiredBeforeDisconnect = $this->config->get('logout_before_disconnect');
         }
     }
 

--- a/src/Adapter/OAuth2.php
+++ b/src/Adapter/OAuth2.php
@@ -267,6 +267,10 @@ abstract class OAuth2 extends AbstractAdapter implements AdapterInterface
 
         $this->setCallback($this->config->get('callback'));
         $this->setApiEndpoints($this->config->get('endpoints'));
+
+        if ($this->config->exists('isLogoutRequiredBeforeDisconnect')) {
+            $this->isLogoutRequiredBeforeDisconnect = $this->config->get('isLogoutRequiredBeforeDisconnect');
+        }
     }
 
     /**

--- a/src/Adapter/OpenID.php
+++ b/src/Adapter/OpenID.php
@@ -112,6 +112,11 @@ abstract class OpenID extends AbstractAdapter implements AdapterInterface
      */
     public function disconnect()
     {
+        if ($this->isLogoutRequiredBeforeDisconnect){
+            $resp = $this->logout();
+            $this->logger->debug("logout", [$resp]);
+        }
+
         $this->storage->delete($this->providerId . '.user');
 
         return true;

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -66,7 +66,21 @@ class Keycloak extends OAuth2
 
         $this->authorizeUrl = $this->apiBaseUrl . 'auth';
         $this->accessTokenUrl = $this->apiBaseUrl . 'token';
+    }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected function initialize()
+    {
+        parent::initialize();
+
+        if ($this->isRefreshTokenAvailable()) {
+            $this->tokenRefreshParameters += [
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ];
+        }
     }
 
     /**

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -113,4 +113,11 @@ class Keycloak extends OAuth2
 
         return $userProfile;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function logout() {
+        return $this->apiRequest('logout', 'POST', $this->tokenRefreshParameters);
+    }
 }

--- a/src/Storage/StorageImpl.php
+++ b/src/Storage/StorageImpl.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Hybridauth\Storage;
+
+class StorageImpl implements StorageInterface {
+    private array $data;
+
+    public function __construct()
+    {
+        $this->data = [];
+    }
+
+    public function get($key) {
+        return $this->data[$key] ?? null;
+    }
+
+    public function set($key, $value) {
+        $this->data[$key] = $value;
+    }
+
+    public function delete($key) {
+        if (array_key_exists($key, $this->data)){
+            unset($this->data[$key]);
+        }
+    }
+
+    public function deleteMatch($key) {
+        foreach ($this->data as $k => $v) {
+            if (strstr($k, $key)) {
+                unset($this->data[$k]);
+            }
+        }
+    }
+
+    public function clear() {
+        $this->data = [];
+    }
+}

--- a/tests/Provider/KeycloakTest.php
+++ b/tests/Provider/KeycloakTest.php
@@ -2,7 +2,10 @@
 
 namespace HybridauthTest\Hybridauth\Provider;
 
+use Hybridauth\HttpClient\HttpClientInterface;
 use Hybridauth\Provider\Keycloak;
+use Hybridauth\Storage\StorageImpl;
+use Hybridauth\Storage\StorageInterface;
 use Hybridauth\User\Profile;
 
 class KeycloakTest extends \PHPUnit\Framework\TestCase
@@ -36,7 +39,7 @@ class KeycloakTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($profile, $keycloak->getUserProfile());
     }
 
-    /* Test parsing keycloak user profile with organization feature enabled. The issued ID token is similar but contains the organization scope with this format:    
+    /* Test parsing keycloak user profile with organization feature enabled. The issued ID token is similar but contains the organization scope with this format:
         "name": "Alice Jenkins",
         "preferred_username": "alice@acme.org",
         "given_name": "Alice",
@@ -76,5 +79,53 @@ class KeycloakTest extends \PHPUnit\Framework\TestCase
         $profile->data = ['organization' => 'my_org'];
 
         $this->assertEquals($profile, $keycloak->getUserProfile());
+    }
+
+    public function test_refreshAccessToken_ProviderClientIdAndSecret()
+    {
+        $config = [
+            'url' => 'sha.dok',
+            'keys' => [
+                'id' => 'ga',
+                'secret' => 'bu',
+            ],
+            'tokens' => [
+                'access_token' => 'old_access_token',
+                'token_type' => 'Bearer',
+                'expires_at' => 1731454668,
+                'refresh_token' => 'zo',
+            ],
+            'realm' => 'meu',
+            'callback' => 'http://callbacksha.dok'
+        ];
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $storage = $this->createMock(StorageInterface::class);
+        $keycloak = new Keycloak($config, $httpClient, new StorageImpl());
+
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with(
+                'sha.dok/realms/meu/protocol/openid-connect/token',
+                'POST',
+                [
+                    'grant_type' => 'refresh_token',
+                    'client_id' => 'ga',
+                    'client_secret' => 'bu',
+                    'refresh_token' => 'zo',
+                ],
+                []
+            )
+            ->willReturn(json_encode(['access_token' => 'new_access_token']));
+
+        $httpClient->expects($this->once())
+            ->method('getResponseClientError')
+            ->willReturn(false);
+
+        $httpClient->expects($this->once())
+            ->method('getResponseHttpCode')
+            ->willReturn(200);
+
+        $keycloak->refreshAccessToken();
     }
 }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | No
| Patch: Bug Fix?          | No
| Major: Breaking Change? | No
| Minor: New Feature?      | Yes

Current PR aims at being able to force Identity Provider logout when disconnect is called and reset the session afterwhile. 

Logout is a new (empty) API added in Adapter. it is by default doing nothing in Oauth2/OpendID (empty implementation). Except for Keycloak.

Calling logout is configurable via 'logout_before_disconnect' parameter. if not set (backward compatibility), logout is not triggered.
