### PR TITLE
Fix E_DEPRECATED warning when using obsolete curl_close with PHP 8.5

### DIFF
--- a/src/HttpClient/Curl.php
+++ b/src/HttpClient/Curl.php
@@ -170,7 +170,9 @@ class Curl implements HttpClientInterface
             }
         }
 
-        curl_close($curl);
+        if (version_compare(PHP_VERSION, '8.5.0', '<')) {
+            curl_close($curl);
+        }
 
         return $this->responseBody;
     }


### PR DESCRIPTION
| Q                        | A
| ------------------------ | ---
| Fixed Issues?            | Fixes E_DEPRECATION warning with PHP 8.5
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No
| Minor: New Feature?      | No

This patch does not call `curl_close()` any more for PHP 8.5 or up as it does nothing since PHP 8.0 and an E_DEPRECATION warning was added to PHP 8.5 as the function might be removed in later PHP version.
