### PR TITLE
fix: remove unused response assignment in exception handling

### DIFF
--- a/src/HttpClient/Guzzle.php
+++ b/src/HttpClient/Guzzle.php
@@ -166,8 +166,6 @@ class Guzzle implements HttpClientInterface
                     break;
             }
         } catch (\Exception $e) {
-            $response = $e->getResponse();
-
             $this->responseClientError = $e->getMessage();
         }
 


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixed #1417
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

Removed an unused variable assignment in the Guzzle HTTP client exception handler that was attempting to call `$e->getResponse()` without using the result.

Rationale:

The `$response` variable assigned in the catch block was never used, as the subsequent code only accesses `$response` when `$this->responseClientError` is null/false, but the exception handler sets this property. Not all exception types have a `getResponse()` method, which **will** cause additional errors when (and if) a non-HTTP exception is thrown
