### PR TITLE
Fix issues with PHP 8.4 and changes to nullable vars

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -92,9 +92,9 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function __construct(
         $config = [],
-        HttpClientInterface $httpClient = null,
-        StorageInterface $storage = null,
-        LoggerInterface $logger = null
+        ?HttpClientInterface $httpClient = null,
+        ?StorageInterface $storage = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->providerId = (new \ReflectionClass($this))->getShortName();
 
@@ -243,7 +243,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setHttpClient(HttpClientInterface $httpClient = null)
+    public function setHttpClient(?HttpClientInterface $httpClient = null)
     {
         $this->httpClient = $httpClient ?: new HttpClient();
 
@@ -263,7 +263,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setStorage(StorageInterface $storage = null)
+    public function setStorage(?StorageInterface $storage = null)
     {
         $this->storage = $storage ?: new Session();
     }
@@ -279,7 +279,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function setLogger(LoggerInterface $logger = null)
+    public function setLogger(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?: new Logger(
             $this->config->get('debug_mode'),

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -122,7 +122,7 @@ interface AdapterInterface
      *
      * @param HttpClientInterface $httpClient
      */
-    public function setHttpClient(HttpClientInterface $httpClient = null);
+    public function setHttpClient(?HttpClientInterface $httpClient = null);
 
     /**
      * Return http client instance.
@@ -134,7 +134,7 @@ interface AdapterInterface
      *
      * @param StorageInterface $storage
      */
-    public function setStorage(StorageInterface $storage = null);
+    public function setStorage(?StorageInterface $storage = null);
 
     /**
      * Return storage instance.
@@ -146,7 +146,7 @@ interface AdapterInterface
      *
      * @param LoggerInterface $logger
      */
-    public function setLogger(LoggerInterface $logger = null);
+    public function setLogger(?LoggerInterface $logger = null);
 
     /**
      * Return logger instance.

--- a/src/Hybridauth.php
+++ b/src/Hybridauth.php
@@ -62,9 +62,9 @@ class Hybridauth
      */
     public function __construct(
         $config,
-        HttpClientInterface $httpClient = null,
-        StorageInterface $storage = null,
-        LoggerInterface $logger = null
+        ?HttpClientInterface $httpClient = null,
+        ?StorageInterface $storage = null,
+        ?LoggerInterface $logger = null
     ) {
         if (is_string($config) && file_exists($config)) {
             $config = include $config;

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -181,7 +181,7 @@ class Instagram extends OAuth2
      * @throws \Hybridauth\Exception\InvalidAccessTokenException
      * @throws \Hybridauth\Exception\UnexpectedApiResponseException
      */
-    public function getUserMedia($limit = 12, $pageId = null, array $fields = null)
+    public function getUserMedia($limit = 12, $pageId = null, ?array $fields = null)
     {
         if (empty($fields)) {
             $fields = [
@@ -227,7 +227,7 @@ class Instagram extends OAuth2
      * @throws \Hybridauth\Exception\InvalidAccessTokenException
      * @throws \Hybridauth\Exception\UnexpectedApiResponseException
      */
-    public function getMedia($mediaId, array $fields = null)
+    public function getMedia($mediaId, ?array $fields = null)
     {
         if (empty($fields)) {
             $fields = [


### PR DESCRIPTION
In PHP 8.4, with exceptions being converted through a set_error_handler() method, we get errors like this:

```
Hybridauth\Adapter\AbstractAdapter::__construct(): Implicitly marking parameter $httpClient as nullable is deprecated, the explicit nullable type must be used instead in /var/www/apps/mycompiler/8528a9f9/vendor/hybridauth/hybridauth/src/Adapter/AbstractAdapter.php:93
```

Since such a design is in use by many PHP frameworks and codebases, I'd like to change the occurrences of nullable variables to use `?type x = null` instead of `type x = null`.

Thank you.