### PR TITLE
fix issue #1432

### DIFF
--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -539,7 +539,7 @@ class Facebook extends OAuth2
 
         $payload = json_decode(base64_decode($segments[0] ?? ''));
 
-        if (!is_object($payload) || $payload?->kid === null) {
+        if (!is_object($payload) || !isset($payload->kid)) {
             return null;
         }
 


### PR DESCRIPTION
[fix] requires PHP >= 8.0 #1432

$payload?->kid (nullsafe operator) is compatible only with PHP >= 8.0
https://github.com/hybridauth/hybridauth/issues/1432
https://github.com/hybridauth/hybridauth/blame/9449686baf2593739129a24e515a60908738ea8d/src/Provider/Facebook.php#L542


